### PR TITLE
Remove an extraneous comments from the iOS setup docs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -69,7 +69,6 @@ To integrate with an iOS app, you can use [CocoaPods](https://cocoapods.org). Ad
 project 'MyApp.xcodeproj'
 source 'https://github.com/facebook/Sonar.git'
 source 'https://github.com/CocoaPods/Specs'
-# Uncomment the next line to define a global platform for your project
 swift_version = "4.1"
 sonarkit_version = '0.6.15'
 


### PR DESCRIPTION
This comment was left there from the default cocoapods-generated Podfile, so it can now be removed.