### PR TITLE
Fix crash of iOS FlipperNetworkPlugin

### DIFF
--- a/iOS/Plugins/FlipperKitNetworkPlugin/SKIOSNetworkPlugin/FLEXNetworkLib/FLEXNetworkObserver.mm
+++ b/iOS/Plugins/FlipperKitNetworkPlugin/SKIOSNetworkPlugin/FLEXNetworkLib/FLEXNetworkObserver.mm
@@ -270,6 +270,14 @@ didBecomeDownloadTask:(NSURLSessionDownloadTask *)downloadTask delegate:(id<NSUR
         Method originalResume = class_getInstanceMethod(className, selector);
 
         void (^swizzleBlock)(NSURLSessionTask *) = ^(NSURLSessionTask *slf) {
+          
+            // iOS's internal HTTP parser finalization code is mysteriously not thread safe,
+            // invoke it asynchronously has a chance to cause a `double free` crash.
+            // This line below will ask for HTTPBody synchronously, make the HTTPParser parse the request and cache them in advance,
+            // After that the HTTPParser will be finalized,
+            // make sure other threads inspecting the request won't trigger a race to finalize the parser.
+            [slf.currentRequest HTTPBody];
+          
             [[FLEXNetworkObserver sharedObserver] URLSessionTaskWillResume:slf];
             ((void(*)(id, SEL))objc_msgSend)(slf, swizzledSelector);
         };


### PR DESCRIPTION
## Summary
  Flipper's network plugin may cause crash on a frequency of about one time per 1~2 days(I think it depends on how many network request we send).
![IMG_3095](https://user-images.githubusercontent.com/24563710/65739973-cc540080-e119-11e9-9e6e-e4a925ecc63c.JPG)

  I assume the crash is caused by part of the code of HTTPParser is not thread-safe, and invoke it asynchronously may cause double-free crash. So I manually ask for HTTPBody synchronously, make the HTTPParser parse the request and cache them in advance, before any possible asynchronous invoking.

## Changelog
  Fix potential crash cause by network plugin.

## Test Plan
1. Run our App with Flipper integrated
2. Make sure FlipperNetworkPlugin is active
3. It may take days to reproduce the crash