### PR TITLE
Fixes for shared preferences viewer plugin

### DIFF
--- a/src/plugins/shared_preferences/index.js
+++ b/src/plugins/shared_preferences/index.js
@@ -235,7 +235,7 @@ export default class extends FlipperPlugin<SharedPreferencesState> {
                       value: element.name,
                     },
                     value: {
-                      value: element.value,
+                      value: String(element.value),
                     },
                   },
 

--- a/src/plugins/shared_preferences/index.js
+++ b/src/plugins/shared_preferences/index.js
@@ -201,13 +201,13 @@ export default class extends FlipperPlugin<SharedPreferencesState> {
         <Heading>
           <span style={{marginRight: '16px'}}>Preference File</span>
           <Select
-            options={Object.keys(this.state.sharedPreferences).reduce(
-              (obj, item) => {
+            options={Object.keys(this.state.sharedPreferences)
+              .sort((a, b) => (a.toLowerCase() > b.toLowerCase() ? 1 : -1))
+              .reduce((obj, item) => {
                 obj[item] = item;
                 return obj;
-              },
-              {},
-            )}
+              }, {})}
+            selected={this.state.selectedPreferences}
             onChange={this.onSharedPreferencesSelected}
           />
         </Heading>


### PR DESCRIPTION
## Summary

Resolve issues for SharedPreferences Viewer 

## Changelog

Fix issue #469 - Changed values for Booleans not displaying
Fix issue #499 - SharedPreference files names not sorted


