### PR TITLE
Flipper: Fix exception in popup menus

### DIFF
--- a/src/ui/components/searchable/FilterToken.tsx
+++ b/src/ui/components/searchable/FilterToken.tsx
@@ -164,8 +164,9 @@ export default class FilterToken extends PureComponent<Props> {
         window: electron.remote.getCurrentWindow(),
         // @ts-ignore: async is private API
         async: true,
-        x: left,
-        y: bottom + 8,
+        // Note: Electron requires the x/y parameters to be integer values for marshalling
+        x: Math.round(left),
+        y: Math.round(bottom + 8),
       });
     }
   };


### PR DESCRIPTION
Summary: When JavaScript fiction meets native interop reality, things get weird. Apparently some coordinates must be integer values.

Reviewed By: mweststrate

Differential Revision: D19606677

