### PR TITLE
Build Sample app rather than just building the sample pods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ matrix:
       script:
         - cd iOS/Sample
         - xcodebuild -showsdks
-        - xcodebuild clean build -workspace Sample.xcworkspace -scheme Pods-Sample -sdk iphonesimulator11.4
+        - xcodebuild clean build -workspace Sample.xcworkspace -scheme Sample -sdk iphonesimulator11.4
 
     - language: android
       os: linux


### PR DESCRIPTION
Currently travis just builds the pods which sample app depends on. The test case which the current setup misses it that it will fail to check if the required header files are exposed to public. The master is broken recently because a header file is not exposed publicly and sample app fails to build, whereas all the dependencies like Sonar and SonarKit build successfully. This PR updates the travis, so that it builds sample app rather than the dependent pods. 