### PR TITLE
[circleci] Add branch filter for builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,8 +25,15 @@ workflows:
   build:
     jobs:
       - build
-      - release:
+
+  release:
+    triggers:
+      - schedules:
           filters:
+            branches:
+              - only: master
             tags:
               - only: /^v.*/
 
+    jobs:
+      - release


### PR DESCRIPTION
Summary:
Nothing seems to run now, so let's try "trigger schedules" instead.

Test Plan:

```
$ circleci config validate
Config file at .circleci/config.yml is valid
```