### PR TITLE
Enable cocoapods caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,8 @@ matrix:
 
     - language: objective-c
 
+      cache: cocoapods
+
       before_install:
         - rm -rf iOS/Sample/Pods
         - rm -f iOS/Sample/Podfile.lock


### PR DESCRIPTION
Enable caching for cocoapods.

This was my attempt to fix the test which @priteshrnandgaonkar did with #490, but might still be useful.