### PR TITLE
Make guava dependency test-only

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -54,7 +54,6 @@ android {
         implementation deps.rhino
         compileOnly deps.leakcanary
 
-        testImplementation deps.guava
         testImplementation deps.mockito
         testImplementation deps.robolectric
         testImplementation deps.hamcrest

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,7 +45,6 @@ android {
         compileOnly deps.lithoAnnotations
         implementation project(':fbjni')
         implementation deps.soloader
-        implementation deps.guava
         implementation deps.jsr305
         implementation deps.supportAppCompat
         implementation deps.stetho
@@ -55,6 +54,7 @@ android {
         implementation deps.rhino
         compileOnly deps.leakcanary
 
+        testImplementation deps.guava
         testImplementation deps.mockito
         testImplementation deps.robolectric
         testImplementation deps.hamcrest

--- a/android/src/test/java/com/facebook/flipper/plugins/console/JavascriptSessionTest.java
+++ b/android/src/test/java/com/facebook/flipper/plugins/console/JavascriptSessionTest.java
@@ -9,9 +9,9 @@ package com.facebook.flipper.plugins.console;
 
 import static org.junit.Assert.assertEquals;
 
-import com.google.common.collect.ImmutableMap;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -42,12 +42,13 @@ public class JavascriptSessionTest {
 
   @Test
   public void testVariablesGetBoundCorrectly() throws Exception {
+    Map<String, Object> data = new HashMap<>();
+    data.put("a", 2);
+    data.put("b", 2);
     JavascriptSession session =
         new JavascriptSession(
             mContextFactory,
-            ImmutableMap.<String, Object>of(
-                "a", 2,
-                "b", 2));
+            data);
     JSONObject json = session.evaluateCommand("a+b");
     assertEquals("json", json.getString("type"));
     assertEquals(4, json.getInt("value"));
@@ -65,10 +66,12 @@ public class JavascriptSessionTest {
 
   @Test
   public void testJavaObjectEvaluation() throws Exception {
+    Map<String, Object> data = new HashMap<>();
+    data.put("object", new HashMap<String, String>());
     JavascriptSession session =
         new JavascriptSession(
             mContextFactory,
-            ImmutableMap.<String, Object>of("object", new HashMap<String, String>()));
+            data);
     JSONObject json = session.evaluateCommand("object");
     assertEquals("javaObject", json.getString("type"));
     assertEquals("{}", json.getJSONObject("value").getString("toString"));
@@ -76,10 +79,12 @@ public class JavascriptSessionTest {
 
   @Test
   public void testJavaMethodEvaluation() throws Exception {
+    Map<String, Object> data = new HashMap<>();
+    data.put("object", new HashMap<String, String>());
     JavascriptSession session =
         new JavascriptSession(
             mContextFactory,
-            ImmutableMap.<String, Object>of("object", new HashMap<String, String>()));
+            data);
     JSONObject json = session.evaluateCommand("object.get");
     assertEquals("method", json.getString("type"));
   }


### PR DESCRIPTION
It's only used in `JavascriptSessionTest`, and seems fine to keep it in tests

Resolves #172