### PR TITLE
Enable override of context menu on ManagedTable.

### DIFF
--- a/src/ui/components/ContextMenu.js
+++ b/src/ui/components/ContextMenu.js
@@ -9,7 +9,7 @@ import * as React from 'react';
 import FlexColumn from './FlexColumn.js';
 import PropTypes from 'prop-types';
 
-type MenuTemplate = Array<Electron$MenuItemOptions>;
+export type MenuTemplate = Array<Electron$MenuItemOptions>;
 
 type Props = {
   /** List of items in the context menu. Used for static menus. */

--- a/src/ui/components/table/ManagedTable.js
+++ b/src/ui/components/table/ManagedTable.js
@@ -16,6 +16,8 @@ import type {
   TableOnAddFilter,
 } from './types.js';
 
+import type {MenuTemplate} from '../ContextMenu.js';
+
 import React from 'react';
 import styled from '../../styled/index.js';
 import AutoSizer from 'react-virtualized-auto-sizer';
@@ -106,6 +108,10 @@ export type ManagedTableProps = {|
    * Rows that are highlighted initially.
    */
   highlightedRows?: Set<string>,
+  /**
+   * Allows to create context menu items for rows
+   */
+  buildContextMenuItems?: () => MenuTemplate,
 |};
 
 type ManagedTableState = {|
@@ -541,7 +547,11 @@ class ManagedTable extends React.Component<
           ) : (
             <AutoSizer>
               {({width, height}) => (
-                <ContextMenu buildItems={this.buildContextMenuItems}>
+                <ContextMenu
+                  buildItems={
+                    this.props.buildContextMenuItems ||
+                    this.buildContextMenuItems
+                  }>
                   <List
                     itemCount={rows.length}
                     itemSize={index =>


### PR DESCRIPTION
Summary: This patch add a new prop on ManageTabled called buildContextMenuItems. It allows
to override the current context menu when right click on the ManagedTable rows.