### PR TITLE
Add protect when save task

### DIFF
--- a/iOS/Plugins/FlipperKitNetworkPlugin/SKIOSNetworkPlugin/FLEXNetworkLib/FLEXNetworkObserver.mm
+++ b/iOS/Plugins/FlipperKitNetworkPlugin/SKIOSNetworkPlugin/FLEXNetworkLib/FLEXNetworkObserver.mm
@@ -847,7 +847,10 @@ static char const *const kFLEXRequestIDKey = "kFLEXRequestIDKey";
 
 + (void)setRequestID:(NSString *)requestID forConnectionOrTask:(id)connectionOrTask
 {
-    objc_setAssociatedObject(connectionOrTask, kFLEXRequestIDKey, requestID, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    if (connectionOrTask) {
+        objc_setAssociatedObject(connectionOrTask, kFLEXRequestIDKey, requestID, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+    
 }
 
 #pragma mark - Initialization


### PR DESCRIPTION
Bugfix

Add protect when save task

If local cache resource are valid, we don't create a Task .So here are crash.  
