### PR TITLE
Update CocoaPods in Getting Started documentation

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -111,16 +111,23 @@ We support both Swift and Objective-C for Flipper with CocoaPods as build and di
 <!--Objective-C-->
 ```ruby
 project 'MyApp.xcodeproj'
-flipperkit_version = '0.25.0'
+
+def flipper_pods()
+  flipperkit_version = '0.25.0'
+  pod 'FlipperKit', '~>' + flipperkit_version, :configuration => 'Debug'
+  pod 'FlipperKit/FlipperKitLayoutComponentKitSupport', '~>' + flipperkit_version, :configuration => 'Debug'
+  pod 'FlipperKit/SKIOSNetworkPlugin', '~>' + flipperkit_version, :configuration => 'Debug'
+  pod 'FlipperKit/FlipperKitUserDefaultsPlugin', '~>' + flipperkit_version, :configuration => 'Debug'
+  pod 'FlipperKit/FlipperKitReactPlugin', '~>' + flipperkit_version, :configuration => 'Debug'
+end
 
 target 'MyApp' do
   platform :ios, '9.0'
   # use_modular_headers!
   # use_frameworks!
-  pod 'FlipperKit', '~>' + flipperkit_version, :configuration => 'Debug'
-  pod 'FlipperKit/FlipperKitLayoutComponentKitSupport', '~>' + flipperkit_version, :configuration => 'Debug'
-  pod 'FlipperKit/SKIOSNetworkPlugin', '~>' + flipperkit_version, :configuration => 'Debug'
-  pod 'FlipperKit/FlipperKitUserDefaultsPlugin', '~>' + flipperkit_version, :configuration => 'Debug'
+
+  # For enabling Flipper.
+  flipper_pods()
 
   def flipper_pre_install_static_frameworks(installer)
     $static_framework = ['FlipperKit', 'Flipper', 'Flipper-Folly',

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -185,26 +185,25 @@ target 'MyApp' do
   pod 'FlipperKit/SKIOSNetworkPlugin', '~>' + flipperkit_version, :configuration => 'Debug'
   pod 'FlipperKit/FlipperKitUserDefaultsPlugin', '~>' + flipperkit_version, :configuration => 'Debug'
 
-  # If you use `use_frameworks!` in your Podfile,
-  # uncomment the below $static_framework array and also
-  # the pre_install section.  This will cause Flipper and
-  # it's dependencies to be built as a static library and all other pods to
-  # be dynamic.
-  # $static_framework = ['FlipperKit', 'Flipper', 'Flipper-Folly',
-  #   'CocoaAsyncSocket', 'ComponentKit', 'DoubleConversion',
-  #   'glog', 'Flipper-PeerTalk', 'Flipper-RSocket', 'Yoga', 'YogaKit',
-  #   'CocoaLibEvent', 'openssl-ios-bitcode', 'boost-for-react-native']
-  #
-  # pre_install do |installer|
-  #   Pod::Installer::Xcode::TargetValidator.send(:define_method, :verify_no_static_framework_transitive_dependencies) {}
-  #   installer.pod_targets.each do |pod|
-  #       if $static_framework.include?(pod.name)
-  #         def pod.build_type;
-  #           Pod::Target::BuildType.static_library
-  #         end
-  #       end
-  #     end
-  # end
+  def flipper_pre_install_static_frameworks(installer)
+    $static_framework = ['FlipperKit', 'Flipper', 'Flipper-Folly',
+    'CocoaAsyncSocket', 'ComponentKit', 'DoubleConversion',
+    'glog', 'Flipper-PeerTalk', 'Flipper-RSocket', 'Yoga', 'YogaKit',
+    'CocoaLibEvent', 'openssl-ios-bitcode', 'boost-for-react-native']
+
+    installer.pod_targets.each do |pod|
+      if $static_framework.include?(pod.name)
+        def pod.build_type;
+          Pod::Target::BuildType.static_library
+        end
+      end
+    end
+  end
+
+  pre_install do |installer|
+    # Apply this only if you have defined use_frameworks!
+    # flipper_pre_install_static_frameworks(installer)
+  end
 
 
   # This post_install hook adds the -DFB_SONARKIT_ENABLED flag to OTHER_SWIFT_FLAGS, necessary to build swift target

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -121,26 +121,28 @@ target 'MyApp' do
   pod 'FlipperKit/SKIOSNetworkPlugin', '~>' + flipperkit_version, :configuration => 'Debug'
   pod 'FlipperKit/FlipperKitUserDefaultsPlugin', '~>' + flipperkit_version, :configuration => 'Debug'
 
-  # If you use `use_frameworks!` in your Podfile,
-  # uncomment the below $static_framework array and also
-  # the pre_install section.  This will cause Flipper and
-  # it's dependencies to be built as a static library and all other pods to
-  # be dynamic.
-  # $static_framework = ['FlipperKit', 'Flipper', 'Flipper-Folly',
-  #   'CocoaAsyncSocket', 'ComponentKit', 'DoubleConversion',
-  #   'glog', 'Flipper-PeerTalk', 'Flipper-RSocket', 'Yoga', 'YogaKit',
-  #   'CocoaLibEvent', 'openssl-ios-bitcode', 'boost-for-react-native']
-  #
-  # pre_install do |installer|
-  #   Pod::Installer::Xcode::TargetValidator.send(:define_method, :verify_no_static_framework_transitive_dependencies) {}
-  #   installer.pod_targets.each do |pod|
-  #       if $static_framework.include?(pod.name)
-  #         def pod.build_type;
-  #           Pod::Target::BuildType.static_library
-  #         end
-  #       end
-  #     end
-  # end
+  def flipper_pre_install_static_frameworks(installer)
+    $static_framework = ['FlipperKit', 'Flipper', 'Flipper-Folly',
+    'CocoaAsyncSocket', 'ComponentKit', 'DoubleConversion',
+    'glog', 'Flipper-PeerTalk', 'Flipper-RSocket', 'Yoga', 'YogaKit',
+    'CocoaLibEvent', 'openssl-ios-bitcode', 'boost-for-react-native']
+
+    installer.pod_targets.each do |pod|
+      if $static_framework.include?(pod.name)
+        def pod.build_type;
+          Pod::Target::BuildType.static_library
+        end
+      end
+    end
+  end
+  
+  pre_install do |installer|
+    Pod::Installer::Xcode::TargetValidator.send(:define_method, :verify_no_static_framework_transitive_dependencies) {}
+
+    # Apply this only if you have defined use_frameworks!
+    # flipper_pre_install_static_frameworks(installer)
+  end
+
 
   # This post_install hook adds the -DFB_SONARKIT_ENABLED=1 flag to OTHER_CFLAGS, necessary to expose Flipper classes in the header files
   post_install do |installer|

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -167,6 +167,8 @@ target 'MyApp' do
 
   # For enabling Flipper.
   flipper_pods()
+
+  # Add new pods below this line
 end
 ```
 <!--Swift-->

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -116,10 +116,10 @@ flipperkit_version = '0.25.0'
 target 'MyApp' do
   platform :ios, '9.0'
   # use_framework!
