### PR TITLE
Ensure build dir exists before writing to it

### DIFF
--- a/android/third-party/native.gradle
+++ b/android/third-party/native.gradle
@@ -226,6 +226,7 @@ task prepareRSocket(dependsOn: [downloadRSocket], type: Copy) {
 
 task writeCacheRevision(dependsOn: createNativeDepsDirectories) {
     doLast {
+        buildDir.mkdirs()
         revisionFile.text = CACHE_REVISION.toString()
     }
 }


### PR DESCRIPTION
This is because `doLast` may happen after the cleanup came around to undo `createNativeDepsDirectories` specified as dependency.