### PR TITLE
[eslint] Restore "fb" preset

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,6 +27,16 @@ module.exports = {
 
     // additional rules for this project
     'header/header': [2, 'block', {pattern}],
-    'prettier/prettier': [2, {requirePragma: true}],
+    'prettier/prettier': [
+      2,
+      {
+        requirePragma: true,
+        singleQuote: true,
+        trailingComma: 'all',
+        bracketSpacing: false,
+        jsxBracketSameLine: true,
+        parser: 'flow',
+      },
+    ],
   },
 };


### PR DESCRIPTION
Summary:
I must have run this locally on an outdated version of eslint or the
plugin, because I did not see all the formatting errors. This is because
`eslint-plugin-prettier` dropped support for the `fb` preset (see https://github.com/prettier/eslint-plugin-prettier/pull/113/files). This restores the equivalent ruleset explicitly.

Test Plan:
`yarn && yarn run eslint .` + waiting for Circle.