### PR TITLE
Force trusty for Android builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,6 +81,7 @@ matrix:
         - tail -100 ./build.log
     - language: android
       os: linux
+      dist: trusty
       android:
         components:
           - tools


### PR DESCRIPTION
The Android build is currently broken and this coincided with the switch from `trusty` to `xenial`.

![Screenshot 2019-07-29 15 58 46](https://user-images.githubusercontent.com/9906/62058727-c923bd80-b219-11e9-8edd-231bc700dda3.png)
(green build)

![Screenshot 2019-07-29 15 58 52](https://user-images.githubusercontent.com/9906/62058731-ca54ea80-b219-11e9-8773-29f3ff412bde.png)
(red build)

It looks like Travis messed up their provisioning profiles and is shipping non-Android images for Android build tasks. Not cool.

https://travis-ci.org/facebook/flipper/jobs/564982262
