### PR TITLE
Allow Flipper module instances to be created by applications

### DIFF
--- a/react-native/react-native-flipper/android/src/main/java/com/facebook/flipper/reactnative/FlipperModule.java
+++ b/react-native/react-native-flipper/android/src/main/java/com/facebook/flipper/reactnative/FlipperModule.java
@@ -30,7 +30,7 @@ public class FlipperModule extends ReactContextBaseJavaModule {
 
   private final FlipperReactNativeJavaScriptPluginManager mManager;
 
-  FlipperModule(
+  public FlipperModule(
       FlipperReactNativeJavaScriptPluginManager manager, ReactApplicationContext reactContext) {
     super(reactContext);
     mManager = manager;

--- a/react-native/react-native-flipper/android/src/main/java/com/facebook/flipper/reactnative/FlipperReactNativeJavaScriptPluginManager.java
+++ b/react-native/react-native-flipper/android/src/main/java/com/facebook/flipper/reactnative/FlipperReactNativeJavaScriptPluginManager.java
@@ -30,10 +30,10 @@ import org.json.JSONTokener;
  * <p>Note that this manager is not bound to a specific FlipperModule instance, as that might be
  * swapped in and out over time.
  */
-final class FlipperReactNativeJavaScriptPluginManager {
+public final class FlipperReactNativeJavaScriptPluginManager {
   private static FlipperReactNativeJavaScriptPluginManager sInstance;
 
-  static synchronized FlipperReactNativeJavaScriptPluginManager getInstance() {
+  public static synchronized FlipperReactNativeJavaScriptPluginManager getInstance() {
     if (sInstance == null) {
       sInstance = new FlipperReactNativeJavaScriptPluginManager();
     }


### PR DESCRIPTION
## Summary

This allows using the flipper RN module with TurboModules instead of using FlipperPackage.

## Changelog

[react-native-flipper] Allow Flipper module instances to be created by applications

## Test Plan

An instance of the Flipper module can now be created like this when using TurboModules:

```java
  @Override
  public NativeModule getModule(String name, ReactApplicationContext reactContext) {
    switch (name) {
      ...
      case FlipperModule.NAME:
        return new FlipperModule(FlipperReactNativeJavaScriptPluginManager.getInstance(), reactContext);
      ...
    }
  }
```

Tested that it builds
