### PR TITLE
Use textContent for showing dev error message

### DIFF
--- a/static/index.dev.html
+++ b/static/index.dev.html
@@ -75,14 +75,14 @@
           suppressErrors = true;
         });
 
-        function openError(html) {
+        function openError(text) {
           if (suppressErrors) {
             return;
           }
 
           const box = document.querySelector('.__infinity-dev-box-error');
           box.removeAttribute('hidden');
-          box.innerHTML = html;
+          box.textContent = text;
           onLoad();
         }
 


### PR DESCRIPTION
Summary:
`innerHTML` seems unnecessarily dangerous, rendering unescaped content from the network in an execution context. It can also raise exceptions if the HTML received is invalid, so let's not do this?

Test Plan:
Broke the URL fetch to force an error:
![screenshot 2018-08-01 14 36 39](https://user-images.githubusercontent.com/9906/43525116-d3df97f6-9598-11e8-9b47-ac135c57e78f.png)
