### PR TITLE
fix(flipper-static): show default warning message on firing in unknown flags

### DIFF
--- a/static/index.js
+++ b/static/index.js
@@ -70,6 +70,7 @@ const argv = yargs
   })
   .version(global.__VERSION__)
   .help()
+  .strict()
   .parse(process.argv.slice(1));
 
 const {config, configPath, flipperDir} = setup(argv);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Passing in unknown options along with `flutter-static` now shows the default warning message as part of the API.

## Changelog
show default warning message on firing in unknown flags
<!-- Help reviewers and the release process by writing your own changelog entry. This should just be a brief oneline we can mention in our release notes: https://github.com/facebook/flipper/releases -->

## Test Plan
N/A
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI / output of the test runner and how you invoked it. -->

