### PR TITLE
Fix soloader gradle dependency

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -86,7 +86,7 @@ repositories {
 
 dependencies {
   debugImplementation 'com.facebook.flipper:flipper:0.14.1'
-  debugImplementation 'com.facebook.flipper:soloader:0.5.1'
+  debugImplementation 'com.facebook.soloader:soloader:0.5.1'
 }
 ```
 


### PR DESCRIPTION
The gradle dependency on soloader was using a wrong groupId (flipper instead of soloader)