### PR TITLE
Add Github action to upload android sample apps

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,27 @@
+name: Publish Sample App
+
+on: 
+  release:
+    types: [created]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Build with Gradle
+      run: ./gradlew sample:assembleDebug
+    - name: Rename apk
+      run: mv android/sample/build/outputs/apk/debug/sample-debug.apk SampleApp-android.apk
+    - name: Upload
+      uses: skx/github-action-publish-binaries@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        args: 'SampleApp-android.apk'


### PR DESCRIPTION
Now on every new release, a sample app will be built and added to the Github release artifacts.

## Summary

Adds a Github action to automatically build and attach the android sample app for every flipper release.
This will allow potential users to try out flipper without having to go to the trouble of building their own app.

## Test Plan
Tested on my private repo:
https://github.com/jknoxville/flipper/releases/tag/v0.1.john
