### PR TITLE
[ci] Increase verbosity

### DIFF
--- a/scripts/publish-android-release.sh
+++ b/scripts/publish-android-release.sh
@@ -12,5 +12,5 @@ elif [ "$IS_SNAPSHOT" != "" ]; then
   exit 1
 else
   openssl aes-256-cbc -d -in scripts/bintray-publish-keys.enc -k "$ANDROID_PUBLISH_KEY" >> "$BASEDIR/gradle.properties"
-  "$BASEDIR"/gradlew bintrayUpload --quiet -PdryRun=false
+  "$BASEDIR"/gradlew bintrayUpload -PdryRun=false
 fi


### PR DESCRIPTION
Summary:
Apparently, `--quiet` is *too* quiet on "dumb" terminals,
staying quiet for longer than 10 minutes on Circle CI, causing
the jobs to fail.

Test Plan:
Manually running it here: https://circleci.com/gh/facebook/flipper/145