### PR TITLE
Limit request/response body to 100kb to address #457

### DIFF
--- a/android/plugins/network/src/main/java/com/facebook/flipper/plugins/network/FlipperOkhttpInterceptor.java
+++ b/android/plugins/network/src/main/java/com/facebook/flipper/plugins/network/FlipperOkhttpInterceptor.java
@@ -40,6 +40,7 @@ public class FlipperOkhttpInterceptor implements Interceptor {
     this.plugin = plugin;
   }
 
+  /** If you want to change the number of bytes displayed for the body, use this constructor */
   public FlipperOkhttpInterceptor(NetworkFlipperPlugin plugin, long maxBodyBytes) {
     this.plugin = plugin;
     this.maxBodyBytes = maxBodyBytes;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

As previously reported in #457, I immediately started to see crashes with Flipper integrated due to large responses (e.g., >= 100MB). This will only write the first 100KB of the response or request body into `RequestInfo` objects.

## Changelog

- Limits request/response body in network request info to 100KB max.

## Test Plan

- Make a network request which has a response size of < 100kb, verify that it is visible in its entirety
- Make a network request w/ response size > 100kb, verify that it is truncated
- Ideally, use your application with the Network plugin running, and do not see OOMs
