### PR TITLE
Fix docs inconsistencies

### DIFF
--- a/docs/layout-plugin.md
+++ b/docs/layout-plugin.md
@@ -3,7 +3,7 @@ id: layout-plugin
 title: Layout Inspector
 ---
 
-The Layout Inspector in Flipper is useful for a ton of different debugging scenarios. First of all you can inspect what views the hierarchy is made up of as well as what properties each view has. This is incredibly useful when debugging issues with your product.
+The Layout Inspector in Flipper is useful for a ton of different debugging scenarios. First of all, you can inspect what views the hierarchy is made up of as well as what properties each view has. This is incredibly useful when debugging issues with your product.
 
 The Layout tab supports [Litho](https://fblitho.com) and [ComponentKit](https://componentkit.org) components as well! We integrate with these frameworks to present components in the hierarchy just as if they were native views. We show you all the layout properties, props, and state of the components. The layout inspector is further extensible to support other UI frameworks.
 

--- a/docs/send-data.md
+++ b/docs/send-data.md
@@ -4,7 +4,7 @@ title: Sending Data to Plugins
 sidebar_label: Send Data
 ---
 
-It is often useful to get an instance of a flipper plugin to send data to it. Flipper makes this simple with built in support.
+It is often useful to get an instance of a Flipper plugin to send data to it. Flipper makes this simple with built-in support.
 
 Plugins should be treated as singleton instances as there can only be one `SonarClient` and each `SonarClient` can only have one instance of a certain plugin. The Flipper API makes this simple by offering a way to get the current client and query it for plugins.
 
@@ -47,4 +47,4 @@ myPlugin = client.getPlugin<MySonarPlugin>("MySonarPlugin");
 myPlugin->sendData(myData);
 ```
 
-Here, `sendData` is an example of a method that might be implemented by the flipper plugin.
+Here, `sendData` is an example of a method that might be implemented by the Flipper plugin.


### PR DESCRIPTION
Summary:
When referring to the project, we usually capitalize Flipper, but don't
do this super consistently. This fixes a few cases and some other
grammar issues.

Test Plan:
eyes