### PR TITLE
[ci] Skip `yarn test` for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,6 @@ matrix:
         - yarn
 
       script:
-        - yarn test
         - yarn lint
         - yarn build --mac --version=$TRAVIS_BUILD_NUMBER
 


### PR DESCRIPTION
Summary:
This isn't working on Travis yet and will skip the subsequent steps
which do provide value if run right now.

Test Plan:
Watch for Travis signal.