### PR TITLE
[kaios] Lock down deps

### DIFF
--- a/src/plugins/kaios-allocations/package.json
+++ b/src/plugins/kaios-allocations/package.json
@@ -18,6 +18,11 @@
   },
   "dependencies": {
     "firefox-client": "0.3.0",
-    "promisify-child-process": "3.1.1"
+    "promisify-child-process": "^3.1.1"
+  },
+  "greenkeeper": {
+    "ignore": [
+      "firefox-client"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
Firefox client is no longer maintained. This is the last official version we can use.

## Test Plan

Greenkeeper.

