### PR TITLE
Upgrade to fbjni 0.2.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -57,9 +57,9 @@ android {
 
     dependencies {
         compileOnly deps.proguardAnnotations
-        implementation 'com.facebook.fbjni:fbjni:0.0.1'
-        extractHeaders 'com.facebook.fbjni:fbjni:0.0.1:headers'
-        extractJNI 'com.facebook.fbjni:fbjni:0.0.1'
+        implementation 'com.facebook.fbjni:fbjni:0.0.2'
+        extractHeaders 'com.facebook.fbjni:fbjni:0.0.2:headers'
+        extractJNI 'com.facebook.fbjni:fbjni:0.0.2'
         implementation deps.soloader
         implementation deps.jsr305
         implementation deps.supportAppCompat

--- a/build.gradle
+++ b/build.gradle
@@ -31,11 +31,6 @@ subprojects {
         mavenCentral()
         jcenter()
 
-        maven {
-            // TODO: Remove once this is on official JCenter.
-            url 'https://dl.bintray.com/facebook/maven/'
-        }
-
         if (isSnapshot()) {
             maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
         }


### PR DESCRIPTION
Summary:
This is now published to Maven Central and doesn't require a
separate repository.

Test Plan:
CI
