### PR TITLE
Add accepted Android SDK license

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,16 @@ executors:
       TERM: 'dumb'
 
 jobs:
+  add_accepted_android_sdk_license:
+    executor: default-executor
+    docker:
+      - image: circleci/android:api-28-ndk-r17b
+      - run:
+          name: Add accepted Android SDK license
+          command: |
+            mkdir -p "$ANDROID_HOME/licenses/"
+            echo > "$ANDROID_HOME/licenses/android-sdk-license"
+            echo -n 24333f8a63b6825ea9c5514f83c2829b004d1fee > "$ANDROID_HOME/licenses/android-sdk-license"
   snapshot:
     executor: default-executor
     docker:
@@ -33,6 +43,7 @@ workflows:
   version: 2
   build-and-deploy:
     jobs:
+      - add_accepted_android_sdk_license
       - snapshot:
           filters:
             branches:


### PR DESCRIPTION
Android SDK license SHA has been updated as of January 16, 2019 so it needs to be re-accepted. This is only needed for CircleCI since in Travis setup `sdkmanager` is used in order to accept the Licenses.