### PR TITLE
Run yarn build step on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ matrix:
           on:
             branch: master
     - language: node_js
+      os: linux
       node_js:
         - "11"
 
@@ -37,7 +38,7 @@ matrix:
       script:
         - yarn lint
         - yarn test
-        - yarn build --mac --version=$TRAVIS_BUILD_NUMBER
+        - yarn build --linux --version=$TRAVIS_BUILD_NUMBER
 
     - language: objective-c
       cache:


### PR DESCRIPTION
Summary:
This is the step that keeps failing because of some libuv
nonsense. It's faster and more reliable on Linux, so
there's really no good reason for running it on Mac.

No guarantee that this will fix it, but in the worst case
manually pressing "Rerun" will be faster.

Differential Revision: D18324723

