### PR TITLE
Enabling fullscreen mode on macos

### DIFF
--- a/static/index.js
+++ b/static/index.js
@@ -161,7 +161,6 @@ function tryCreateWindow() {
       minWidth: 800,
       minHeight: 600,
       center: true,
-      fullscreenable: false,
       backgroundThrottling: false,
       titleBarStyle: 'hiddenInset',
       vibrancy: 'sidebar',


### PR DESCRIPTION
I wanted to use Flipper/Sonar in a fullscreen/split screen environment end was surprised the feature was disabled. When I checked the blame it looks like it's been like this from the get go, so there might not even be a real reason to have it disabled. Please correct me if I'm wrong.

The default value for `fullsreenable` is true. Removing setting the
parameter reenables the feature.

## Test Plan

- Flipped the switch, saw it go fullscreen
- Also works in split screens