### PR TITLE
[readme] Remove rename warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,6 @@
 # Flipper [![Build Status](https://travis-ci.org/facebook/flipper.svg?branch=master)](https://travis-ci.org/facebook/flipper)
 
----
-
-**Flipper, formerly Sonar, is currently in the process of being renamed. This may cause some inconsistencies until everything is in place. We apologize for any inconvience caused.**
-
----
-
-Flipper is a platform for debugging mobile apps on iOS and Android. Visualize, inspect, and control your apps from a simple desktop interface. Use Flipper as is or extend it using the plugin API.
+Flipper (formerly Sonar) is a platform for debugging mobile apps on iOS and Android. Visualize, inspect, and control your apps from a simple desktop interface. Use Flipper as is or extend it using the plugin API.
 
 ![Flipper](/website/static/img/splash@2x.png)
 


### PR DESCRIPTION
We're in a pretty good state now. Let's get rid of the big warning.