### PR TITLE
adding PreferenceManager.getDefaultSharedPreferencesName to default

### DIFF
--- a/android/src/main/java/com/facebook/flipper/plugins/sharedpreferences/SharedPreferencesFlipperPlugin.java
+++ b/android/src/main/java/com/facebook/flipper/plugins/sharedpreferences/SharedPreferencesFlipperPlugin.java
@@ -141,6 +141,7 @@ public class SharedPreferencesFlipperPlugin implements FlipperPlugin {
       return Build.VERSION.SDK_INT >= Build.VERSION_CODES.N
               ? PreferenceManager.getDefaultSharedPreferencesName(context)
               : context.getPackageName() + "_preferences";
+  }
   
   private SharedPreferences getSharedPreferencesFor(String name) {
     for (Map.Entry<SharedPreferences, SharedPreferencesDescriptor> entry :

--- a/android/src/main/java/com/facebook/flipper/plugins/sharedpreferences/SharedPreferencesFlipperPlugin.java
+++ b/android/src/main/java/com/facebook/flipper/plugins/sharedpreferences/SharedPreferencesFlipperPlugin.java
@@ -10,6 +10,8 @@ import static android.content.Context.MODE_PRIVATE;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.os.Build;
+import android.preference.PreferenceManager;
 import com.facebook.flipper.core.FlipperConnection;
 import com.facebook.flipper.core.FlipperObject;
 import com.facebook.flipper.core.FlipperPlugin;
@@ -128,10 +130,18 @@ public class SharedPreferencesFlipperPlugin implements FlipperPlugin {
         String prefName = each.substring(0, each.indexOf(XML_SUFFIX));
         descriptors.add(new SharedPreferencesDescriptor(prefName, MODE_PRIVATE));
       }
-    }
+    }    
+
+    descriptors.add(0, new SharedPreferencesDescriptor(getDefaultSharedPreferencesName(context), MODE_PRIVATE));
+          
     return descriptors;
   }
 
+  private static String getDefaultSharedPreferencesName(Context context) {
+      return Build.VERSION.SDK_INT >= Build.VERSION_CODES.N
+              ? PreferenceManager.getDefaultSharedPreferencesName(context)
+              : context.getPackageName() + "_preferences";
+  
   private SharedPreferences getSharedPreferencesFor(String name) {
     for (Map.Entry<SharedPreferences, SharedPreferencesDescriptor> entry :
         mSharedPreferences.entrySet()) {

--- a/android/src/main/java/com/facebook/flipper/plugins/sharedpreferences/SharedPreferencesFlipperPlugin.java
+++ b/android/src/main/java/com/facebook/flipper/plugins/sharedpreferences/SharedPreferencesFlipperPlugin.java
@@ -132,7 +132,7 @@ public class SharedPreferencesFlipperPlugin implements FlipperPlugin {
       }
     }    
 
-    descriptors.add(0, new SharedPreferencesDescriptor(getDefaultSharedPreferencesName(context), MODE_PRIVATE));
+    descriptors.add(new SharedPreferencesDescriptor(getDefaultSharedPreferencesName(context), MODE_PRIVATE));
           
     return descriptors;
   }


### PR DESCRIPTION
## Summary

Adding context [PreferenceManager.getDefaultSharedPreferencesName](https://developer.android.com/reference/android/preference/PreferenceManager.html#getDefaultSharedPreferences(android.content.Context)) by default. 

## Changelog

Adding context default shared preference by default. 
