### PR TITLE
Greenkeeper/promisify child process 3.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "patch-package": "^6.2.0",
     "pkg": "^4.4.1",
     "promise-retry": "^1.1.1",
-    "promisify-child-process": "^3.1.1",
+    "promisify-child-process": "^3.1.3",
     "prop-types": "^15.6.0",
     "query-string": "^6.2.0",
     "react": "16.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7272,10 +7272,10 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-promisify-child-process@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/promisify-child-process/-/promisify-child-process-3.1.1.tgz#3a029c1d97bdb8bbcc8862c765b91f1cee0f2691"
-  integrity sha512-683UHZEP4Bm75BvBujEe87AdE9lxnoWpcU5pEw4FG9HCSwwZC9pF7HUj3QmlDAvhyvulkWHLZs1lVRBNTvkbXQ==
+promisify-child-process@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/promisify-child-process/-/promisify-child-process-3.1.3.tgz#52a3b66638ae101fa2e68f9a2cbd101846042e33"
+  integrity sha512-qVox3vW2hqbktVw+IN7YZ/kgGA+u426ekmiZxiofNe9O4GSewjROwRQ4MQ6IbvhpeYSLqiLS0kMn+FWCz6ENlg==
   dependencies:
     "@babel/runtime" "^7.1.5"
 


### PR DESCRIPTION
Fixes the breakage that came with 3.1.2. Closes #694.