### PR TITLE
Fix for iOS Cocoapods default config

### DIFF
--- a/Specs/SonarKit/0.6.15/SonarKit.podspec
+++ b/Specs/SonarKit/0.6.15/SonarKit.podspec
@@ -57,7 +57,7 @@ Pod::Spec.new do |spec|
     ss.dependency 'OpenSSL-Static', '1.0.2.c1'
     ss.compiler_flags = folly_compiler_flags
     ss.source_files = 'iOS/SonarKit/FBDefines/*.{h,cpp,m,mm}', 'iOS/SonarKit/CppBridge/*.{h,mm}', 'iOS/SonarKit/FBCxxUtils/*.{h,mm}', 'iOS/SonarKit/Utilities/**/*.{h,m}', 'iOS/SonarKit/*.{h,m,mm}'
-    ss.public_header_files = 'iOS/SonarKit/**/{SonarClient,SonarPlugin,SonarConnection,SonarResponder,SKMacros}.h'
+    ss.public_header_files = 'iOS/SonarKit/FBDefines/FBMacros.h', 'iOS/SonarKit/**/{SonarClient,SonarPlugin,SonarConnection,SonarResponder,SKMacros}.h'
     header_search_paths = "\"$(PODS_ROOT)/SonarKit/iOS/SonarKit\" \"$(PODS_ROOT)\"/Headers/Private/SonarKit/** \"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/PeerTalkSonar\""
     ss.pod_target_xcconfig = { "USE_HEADERMAP" => "NO",
                              "DEFINES_MODULE" => "YES",

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -71,7 +71,7 @@ source 'https://github.com/facebook/Sonar.git'
 source 'https://github.com/CocoaPods/Specs'
 # Uncomment the next line to define a global platform for your project
 swift_version = "4.1"
-sonarkit_version = '0.6.14'
+sonarkit_version = '0.6.15'
 
 target 'MyApp' do
 

--- a/iOS/Sample/Sample.xcodeproj/project.pbxproj
+++ b/iOS/Sample/Sample.xcodeproj/project.pbxproj
@@ -335,11 +335,11 @@
 					"\"${PODS_ROOT}/Headers/Public/DoubleConversion\"",
 					"\"${PODS_ROOT}/Headers/Public/Folly\"",
 					"\"${PODS_ROOT}/Headers/Public/PeerTalk\"",
-					"\"${PODS_ROOT}/Headers/Public/Sonar\"/**",
+					"\"${PODS_ROOT}/Headers/Public/Sonar\"",
 					"\"${PODS_ROOT}/Headers/Public/SonarKit\"",
 					"\"${PODS_ROOT}/Headers/Public/Yoga\"",
 					"\"${PODS_ROOT}/Headers/Public/boost-for-react-native\"",
-					"\"${PODS_ROOT}/Headers/Public/glog\"/**",
+					"\"${PODS_ROOT}/Headers/Public/glog\"",
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
@@ -399,11 +399,11 @@
 					"\"${PODS_ROOT}/Headers/Public/DoubleConversion\"",
 					"\"${PODS_ROOT}/Headers/Public/Folly\"",
 					"\"${PODS_ROOT}/Headers/Public/PeerTalk\"",
-					"\"${PODS_ROOT}/Headers/Public/Sonar\"/**",
+					"\"${PODS_ROOT}/Headers/Public/Sonar\"",
 					"\"${PODS_ROOT}/Headers/Public/SonarKit\"",
 					"\"${PODS_ROOT}/Headers/Public/Yoga\"",
 					"\"${PODS_ROOT}/Headers/Public/boost-for-react-native\"",
-					"\"${PODS_ROOT}/Headers/Public/glog\"/**",
+					"\"${PODS_ROOT}/Headers/Public/glog\"",
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.3;

--- a/iOS/SampleSwift/SampleSwift.xcodeproj/project.pbxproj
+++ b/iOS/SampleSwift/SampleSwift.xcodeproj/project.pbxproj
@@ -332,7 +332,7 @@
 					"\"${PODS_ROOT}/Headers/Public/PeerTalk\"",
 					"\"${PODS_ROOT}/Headers/Public/RSocket\"",
 					"\"${PODS_ROOT}/Headers/Public/Sonar\"",
-					"\"${PODS_ROOT}/Headers/Public/SonarKit\"/**",
+					"\"${PODS_ROOT}/Headers/Public/SonarKit\"",
 					"\"${PODS_ROOT}/Headers/Public/Yoga\"",
 					"\"${PODS_ROOT}/Headers/Public/glog\"",
 				);
@@ -366,7 +366,7 @@
 					"\"${PODS_ROOT}/Headers/Public/PeerTalk\"",
 					"\"${PODS_ROOT}/Headers/Public/RSocket\"",
 					"\"${PODS_ROOT}/Headers/Public/Sonar\"",
-					"\"${PODS_ROOT}/Headers/Public/SonarKit\"/**",
+					"\"${PODS_ROOT}/Headers/Public/SonarKit\"",
 					"\"${PODS_ROOT}/Headers/Public/Yoga\"",
 					"\"${PODS_ROOT}/Headers/Public/glog\"",
 				);

--- a/iOS/SonarKit.podspec
+++ b/iOS/SonarKit.podspec
@@ -57,7 +57,7 @@ Pod::Spec.new do |spec|
     ss.dependency 'OpenSSL-Static', '1.0.2.c1'
     ss.compiler_flags = folly_compiler_flags
     ss.source_files = 'iOS/SonarKit/FBDefines/*.{h,cpp,m,mm}', 'iOS/SonarKit/CppBridge/*.{h,mm}', 'iOS/SonarKit/FBCxxUtils/*.{h,mm}', 'iOS/SonarKit/Utilities/**/*.{h,m}', 'iOS/SonarKit/*.{h,m,mm}'
-    ss.public_header_files = 'iOS/SonarKit/**/{SonarClient,SonarPlugin,SonarConnection,SonarResponder,SKMacros}.h'
+    ss.public_header_files = 'iOS/SonarKit/FBDefines/FBMacros.h', 'iOS/SonarKit/**/{SonarClient,SonarPlugin,SonarConnection,SonarResponder,SKMacros}.h'
     header_search_paths = "\"$(PODS_ROOT)/SonarKit/iOS/SonarKit\" \"$(PODS_ROOT)\"/Headers/Private/SonarKit/** \"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/PeerTalkSonar\""
     ss.pod_target_xcconfig = { "USE_HEADERMAP" => "NO",
                              "DEFINES_MODULE" => "YES",


### PR DESCRIPTION
Solves #203 

- [x] Sample Objc and Swift apps now have default configs(i.e non-recursive header search paths)
- [x] Fix for the cocoapods default config by adding FBMacros.h file in `Core` subspec
- [x] Updated the Spec(0.6.15) so that 0.6.15 works for default configs
- [x] Updated the doc