### PR TITLE
Provide clearer message about launcher delegation

### DIFF
--- a/static/setup.js
+++ b/static/setup.js
@@ -35,6 +35,9 @@ const startLauncher = () => {
 module.exports = function(argv) {
   if (argv.launcher && isProduction() && isLauncherInstalled()) {
     console.warn('Delegating to Flipper Launcher ...');
+    console.warn(
+      `You can disable this behavior by passing '--no-launcher' at startup.`,
+    );
     startLauncher();
     process.exit(0);
   }


### PR DESCRIPTION
Summary:
To make it more obvious how to disable this if unwanted (e.g. when
testing local builds).

Test Plan:
eyes