### PR TITLE
[flipper] Fix metrics.node.tsx test

### DIFF
--- a/src/utils/__tests__/metrics.node.tsx
+++ b/src/utils/__tests__/metrics.node.tsx
@@ -15,7 +15,7 @@ try {
 }
 
 import {reportPlatformFailures, reportPluginFailures} from '../metrics';
-import {getInstance} from '../../fb/Logger';
+import {getInstance} from '../../fb-stubs/Logger';
 import {CancelledPromiseError} from '../errors';
 import {mocked} from 'ts-jest/utils';
 


### PR DESCRIPTION
Summary:
It shouldn't make a difference which one we import because they're
both mocked but only one works in the GitHub export.

Test Plan:
yarn test; CI