### PR TITLE
Work with custom SharedPreferences implementation

### DIFF
--- a/android/src/main/java/com/facebook/flipper/plugins/sharedpreferences/SharedPreferencesFlipperPlugin.java
+++ b/android/src/main/java/com/facebook/flipper/plugins/sharedpreferences/SharedPreferencesFlipperPlugin.java
@@ -102,7 +102,7 @@ public class SharedPreferencesFlipperPlugin implements FlipperPlugin {
     mSharedPreferences = new HashMap<>(descriptors.size());
     for (SharedPreferencesDescriptor descriptor : descriptors) {
       SharedPreferences preferences =
-          context.getSharedPreferences(descriptor.name, descriptor.mode);
+          descriptor.getSharedPreferences(context);
       preferences.registerOnSharedPreferenceChangeListener(onSharedPreferenceChangeListener);
       mSharedPreferences.put(preferences, descriptor);
     }
@@ -251,6 +251,10 @@ public class SharedPreferencesFlipperPlugin implements FlipperPlugin {
       }
       this.name = name;
       this.mode = mode;
+    }
+
+    public SharedPreferences getSharedPreferences(Context context) {
+        return context.getSharedPreferences(name, mode);
     }
   }
 }


### PR DESCRIPTION
## Summary
see #450 
If we want to control a custom SharedPreferences, we can create a Class as SharedPreferencesDescriptor's Subclass, override the getSharedPreferences() function to return a custom SharedPreferences instance.

## Changelog
add getSharedPreferences() function in SharedPreferencesDescriptor Class

## Test Plan
No
