### PR TITLE
[Flipper] Update Sample apps to refer local podspecs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ yarn-error.log
 **/Pods/
 **/xcuserdata/
 build/
-*.lock
 
 android/third-party/external/
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ yarn-error.log
 **/Pods/
 **/xcuserdata/
 build/
+*.lock
 
 android/third-party/external/
 

--- a/Sonar.podspec
+++ b/Sonar.podspec
@@ -1,0 +1,1 @@
+xplat/Sonar/Sonar.podspec

--- a/iOS/Sample/Podfile
+++ b/iOS/Sample/Podfile
@@ -2,13 +2,12 @@ project 'Sample.xcodeproj'
 source 'https://github.com/facebook/Sonar.git'
 source 'https://github.com/CocoaPods/Specs'
 swift_version = "4.1"
-sonarkit_version = '0.6.16'
 
 target 'Sample' do
-  pod 'SonarKit', '~>'+sonarkit_version
-  pod 'SonarKit/SonarKitLayoutComponentKitSupport', '~>'+sonarkit_version
-  pod 'SonarKit/SKIOSNetworkPlugin', '~>'+sonarkit_version
-
+  pod 'SonarKit', :path => '../../SonarKit.podspec'
+  pod 'SonarKit/SonarKitLayoutComponentKitSupport', :path => '../../SonarKit.podspec'
+  pod 'SonarKit/SKIOSNetworkPlugin', :path => '../../SonarKit.podspec'
+  pod 'Sonar', :path => '../../Sonar.podspec'
   post_install do |installer|
 
         installer.pods_project.targets.each do |target|

--- a/iOS/Sample/Podfile.lock
+++ b/iOS/Sample/Podfile.lock
@@ -1,0 +1,100 @@
+PODS:
+  - boost-for-react-native (1.63.0)
+  - CocoaAsyncSocket (7.6.3)
+  - CocoaLibEvent (1.0.0)
+  - ComponentKit (0.23):
+    - Yoga (~> 1.6)
+  - DoubleConversion (1.1.5)
+  - Folly (1.1.0):
+    - boost-for-react-native
+    - CocoaLibEvent (~> 1.0)
+    - DoubleConversion
+    - glog
+    - OpenSSL-Static (= 1.0.2.c1)
+  - glog (0.3.4)
+  - OpenSSL-Static (1.0.2.c1)
+  - PeerTalk (0.0.2)
+  - RSocket (0.10.0):
+    - Folly
+  - Sonar (0.6.16):
+    - Folly (~> 1.1)
+    - RSocket (~> 0.10)
+  - SonarKit (0.6.16):
+    - SonarKit/Core (= 0.6.16)
+  - SonarKit/Core (0.6.16):
+    - CocoaAsyncSocket (~> 7.6)
+    - Folly (~> 1.1)
+    - OpenSSL-Static (= 1.0.2.c1)
+    - PeerTalk (~> 0.0.2)
+    - Sonar (~> 0.6.16)
+    - SonarKit/CppBridge
+    - SonarKit/FBCxxUtils
+    - SonarKit/FBDefines
+  - SonarKit/CppBridge (0.6.16)
+  - SonarKit/FBCxxUtils (0.6.16)
+  - SonarKit/FBDefines (0.6.16)
+  - SonarKit/SKIOSNetworkPlugin (0.6.16):
+    - SonarKit/Core
+    - SonarKit/SonarKitNetworkPlugin
+  - SonarKit/SonarKitLayoutComponentKitSupport (0.6.16):
+    - ComponentKit
+    - SonarKit/Core
+    - SonarKit/SonarKitLayoutPlugin
+    - Yoga (~> 1.9)
+  - SonarKit/SonarKitLayoutPlugin (0.6.16):
+    - SonarKit/Core
+    - Yoga (~> 1.9)
+    - YogaKit (~> 1.8)
+  - SonarKit/SonarKitNetworkPlugin (0.6.16):
+    - SonarKit/Core
+  - Yoga (1.9.0)
+  - YogaKit (1.9.0):
+    - Yoga (~> 1.9)
+
+DEPENDENCIES:
+  - Sonar (from `../../Sonar.podspec`)
+  - SonarKit (from `../../SonarKit.podspec`)
+  - SonarKit/SKIOSNetworkPlugin (from `../../SonarKit.podspec`)
+  - SonarKit/SonarKitLayoutComponentKitSupport (from `../../SonarKit.podspec`)
+
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - boost-for-react-native
+    - CocoaAsyncSocket
+    - CocoaLibEvent
+    - ComponentKit
+    - DoubleConversion
+    - glog
+    - OpenSSL-Static
+    - Yoga
+    - YogaKit
+  https://github.com/facebook/Sonar.git:
+    - Folly
+    - PeerTalk
+    - RSocket
+
+EXTERNAL SOURCES:
+  Sonar:
+    :path: "../../Sonar.podspec"
+  SonarKit:
+    :path: "../../SonarKit.podspec"
+
+SPEC CHECKSUMS:
+  boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
+  CocoaAsyncSocket: eafaa68a7e0ec99ead0a7b35015e0bf25d2c8987
+  CocoaLibEvent: 2fab71b8bd46dd33ddb959f7928ec5909f838e3f
+  ComponentKit: bf8b4c4e7448bd15b3a8e5a71174ea7aa6cea98d
+  DoubleConversion: e22e0762848812a87afd67ffda3998d9ef29170c
+  Folly: dd92f69322d8535b9df98d7c91e442b0fce2fff2
+  glog: 1de0bb937dccdc981596d3b5825ebfb765017ded
+  OpenSSL-Static: bd17e34564a8591ad76b740318683a6caa19a13e
+  PeerTalk: 77481b0a8136f226b90ccf828d6061f70139ffde
+  RSocket: 4fdb7e562db30a2d4fceddefdc601749ffc9ebe2
+  Sonar: 74d1e3a853f1453511108ac1b3e7469a2b2ade92
+  SonarKit: f6f9715af976f14ecab376eeb0576898c9fb0638
+  Yoga: aaae8abea68951f60bee05f6277d3eed90bb91bb
+  YogaKit: d447a9bb808718e6f58e52a2255a8050081a3ead
+
+PODFILE CHECKSUM: b1786f878ef1a53893b6a0f9d79d4987b72bc916
+
+COCOAPODS: 1.5.2

