### PR TITLE
[android][ci] Make build scripts less verbose

### DIFF
--- a/scripts/publish-android-release.sh
+++ b/scripts/publish-android-release.sh
@@ -12,5 +12,5 @@ elif [ "$IS_SNAPSHOT" != "" ]; then
   exit 1
 else
   openssl aes-256-cbc -d -in scripts/bintray-publish-keys.enc -k "$ANDROID_PUBLISH_KEY" >> "$BASEDIR/gradle.properties"
-  "$BASEDIR"/gradlew bintrayUpload --info -PdryRun=false
+  "$BASEDIR"/gradlew bintrayUpload --quiet -PdryRun=false
 fi

--- a/scripts/publish-android-snapshot.sh
+++ b/scripts/publish-android-snapshot.sh
@@ -7,10 +7,10 @@ IS_SNAPSHOT="$(grep 'VERSION_NAME=[0-9\.]\+-SNAPSHOT' "$BASEDIR/gradle.propertie
 if [ "$ANDROID_PUBLISH_KEY" == "" ]; then
   echo "No encryption key. Skipping snapshot deployment."
   exit
-elif [ "$IS_SNAPSHOT" != "" ]; then
-  echo "Build appears to be a SNAPSHOT release, but this is a script for building stable releases. Skipping ..."
-  exit 0
+elif [ "$IS_SNAPSHOT" == "" ]; then
+  echo "Skipping build. Given build doesn't appear to be a SNAPSHOT release."
+  exit 1
 else
-  openssl aes-256-cbc -d -in scripts/bintray-publish-keys.enc -k "$ANDROID_PUBLISH_KEY" >> "$BASEDIR/gradle.properties"
-  "$BASEDIR"/gradlew :android:uploadArchives --quiet -PdryRun=false
+  openssl aes-256-cbc -d -in scripts/gradle-publish-keys.enc -k "$ANDROID_PUBLISH_KEY" >> "$BASEDIR/gradle.properties"
+  "$BASEDIR"/gradlew uploadArchives --quiet
 fi

--- a/scripts/publish-android-snapshot.sh
+++ b/scripts/publish-android-snapshot.sh
@@ -12,5 +12,5 @@ elif [ "$IS_SNAPSHOT" != "" ]; then
   exit 0
 else
   openssl aes-256-cbc -d -in scripts/bintray-publish-keys.enc -k "$ANDROID_PUBLISH_KEY" >> "$BASEDIR/gradle.properties"
-  "$BASEDIR"/gradlew bintrayUpload --quiet -PdryRun=false
+  "$BASEDIR"/gradlew :android:uploadArchives --quiet -PdryRun=false
 fi

--- a/scripts/publish-android-snapshot.sh
+++ b/scripts/publish-android-snapshot.sh
@@ -9,8 +9,8 @@ if [ "$ANDROID_PUBLISH_KEY" == "" ]; then
   exit
 elif [ "$IS_SNAPSHOT" != "" ]; then
   echo "Build appears to be a SNAPSHOT release, but this is a script for building stable releases. Skipping ..."
-  exit 1
+  exit 0
 else
   openssl aes-256-cbc -d -in scripts/bintray-publish-keys.enc -k "$ANDROID_PUBLISH_KEY" >> "$BASEDIR/gradle.properties"
-  "$BASEDIR"/gradlew bintrayUpload --info -PdryRun=false
+  "$BASEDIR"/gradlew bintrayUpload --quiet -PdryRun=false
 fi


### PR DESCRIPTION
Summary:
`--info` was only useful while debugging the initial setup. This also
makes skipping non-snapshot builds no longer fatal.

Test Plan:
Circle CI