-  pod 'FlipperKit', '~>' + flipperkit_version
-  pod 'FlipperKit/FlipperKitLayoutComponentKitSupport', '~>' + flipperkit_version
-  pod 'FlipperKit/SKIOSNetworkPlugin', '~>' + flipperkit_version
-  pod 'FlipperKit/FlipperKitUserDefaultsPlugin', '~>' + flipperkit_version
+  pod 'FlipperKit', '~>' + flipperkit_version, :configuration => 'Debug'
+  pod 'FlipperKit/FlipperKitLayoutComponentKitSupport', '~>' + flipperkit_version, :configuration => 'Debug'
+  pod 'FlipperKit/SKIOSNetworkPlugin', '~>' + flipperkit_version, :configuration => 'Debug'
+  pod 'FlipperKit/FlipperKitUserDefaultsPlugin', '~>' + flipperkit_version, :configuration => 'Debug'
 
   # If you use `use_frameworks!` in your Podfile,
   # uncomment the below $static_framework array and also
@@ -176,11 +176,11 @@ flipperkit_version = '0.25.0'
 target 'MyApp' do
   platform :ios, '9.0'
 
-  pod 'FlipperKit', '~>' + flipperkit_version
+  pod 'FlipperKit', '~>' + flipperkit_version, :configuration => 'Debug'
   # Layout and network plugins are not yet supported for swift projects
-  pod 'FlipperKit/FlipperKitLayoutComponentKitSupport', '~>' + flipperkit_version
-  pod 'FlipperKit/SKIOSNetworkPlugin', '~>' + flipperkit_version
-  pod 'FlipperKit/FlipperKitUserDefaultsPlugin', '~>' + flipperkit_version
+  pod 'FlipperKit/FlipperKitLayoutComponentKitSupport', '~>' + flipperkit_version, :configuration => 'Debug'
+  pod 'FlipperKit/SKIOSNetworkPlugin', '~>' + flipperkit_version, :configuration => 'Debug'
+  pod 'FlipperKit/FlipperKitUserDefaultsPlugin', '~>' + flipperkit_version, :configuration => 'Debug'
 
   # If you use `use_frameworks!` in your Podfile,
   # uncomment the below $static_framework array and also

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -115,7 +115,8 @@ flipperkit_version = '0.25.0'
 
 target 'MyApp' do
   platform :ios, '9.0'
-  # use_framework!
+  # use_modular_headers!
+  # use_frameworks!
   pod 'FlipperKit', '~>' + flipperkit_version, :configuration => 'Debug'
   pod 'FlipperKit/FlipperKitLayoutComponentKitSupport', '~>' + flipperkit_version, :configuration => 'Debug'
   pod 'FlipperKit/SKIOSNetworkPlugin', '~>' + flipperkit_version, :configuration => 'Debug'


### PR DESCRIPTION
## Summary
"CocoaPods / Podfile" section in "Getting Started" documentation is out of sync with Podfile provided by React Native 0.61.x. This PR updates the necessary parts of setup. In addition, it does some clarifications in code.

## Changelog

Update section "CocoaPods" in "Getting Started" documentation.

## Test Plan

These are changes in documentation. The changes can be tested by installing pods and building the project.
