### PR TITLE
Fix for compilation error about missing virtual destructor in GCDQueue

### DIFF
--- a/iOS/Plugins/SonarKitNetworkPlugin/SonarKitNetworkPlugin/SKDispatchQueue.h
+++ b/iOS/Plugins/SonarKitNetworkPlugin/SonarKitNetworkPlugin/SKDispatchQueue.h
@@ -30,6 +30,8 @@ namespace facebook {
         dispatch_async(_underlyingQueue, block);
       }
 
+      virtual ~GCDQueue() { }
+
     private:
       dispatch_queue_t _underlyingQueue;
     };


### PR DESCRIPTION
error: destructor called on non-final 'facebook::sonar::GCDQueue' that has virtual functions but non-virtual destructor [-Werror,-Wdelete-non-virtual-dtor]
    __data_.second().~_Tp();