### PR TITLE
Use Gradle 5.0RC1 with HTTP retry

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,3 +18,7 @@ LITHO_VERSION=0.20.0
 GRADLE_BINTRAY_PLUGIN_VERSION=1.8.0
 GRADLE_VERSIONS_PLUGIN_VERSION=0.15.0
 ANDROID_MAVEN_GRADLE_PLUGIN_VERSION=2.1
+
+# Gradle internals
+org.gradle.internal.repository.max.retries=10
+org.gradle.internal.repository.initial.backoff=1250

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-rc-1-all.zip


### PR DESCRIPTION
Summary:
This could save our collective sanity. There's now
built-in support for HTTP retries: https://github.com/gradle/gradle/commit/0904f9d136c47e7fc4cd644f0fccbd84f570cc29

Reviewed By: jknoxville

Differential Revision: D12906015
