### PR TITLE
Update Android section of Getting Started

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -45,6 +45,7 @@ repositories {
 }
 
 dependencies {
+  debugImplementation 'com.facebook.soloader:soloader:0.5.1'
   debugImplementation 'com.facebook.flipper:flipper:0.11.1'
 }
 ```


### PR DESCRIPTION
I've updated the Android section of the getting-started docs.

While upgrading from a couple minor versions ago, I discovered `soloader` must now be declared as a dependency in `app/build.gradle`.