--- a/iOS/SampleSwift/Podfile
+++ b/iOS/SampleSwift/Podfile
@@ -4,10 +4,11 @@ source 'https://github.com/CocoaPods/Specs'
 swift_version = "4.1"
 
 target 'SampleSwift' do
-  pod 'SonarKit', '~> 0.6'
+  pod 'SonarKit', :path => '../../SonarKit.podspec'
+  pod 'SonarKit/SKIOSNetworkPlugin', :path => '../../SonarKit.podspec'
+  pod 'Sonar', :path => '../../Sonar.podspec'
   # Layout and network plugins are not yet supported for swift projects
-  # pod 'SonarKit/SonarKitLayoutComponentKitSupport', '~> 0.0.2'
-  pod 'SonarKit/SKIOSNetworkPlugin', '~> 0.6'
+  #pod 'SonarKit/SonarKitLayoutComponentKitSupport', :path => '../../SonarKit.podspec'
 
   post_install do |installer|
         installer.pods_project.targets.each do |target|

--- a/iOS/SampleSwift/Podfile.lock
+++ b/iOS/SampleSwift/Podfile.lock
@@ -1,0 +1,79 @@
+PODS:
+  - boost-for-react-native (1.63.0)
+  - CocoaAsyncSocket (7.6.3)
+  - CocoaLibEvent (1.0.0)
+  - DoubleConversion (1.1.5)
+  - Folly (1.1.0):
+    - boost-for-react-native
+    - CocoaLibEvent (~> 1.0)
+    - DoubleConversion
+    - glog
+    - OpenSSL-Static (= 1.0.2.c1)
+  - glog (0.3.4)
+  - OpenSSL-Static (1.0.2.c1)
+  - PeerTalk (0.0.2)
+  - RSocket (0.10.0):
+    - Folly
+  - Sonar (0.6.16):
+    - Folly (~> 1.1)
+    - RSocket (~> 0.10)
+  - SonarKit (0.6.16):
+    - SonarKit/Core (= 0.6.16)
+  - SonarKit/Core (0.6.16):
+    - CocoaAsyncSocket (~> 7.6)
+    - Folly (~> 1.1)
+    - OpenSSL-Static (= 1.0.2.c1)
+    - PeerTalk (~> 0.0.2)
+    - Sonar (~> 0.6.16)
+    - SonarKit/CppBridge
+    - SonarKit/FBCxxUtils
+    - SonarKit/FBDefines
+  - SonarKit/CppBridge (0.6.16)
+  - SonarKit/FBCxxUtils (0.6.16)
+  - SonarKit/FBDefines (0.6.16)
+  - SonarKit/SKIOSNetworkPlugin (0.6.16):
+    - SonarKit/Core
+    - SonarKit/SonarKitNetworkPlugin
+  - SonarKit/SonarKitNetworkPlugin (0.6.16):
+    - SonarKit/Core
+
+DEPENDENCIES:
+  - Sonar (from `../../Sonar.podspec`)
+  - SonarKit (from `../../SonarKit.podspec`)
+  - SonarKit/SKIOSNetworkPlugin (from `../../SonarKit.podspec`)
+
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - boost-for-react-native
+    - CocoaAsyncSocket
+    - CocoaLibEvent
+    - DoubleConversion
+    - glog
+    - OpenSSL-Static
+  https://github.com/facebook/Sonar.git:
+    - Folly
+    - PeerTalk
+    - RSocket
+
+EXTERNAL SOURCES:
+  Sonar:
+    :path: "../../Sonar.podspec"
+  SonarKit:
+    :path: "../../SonarKit.podspec"
+
+SPEC CHECKSUMS:
+  boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
+  CocoaAsyncSocket: eafaa68a7e0ec99ead0a7b35015e0bf25d2c8987
+  CocoaLibEvent: 2fab71b8bd46dd33ddb959f7928ec5909f838e3f
+  DoubleConversion: e22e0762848812a87afd67ffda3998d9ef29170c
+  Folly: dd92f69322d8535b9df98d7c91e442b0fce2fff2
+  glog: 1de0bb937dccdc981596d3b5825ebfb765017ded
+  OpenSSL-Static: bd17e34564a8591ad76b740318683a6caa19a13e
+  PeerTalk: 77481b0a8136f226b90ccf828d6061f70139ffde
+  RSocket: 4fdb7e562db30a2d4fceddefdc601749ffc9ebe2
+  Sonar: 74d1e3a853f1453511108ac1b3e7469a2b2ade92
+  SonarKit: f6f9715af976f14ecab376eeb0576898c9fb0638
+
+PODFILE CHECKSUM: bfd82cb10666824db61b62e1ff7196e0b2305f0c
+
+COCOAPODS: 1.5.2


### PR DESCRIPTION
Before this PR, travis used to build sample app which used a tagged release of SonarKit and Sonar. So travis used to never check the source code in master branch. This PR, instead uses local podspecs, which refers to the local source code, and thus travis would be testing the local source code. 
Solves #237 