### PR TITLE
Exit with error code on yarn-install failure

### DIFF
--- a/scripts/yarn-install.js
+++ b/scripts/yarn-install.js
@@ -54,4 +54,5 @@ Promise.all(
   .catch(err => {
     console.error('❌  Installing plugin dependencies failed.');
     console.error(err);
+    process.exit(1);
   });


### PR DESCRIPTION
Summary:
If installation fails, we should exit with an error code and not just a
message. This should help narrow down the CI failures, too.

Test Plan:
Travis.