### PR TITLE
[sections] Fix props naming

### DIFF
--- a/src/plugins/sections/StackTrace.js
+++ b/src/plugins/sections/StackTrace.js
@@ -22,12 +22,12 @@ function isSystemLibrary(libraryName: ?string): boolean {
 
 type Props = {
   data: Array<string>,
-  skip_stack_trace_format?: boolean,
+  skipStackTraceFormat?: boolean,
 };
 
 export default class extends React.Component<Props> {
   render() {
-    if (this.props.skip_stack_trace_format) {
+    if (this.props.skipStackTraceFormat) {
       return (
         <StackTrace backgroundColor={colors.white}>
           {this.props.data.map(stack_trace_line => {


### PR DESCRIPTION
Summary:
It's camelCase for props in JS.

Would be good to have a linter for this in place.

Test Plan:
yarn flow