### PR TITLE
Reenable x86 builds

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,7 +20,7 @@ android {
         buildConfigField "boolean", "IS_INTERNAL_BUILD", 'true'
 
         ndk {
-            abiFilters 'x86_64', 'armeabi-v7a', 'arm64-v8a'
+            abiFilters 'x86', 'x86_64', 'armeabi-v7a', 'arm64-v8a'
         }
 
         externalNativeBuild {


### PR DESCRIPTION
Summary:
Fixes https://github.com/facebook/flipper/issues/471

Disabling the x86 builds altogether does more harm than good.

Reviewed By: jknoxville

Differential Revision: D16119936

