### PR TITLE
Enabled app column by fetching process name from pid in android

### DIFF
--- a/src/devices/AndroidDevice.tsx
+++ b/src/devices/AndroidDevice.tsx
@@ -166,7 +166,8 @@ export default class AndroidDevice extends BaseDevice {
   }
 
   async getProcessName(pid: number): Promise<string> {
-    return await this.adb.shell(this.serial, "ps | grep '" + pid + "'")
+    return await this.adb
+      .shell(this.serial, "ps | grep '" + pid + "'")
       .then(adbkit.util.readAll)
       .then(buffer => buffer.toString())
       .then(output => {

--- a/src/devices/AndroidDevice.tsx
+++ b/src/devices/AndroidDevice.tsx
@@ -167,15 +167,15 @@ export default class AndroidDevice extends BaseDevice {
 
   async getProcessName(pid: number): Promise<string> {
     return await this.adb.shell(this.serial, "ps | grep '" + pid + "'")
-        .then(adbkit.util.readAll)
-        .then(buffer => buffer.toString())
-        .then(output => {
-          const index = output.toString().lastIndexOf(" ");
-          if (index > -1) {
-            return output.substr(index + 1).trim();
-          } else {
-            return "unknown-process";
-          }
-        });
+      .then(adbkit.util.readAll)
+      .then(buffer => buffer.toString())
+      .then(output => {
+        const index = output.toString().lastIndexOf(' ');
+        if (index > -1) {
+          return output.substr(index + 1).trim();
+        } else {
+          return 'unknown-process';
+        }
+      });
   }
 }

--- a/src/devices/BaseDevice.tsx
+++ b/src/devices/BaseDevice.tsx
@@ -124,7 +124,7 @@ export default class BaseDevice {
   }
 
   getProcessName(pid: number): Promise<string> {
-    return Promise.reject(() => new Error("Not supported"));
+    return Promise.reject(() => new Error('Not supported'));
   }
 
   getLogs() {

--- a/src/devices/BaseDevice.tsx
+++ b/src/devices/BaseDevice.tsx
@@ -123,6 +123,10 @@ export default class BaseDevice {
     this._notifyLogListeners(entry);
   }
 
+  getProcessName(pid: number): Promise<string> {
+    return Promise.reject(() => new Error("Not supported"));
+  }
+
   getLogs() {
     return this.logEntries;
   }

--- a/src/plugins/logs/index.tsx
+++ b/src/plugins/logs/index.tsx
@@ -492,7 +492,7 @@ export default class LogTable extends FlipperDevicePlugin<
       // Get the Process name from `pid` and add the process name as App column
       const {pid} = entry;
 
-      this.device.getProcessName(pid).then( (processName) => {
+      this.device.getProcessName(pid).then(processName => {
         // Set process name
         entry.app = processName;
 

--- a/src/plugins/logs/index.tsx
+++ b/src/plugins/logs/index.tsx
@@ -489,9 +489,17 @@ export default class LogTable extends FlipperDevicePlugin<
     };
 
     this.logListener = this.device.addLogListener((entry: DeviceLogEntry) => {
-      const processedEntry = processEntry(entry, String(this.counter++));
-      this.incrementCounterIfNeeded(processedEntry.entry);
-      this.scheduleEntryForBatch(processedEntry);
+      // Get the Process name from `pid` and add the process name as App column
+      const {pid} = entry;
+
+      this.device.getProcessName(pid).then( (processName) => {
+        // Set process name
+        entry.app = processName;
+
+        const processedEntry = processEntry(entry, String(this.counter++));
+        this.incrementCounterIfNeeded(processedEntry.entry);
+        this.scheduleEntryForBatch(processedEntry);
+      });
     });
   }
 

--- a/src/ui/components/searchable/Searchable.tsx
+++ b/src/ui/components/searchable/Searchable.tsx
@@ -287,7 +287,7 @@ const Searchable = (
       } else if (e.key === 'Enter' && this.hasFocus() && this._inputRef) {
         this.matchTags(this._inputRef.value, true);
         this.setState({
-            searchTerm: ''
+          searchTerm: '',
         });
 
         this._inputRef.blur();

--- a/src/ui/components/searchable/Searchable.tsx
+++ b/src/ui/components/searchable/Searchable.tsx
@@ -286,6 +286,11 @@ const Searchable = (
         this.removeFilter(this.state.focusedToken);
       } else if (e.key === 'Enter' && this.hasFocus() && this._inputRef) {
         this.matchTags(this._inputRef.value, true);
+        this.setState({
+            searchTerm: ''
+        });
+
+        this._inputRef.blur();
       }
     };
 


### PR DESCRIPTION
## Summary
This solves #326 

## Changelog
Fetching process name from pid when an entry is getting added to the table and adding it as a column called `app` (it already exists, but disabled for android).

Now, people can filter logs based on the `app` either by directly clicking on it from table or by typing `app=<process-name>` in search bar & hit enter


