### PR TITLE
[workflows] Run lint and build step

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -23,5 +23,3 @@ jobs:
       run: yarn lint
     - name: test
       run: yarn test
-    - name: test electron
-      run: yarn test-electron

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -23,3 +23,5 @@ jobs:
       run: yarn lint
     - name: test
       run: yarn test
+    - name: build
+      run: yarn build --linux

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -20,4 +20,6 @@ jobs:
     - name: yarn install, build, and test
       run: |
         yarn
+        yarn lint
         yarn test
+        yarn test-electron

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -17,9 +17,11 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - name: yarn install, build, and test
-      run: |
-        yarn
-        yarn lint
-        yarn test
-        yarn test-electron
+    - name: yarn install
+      run: yarn
+    - name: lint
+      run: yarn lint
+    - name: test
+      run: yarn test
+    - name: test electron
+      run: yarn test-electron


### PR DESCRIPTION
Summary:
Copying more test steps to GH Actions. Currently duplicated but still useful because we can see when things like build breaking in Travis are just flakiness. Once we're happy with this, we can remove the corresponding Travis steps.

Test Plan:
https://github.com/facebook/flipper/pull/583/checks?check_run_id=259190923
https://github.com/facebook/flipper/pull/583/checks?check_run_id=259190943