### PR TITLE
Allow underscore characters in app name

### DIFF
--- a/src/utils/CertificateProvider.js
+++ b/src/utils/CertificateProvider.js
@@ -38,7 +38,7 @@ const caSubject = '/C=US/ST=CA/L=Menlo Park/O=Sonar/CN=SonarCA';
 const serverSubject = '/C=US/ST=CA/L=Menlo Park/O=Sonar/CN=localhost';
 const minCertExpiryWindowSeconds = 24 * 60 * 60;
 const appNotDebuggableRegex = /debuggable/;
-const allowedAppNameRegex = /^[a-zA-Z0-9.\-]+$/;
+const allowedAppNameRegex = /^[a-zA-Z0-9._\-]+$/;
 const operationNotPermittedRegex = /not permitted/;
 const logTag = 'CertificateProvider';
 /*


### PR DESCRIPTION
This whitelist exists to prevent unauthorized code execution. But there's no need to exclude _, which is a valid character in android app names.

Fixes #367 