### PR TITLE
Typo in CircleCI/config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ jobs:
     executor: default-executor
     docker:
       - image: circleci/android:api-28-ndk-r17b
+    steps:
       - run:
           name: Add accepted Android SDK license
           command: |


### PR DESCRIPTION
My bad, forgot the `steps` key.