### PR TITLE
Explicitly specify serial filename to openssl

### DIFF
--- a/src/utils/CertificateProvider.js
+++ b/src/utils/CertificateProvider.js
@@ -601,7 +601,6 @@ export default class CertificateProvider {
       .then(_ =>
         openssl('req', {
           new: true,
-          CAserial: getFilePath('server.srl'),
           key: serverKey,
           out: serverCsr,
           subj: serverSubject,

--- a/src/utils/CertificateProvider.js
+++ b/src/utils/CertificateProvider.js
@@ -27,6 +27,7 @@ const caKey = getFilePath('ca.key');
 const caCert = getFilePath('ca.crt');
 const serverKey = getFilePath('server.key');
 const serverCsr = getFilePath('server.csr');
+const serverSrl = getFilePath('server.srl');
 const serverCert = getFilePath('server.crt');
 
 // Device file paths
@@ -168,6 +169,7 @@ export default class CertificateProvider {
         CA: caCert,
         CAkey: caKey,
         CAcreateserial: true,
+        CAserial: serverSrl,
       });
     });
   }
@@ -599,6 +601,7 @@ export default class CertificateProvider {
       .then(_ =>
         openssl('req', {
           new: true,
+          CAserial: getFilePath('server.srl'),
           key: serverKey,
           out: serverCsr,
           subj: serverSubject,
@@ -611,6 +614,7 @@ export default class CertificateProvider {
           CA: caCert,
           CAkey: caKey,
           CAcreateserial: true,
+          CAserial: serverSrl,
           out: serverCert,
         }),
       )


### PR DESCRIPTION
Manually add `serial.srl` as the `CAserial` param to `openssl`. This
fixes a permissions issue when generating certificates, which fixes some
of the issues explained in #101.