### PR TITLE
Move declaration of required permissions into core lib

### DIFF
--- a/android/sample/AndroidManifest.xml
+++ b/android/sample/AndroidManifest.xml
@@ -9,9 +9,7 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.facebook.flipper.sample">
-  <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-  <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
 
   <application
       android:name=".FlipperSampleApplication"

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -8,4 +8,7 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.facebook.flipper">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
 </manifest>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,14 +22,7 @@ Once you start Flipper and launch an emulator/simulator or connect a device, you
 
 ## Setup your Android app
 
-Add the following permissions to your `AndroidManifest.xml`. The SDK needs these to communicate with the desktop app on localhost via adb. It won't make any external internet requests.
-
-```xml
-<uses-permission android:name="android.permission.INTERNET" />
-<uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
-```
-
-It's recommended that you add the following activity to the manifest too, which can help diagnose integration issues and other problems:
+It's recommended that you add the following activity to the manifest, which can help diagnose integration issues and other problems:
 
 ```xml
 <activity android:name="com.facebook.flipper.android.diagnostics.FlipperDiagnosticActivity"


### PR DESCRIPTION
## Summary

If we move the permissions into the library itself, the manifest
merger will take care of adding them to consuming applications,
making setup instructions easier.

## Changelog

Move required permission declarations into flipper-core

## Test Plan

Using aapt we can dump the permissions of a sample app.
`$ANDROID_HOME/build-tools/29.0.2/aapt d permissions sample-debug.apk `
```
package: com.facebook.flipper.sample
uses-permission: name='android.permission.WRITE_EXTERNAL_STORAGE'
uses-permission: name='android.permission.INTERNET'
uses-permission: name='android.permission.ACCESS_WIFI_STATE'
uses-permission: name='android.permission.READ_EXTERNAL_STORAGE'
uses-permission: name='android.permission.FOREGROUND_SERVICE
```