### PR TITLE
Upgrade to fbjni 0.2.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -58,9 +58,9 @@ android {
     dependencies {
         compileOnly deps.lithoAnnotations
         compileOnly deps.proguardAnnotations
-        implementation 'com.facebook.fbjni:fbjni:0.0.1'
-        extractHeaders 'com.facebook.fbjni:fbjni:0.0.1:headers'
-        extractJNI 'com.facebook.fbjni:fbjni:0.0.1'
+        implementation 'com.facebook.fbjni:fbjni:0.0.2'
+        extractHeaders 'com.facebook.fbjni:fbjni:0.0.2:headers'
+        extractJNI 'com.facebook.fbjni:fbjni:0.0.2'
         implementation deps.soloader
         implementation deps.jsr305
         implementation deps.supportAppCompat

--- a/build.gradle
+++ b/build.gradle
@@ -31,11 +31,6 @@ subprojects {
         mavenCentral()
         jcenter()
 
-        maven {
-            // TODO: Remove once this is on official JCenter.
-            url 'https://dl.bintray.com/facebook/maven/'
-        }
-
         if (isSnapshot()) {
             maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 # in the root directory of this source tree.
 
 # POM publishing constants
-VERSION_NAME=0.23.7
+VERSION_NAME=0.23.8
 GROUP=com.facebook.flipper
 POM_URL=https://github.com/facebook/flipper
 POM_SCM_URL=https://github.com/facebook/flipper.git


### PR DESCRIPTION
Summary:
This is now published to Maven Central and doesn't require a
separate repository.

Test Plan:
CI