### PR TITLE
[android] Add missing native targets

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,7 +17,7 @@ android {
         externalNativeBuild {
             cmake {
                 arguments '-DANDROID_TOOLCHAIN=clang', '-DANDROID_STL=c++_shared'
-                targets 'sonar'
+                targets 'sonar', 'event', 'event_extra', 'event_core'
             }
         }
     }

--- a/android/sample/src/main/java/com/facebook/flipper/sample/FlipperSampleApplication.java
+++ b/android/sample/src/main/java/com/facebook/flipper/sample/FlipperSampleApplication.java
@@ -4,13 +4,13 @@ package com.facebook.flipper.sample;
 
 import android.app.Application;
 import android.content.Context;
-import com.facebook.litho.sonar.LithoSonarDescriptors;
 import com.facebook.soloader.SoLoader;
 import com.facebook.sonar.android.AndroidSonarClient;
 import com.facebook.sonar.core.SonarClient;
 import com.facebook.sonar.plugins.inspector.DescriptorMapping;
 import com.facebook.sonar.plugins.inspector.InspectorSonarPlugin;
 import com.facebook.sonar.plugins.leakcanary.LeakCanarySonarPlugin;
+import com.facebook.sonar.plugins.litho.LithoSonarDescriptors;
 import com.facebook.sonar.plugins.network.NetworkSonarPlugin;
 import com.facebook.sonar.plugins.network.SonarOkhttpInterceptor;
 import com.facebook.sonar.plugins.sharedpreferences.SharedPreferencesSonarPlugin;

--- a/android/src/main/java/com/facebook/sonar/plugins/litho/DebugComponentDescriptor.java
+++ b/android/src/main/java/com/facebook/sonar/plugins/litho/DebugComponentDescriptor.java
@@ -1,6 +1,6 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
-package com.facebook.litho.sonar;
+package com.facebook.sonar.plugins.litho;
 
 import static com.facebook.litho.annotations.ImportantForAccessibility.IMPORTANT_FOR_ACCESSIBILITY_NO;
 import static com.facebook.litho.annotations.ImportantForAccessibility.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS;
@@ -15,7 +15,6 @@ import android.support.v4.util.Pair;
 import android.view.View;
 import com.facebook.litho.Component;
 import com.facebook.litho.ComponentContext;
-import com.facebook.litho.ComponentLifecycle;
 import com.facebook.litho.DebugComponent;
 import com.facebook.litho.DebugLayoutNode;
 import com.facebook.litho.LithoView;

--- a/android/src/main/java/com/facebook/sonar/plugins/litho/LithoSonarDescriptors.java
+++ b/android/src/main/java/com/facebook/sonar/plugins/litho/LithoSonarDescriptors.java
@@ -1,6 +1,6 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
-package com.facebook.litho.sonar;
+package com.facebook.sonar.plugins.litho;
 
 import com.facebook.litho.DebugComponent;
 import com.facebook.litho.LithoView;

--- a/android/src/main/java/com/facebook/sonar/plugins/litho/LithoViewDescriptor.java
+++ b/android/src/main/java/com/facebook/sonar/plugins/litho/LithoViewDescriptor.java
@@ -1,6 +1,6 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
-package com.facebook.litho.sonar;
+package com.facebook.sonar.plugins.litho;
 
 import android.graphics.Rect;
 import android.view.ViewGroup;

--- a/android/src/main/java/com/facebook/sonar/plugins/litho/PropWithDescription.java
+++ b/android/src/main/java/com/facebook/sonar/plugins/litho/PropWithDescription.java
@@ -1,6 +1,6 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
-package com.facebook.litho.sonar;
+package com.facebook.sonar.plugins.litho;
 
 public interface PropWithDescription {
 


### PR DESCRIPTION
Depends on #247.

Summary:
Ensure that `libextra` is included when building sonar targets. My
cleanup was a bit too aggressive.

Fixes #246

Test Plan:
```
./gradlew :sample:installDebug
```

doesn't just build but also run.