### PR TITLE
Enable sandbox plugin

### DIFF
--- a/src/plugins/sandbox/package.json
+++ b/src/plugins/sandbox/package.json
@@ -5,7 +5,6 @@
   "main": "index.js",
   "license": "MIT",
   "keywords": ["flipper-plugin"],
-  "gatekeeper": "sonar_sandbox_plugin",
   "icon": "translate",
   "bugs": {
     "email": "edoardo@fb.com"


### PR DESCRIPTION
Removes a gatekeeper that shouldn't be there.
Reported in https://github.com/facebook/flipper/issues/535
