### PR TITLE
[android] Fix bintray upload script

### DIFF
--- a/scripts/publish-android-release.sh
+++ b/scripts/publish-android-release.sh
@@ -12,5 +12,5 @@ elif [ "$IS_SNAPSHOT" != "" ]; then
   exit 1
 else
   openssl aes-256-cbc -d -in scripts/bintray-publish-keys.enc -k "$ANDROID_PUBLISH_KEY" >> "$BASEDIR/gradle.properties"
-  "$BASEDIR"/gradlew bintrayUpload -PdryRun=false
+  "$BASEDIR"/gradlew :android:bintrayUpload :fbjni:bintrayUpload -PdryRun=false
 fi


### PR DESCRIPTION
Summary:
I feel like I'm having a Groundhog Day moment. Haven't I fixed this
before?

Anyway, the release script fails (very verbosely) with an NPE
(https://circleci.com/gh/facebook/flipper/467?utm_campaign=workflow-failed&utm_medium=email&utm_source=notification)
when you run it on the root project. So we need to specify the
sub-projects we want to run it on.

Test Plan:
Running the new command manually to get `0.14.1` uploaded right now.