### PR TITLE
Show indicator when client setup fails

### DIFF
--- a/src/chrome/MainSidebar.js
+++ b/src/chrome/MainSidebar.js
@@ -156,12 +156,18 @@ class PluginSidebarListItem extends Component<{
   }
 }
 
-const Spinner = styled(LoadingIndicator)({
-  marginTop: '10px',
-  marginBottom: '10px',
-  marginLeft: 'auto',
-  marginRight: 'auto',
-});
+const Spinner = centerInSidebar(LoadingIndicator);
+
+const ErrorIndicator = centerInSidebar(Glyph);
+
+function centerInSidebar(component) {
+  return styled(component)({
+    marginTop: '10px',
+    marginBottom: '10px',
+    marginLeft: 'auto',
+    marginRight: 'auto',
+  });
+}
 
 type MainSidebarProps = {|
   selectedPlugin: ?string,
@@ -177,6 +183,7 @@ type MainSidebarProps = {|
   uninitializedClients: Array<{
     client: UninitializedClient,
     deviceId?: string,
+    errorMessage?: string,
   }>,
   numNotifications: number,
   devicePlugins: Map<string, Class<FlipperDevicePlugin<>>>,
@@ -290,7 +297,7 @@ class MainSidebar extends PureComponent<MainSidebarProps> {
         {uninitializedClients.map(entry => (
           <React.Fragment key={JSON.stringify(entry.client)}>
             <SidebarHeader>{entry.client.appName}</SidebarHeader>
-            <Spinner size={16} />
+            {entry.errorMessage ? <ErrorIndicator name={"mobile-cross"} size={16} /> : <Spinner size={16}/>}
           </React.Fragment>
         ))}
       </Sidebar>

--- a/src/dispatcher/iOSDevice.js
+++ b/src/dispatcher/iOSDevice.js
@@ -9,6 +9,7 @@ import type {ChildProcess} from 'child_process';
 import type {Store} from '../reducers/index.js';
 import type Logger from '../fb-stubs/Logger.js';
 import type {DeviceType} from '../devices/BaseDevice';
+import {RecurringError} from '../utils/errors';
 
 import {promisify} from 'util';
 import path from 'path';
@@ -111,10 +112,12 @@ function getActiveSimulators(): Promise<Array<IOSDeviceParams>> {
 }
 
 function getActiveDevices(): Promise<Array<IOSDeviceParams>> {
-  return iosUtil.targets().catch(e => {
-    console.warn(e);
-    return [];
-  });
+  return iosUtil.isAvailable()
+    ? iosUtil.targets().catch(e => {
+        console.error(new RecurringError(e.message));
+        return [];
+      })
+    : Promise.resolve([]);
 }
 
 export default (store: Store, logger: Logger) => {

--- a/src/reducers/connections.js
+++ b/src/reducers/connections.js
@@ -315,7 +315,7 @@ export default function reducer(
           .map(
             c =>
               isEqual(c.client, payload.client)
-                ? {...c, error: errorMessage}
+                ? {...c, errorMessage: errorMessage}
                 : c,
           )
           .sort((a, b) => a.client.appName.localeCompare(b.client.appName)),

--- a/src/server.js
+++ b/src/server.js
@@ -192,7 +192,6 @@ export default class Server extends EventEmitter {
                 });
               })
               .catch(e => {
-                console.error(e, 'server');
                 subscriber.onError(e);
                 this.emit('client-setup-error', {client, error: e});
               });


### PR DESCRIPTION
At the moment, when a client is failing to connect, you effectively get an infinite spinner, as it keeps retrying.

This keeps the spinner while it's retrying, but in between, shows a failure icon.