### PR TITLE
[android] Bump Litho version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ POM_DEVELOPER_ID=facebook
 POM_DEVELOPER_NAME=facebook
 
 # Shared version numbers
-LITHO_VERSION=0.19.0
+LITHO_VERSION=0.20.0
 
 # Deps for publishing
 GRADLE_BINTRAY_PLUGIN_VERSION=1.8.0


### PR DESCRIPTION
Summary:
0.20.0 has been released.

Test Plan:
`./gradlew :sample:installDebug`