### PR TITLE
Docs corrections in establishing-a-connection

### DIFF
--- a/docs/establishing-a-connection.md
+++ b/docs/establishing-a-connection.md
@@ -4,8 +4,6 @@ title: Establishing a connection
 sidebar_label: Establishing a connection
 ---
 
-# Establishing a Connection
-
 Below is an outline of how a connection is established between an app with with our SDK integrated, and the desktop app. This all goes on behind the scenes inside the mobile SDK, so users shouldn't need to worry about it.
 
 ## Transport Protocol
@@ -20,7 +18,7 @@ Any mobile app with the Flipper SDK installed will continually attempt to connec
 ## Certificate Exchange
 
 To avoid mobile apps from connecting to untrusted ports on localhost, they will only connect to servers that have a valid, trusted TLS certificate.
-In order for the mobile app to know which certificates it can trust, it conducts a certificate exchange with the desktop app before making it can make its first secure connection.
+In order for the mobile app to know which certificates it can trust, it conducts a certificate exchange with the desktop app before it can make its first secure connection.
 
 This is achieved through the following steps:
 * Desktop app starts an insecure server on port 8089.


### PR DESCRIPTION
The title gets taken from the header, so is duplicated.