### PR TITLE
[iOS] Adds stub podspec files to reserve the name on cocoapods master repo

### DIFF
--- a/StubPodspecs/Flipper.podspec
+++ b/StubPodspecs/Flipper.podspec
@@ -1,0 +1,14 @@
+Pod::Spec.new do |spec|
+  spec.name = 'Flipper'
+  spec.version = '0.11.1'
+  spec.license = { :type => 'MIT' }
+  spec.source = { :git => 'https://github.com/facebook/Sonar.git',
+                  :tag=> "v0.11.1" }
+  spec.homepage = 'https://github.com/facebook/flipper'
+  spec.source_files = 'README.md'
+  spec.summary = 'Flipper iOS podspec'
+  spec.authors = 'Facebook'
+  spec.static_framework = true
+  spec.module_name = 'Flipper'
+  spec.platforms = { :ios => "8.4" }
+end

--- a/StubPodspecs/FlipperKit.podspec
+++ b/StubPodspecs/FlipperKit.podspec
@@ -1,0 +1,14 @@
+Pod::Spec.new do |spec|
+  spec.name = 'FlipperKit'
+  spec.version = '0.11.1'
+  spec.license = { :type => 'MIT' }
+  spec.source = { :git => 'https://github.com/facebook/Sonar.git',
+                  :tag=> "v0.11.1" }
+  spec.homepage = 'https://github.com/facebook/flipper'
+  spec.source_files = 'README.md'
+  spec.summary = 'FlipperKit iOS podspec'
+  spec.authors = 'Facebook'
+  spec.static_framework = true
+  spec.module_name = 'FlipperKit'
+  spec.platforms = { :ios => "8.4" }
+end

--- a/StubPodspecs/README.md
+++ b/StubPodspecs/README.md
@@ -1,0 +1,1 @@
+This podspecs are the stub one's and are solely meant to reserve the name on cocoapods repo until this [issue](https://github.com/facebook/flipper/issues/132) is solved.


### PR DESCRIPTION
This PR adds a stub podspec files which will be pushed to cocoapods master repo to reserve our project name on cocoapods master repo. This PR follows the suggestion given by @KrauseFx in #132 132