### PR TITLE
[desktop] Fix initialization

### DIFF
--- a/static/index.dev.html
+++ b/static/index.dev.html
@@ -86,7 +86,7 @@
           };
 
           script.onload = () => {
-            global.Sonar.init();
+            global.Flipper.init();
           };
 
           document.body.appendChild(script);

--- a/static/index.html
+++ b/static/index.html
@@ -15,7 +15,7 @@
     </script>
     <script src="bundle.js"></script>
     <script>
-      global.Sonar.init();
+      global.Flipper.init();
     </script>
   </body>
 </html>


### PR DESCRIPTION
Summary:
The global variable generated by metro(?) was changed from Sonar to
Flipper without updating its callside.

Fixes #267

Test Plan:
Break point at `index.dev.html:89 Uncaught TypeError: Cannot read
property 'init' of undefined` shows that Sonar is undefined while
Flipper is. Manually calling `Flipper.init()` unbreaks it.