### PR TITLE
Properly fix license issue in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,17 +9,6 @@ executors:
       TERM: 'dumb'
 
 jobs:
-  add_accepted_android_sdk_license:
-    executor: default-executor
-    docker:
-      - image: circleci/android:api-28-ndk-r17b
-    steps:
-      - run:
-          name: Add accepted Android SDK license
-          command: |
-            mkdir -p "$ANDROID_HOME/licenses/"
-            echo > "$ANDROID_HOME/licenses/android-sdk-license"
-            echo -n 24333f8a63b6825ea9c5514f83c2829b004d1fee > "$ANDROID_HOME/licenses/android-sdk-license"
   snapshot:
     executor: default-executor
     docker:
@@ -28,7 +17,9 @@ jobs:
       - checkout
       - run:
           name: build and deploy
-          command: ./gradlew :android:assembleRelease && scripts/publish-android-snapshot.sh
+          command: |
+            yes | sdkmanager "platforms;android-27" || true
+            ./gradlew :android:assembleRelease && scripts/publish-android-snapshot.sh
 
   release:
     executor: default-executor
@@ -38,13 +29,14 @@ jobs:
       - checkout
       - run:
           name: build and deploy
-          command: ./gradlew :android:assembleRelease && scripts/publish-android-release.sh
+          command: |
+            yes | sdkmanager "platforms;android-27" || true
+            ./gradlew :android:assembleRelease && scripts/publish-android-release.sh
 
 workflows:
   version: 2
   build-and-deploy:
     jobs:
-      - add_accepted_android_sdk_license
       - snapshot:
           filters:
             branches:


### PR DESCRIPTION
Apparently this seems to be the only way to make build work, with the updated licenses. It also follows the same strategy as Travis.

I am using double pipe in `sdkmanager` command execution, to avoid breaking the build, because `sdkmanager` returns exit code 141 in case it meets the requirements requested. (e.g.: `yes | sdkmanager --licenses` returns 141, which in turn breaks the build due to `set -eo pipefail` Bash flags, that CircleCI is using in order to execute any scripts)

For the record, I tried the following solutions, that did not work:
* Add accepted license SHA in Android SDK licenses folder.
* Accept all licenses prior to running the other jobs (with a separate job, working as a dependency to the rest of the Workflow jobs) (`yes | sdkmanager --licenses`)
* Accept all licenses prior to executing any Gradle command (without a separate job) (`yes | sdkmanager --licenses`)