### PR TITLE
Bump Kotlin to 1.3.31

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ POM_DEVELOPER_NAME=facebook
 # Shared version numbers
 LITHO_VERSION=0.26.1
 ANDROIDX_VERSION=1.0.0
-KOTLIN_VERSION=1.3.21
+KOTLIN_VERSION=1.3.31
 
 # Gradle internals
 org.gradle.internal.repository.max.retries=10


### PR DESCRIPTION
Summary:
Making sure we stay up-to-date.

Test Plan:
./gradlew :tutorial:installDebug