### PR TITLE
 Upgrade folly to v2020.02.17.00 

### DIFF
--- a/android/third-party/native.gradle
+++ b/android/third-party/native.gradle
@@ -140,7 +140,6 @@ task finalizeFollyWithDemangle(dependsOn: [prepareFolly], type: Copy) {
     into "$externalDir/folly/folly/detail/"
 }
 
-
 // HACK to fix template issue with newest NDK
 task finalizeFollyWithFileUtil(dependsOn: [prepareFolly], type: Copy) {
     from './overrides/Folly/'
@@ -148,11 +147,7 @@ task finalizeFollyWithFileUtil(dependsOn: [prepareFolly], type: Copy) {
     into "$externalDir/folly/folly/"
 }
 
-//TODO: Get rid off this hack.
-task finalizeFolly(dependsOn: [finalizeFollyWithDemangle, finalizeFollyWithFileUtil], type: Copy) {
-    from './overrides/Folly/'
-   include 'AsyncServerSocket.cpp'
-   into "$externalDir/folly/folly/io/async/"
+task finalizeFolly(dependsOn: [finalizeFollyWithDemangle, finalizeFollyWithFileUtil]) {
 }
 
 task downloadLibEvent(dependsOn: [], type: Download) {

--- a/android/third-party/native.gradle
+++ b/android/third-party/native.gradle
@@ -11,7 +11,7 @@ import org.apache.tools.ant.filters.ReplaceTokens
 // Increment this when making changes to any of the native
 // dependencies.
 // !!!
-final def CACHE_REVISION = 29
+final def CACHE_REVISION = 30
 
 final def externalDir = new File("$projectDir/external")
 final def downloadsDir = new File("$externalDir/downloads")
@@ -117,7 +117,7 @@ task prepareBoost(dependsOn: [downloadBoost], type: Copy) {
 }
 
 task downloadFolly(dependsOn: createNativeDepsDirectories, type: Download) {
-    src 'https://github.com/facebook/folly/archive/v2019.09.02.00.tar.gz'
+    src 'https://github.com/facebook/folly/archive/v2020.02.17.00.tar.gz'
     onlyIfNewer true
     overwrite false
     dest new File(downloadsDir, 'folly-' + getDownloadFileName(src))
@@ -127,8 +127,8 @@ task prepareFolly(dependsOn: [downloadFolly], type: Copy) {
     onlyIf { isCacheOutOfDate(CACHE_REVISION) }
     from tarTree(downloadFolly.dest)
     from './overrides/Folly/'
-    include 'folly-2019.09.02.00/folly/**/*', 'build.gradle', 'CMakeLists.txt', 'ApplicationManifest.xml'
-    eachFile { it.path = it.path - "folly-2019.09.02.00/" }
+    include 'folly-2020.02.17.00/folly/**/*', 'build.gradle', 'CMakeLists.txt', 'ApplicationManifest.xml'
+    eachFile { it.path = it.path - "folly-2020.02.17.00/" }
     includeEmptyDirs = false
     into "$externalDir/folly/"
 }
@@ -140,8 +140,16 @@ task finalizeFollyWithDemangle(dependsOn: [prepareFolly], type: Copy) {
     into "$externalDir/folly/folly/detail/"
 }
 
+
+// HACK to fix template issue with newest NDK
+task finalizeFollyWithFileUtil(dependsOn: [prepareFolly], type: Copy) {
+    from './overrides/Folly/'
+    include 'FileUtil.cpp'
+    into "$externalDir/folly/folly/"
+}
+
 //TODO: Get rid off this hack.
-task finalizeFolly(dependsOn: [finalizeFollyWithDemangle], type: Copy) {
+task finalizeFolly(dependsOn: [finalizeFollyWithDemangle, finalizeFollyWithFileUtil], type: Copy) {
     from './overrides/Folly/'
    include 'AsyncServerSocket.cpp'
    into "$externalDir/folly/folly/io/async/"

--- a/android/third-party/overrides/Folly/CMakeLists.txt
+++ b/android/third-party/overrides/Folly/CMakeLists.txt
@@ -95,7 +95,6 @@ list(APPEND SRC_FILES ${FOLLY_DIR}/io/async/HHWheelTimer.cpp
                       ${FOLLY_DIR}/SocketAddress.cpp
                       ${FOLLY_DIR}/Executor.cpp
                       ${FOLLY_DIR}/FileUtil.cpp
-                      ${FOLLY_DIR}/lang/ColdClass.cpp
                       ${FOLLY_DIR}/lang/Assume.cpp
                       ${FOLLY_DIR}/json.cpp
                       ${FOLLY_DIR}/Unicode.cpp

--- a/android/third-party/overrides/Folly/FileUtil.cpp
+++ b/android/third-party/overrides/Folly/FileUtil.cpp
@@ -1,0 +1,270 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/FileUtil.h>
+
+#include <cerrno>
+#include <string>
+#include <system_error>
+#include <vector>
+
+#include <folly/detail/FileUtilDetail.h>
+#include <folly/net/NetOps.h>
+#include <folly/portability/Fcntl.h>
+#include <folly/portability/Sockets.h>
+#include <folly/portability/Stdlib.h>
+#include <folly/portability/SysFile.h>
+#include <folly/portability/SysStat.h>
+
+namespace folly {
+
+using namespace fileutil_detail;
+
+static int filterCloseReturn(int r) {
+  // Ignore EINTR.  On Linux, close() may only return EINTR after the file
+  // descriptor has been closed, so you must not retry close() on EINTR --
+  // in the best case, you'll get EBADF, and in the worst case, you'll end up
+  // closing a different file (one opened from another thread).
+  //
+  // Interestingly enough, the Single Unix Specification says that the state
+  // of the file descriptor is unspecified if close returns EINTR.  In that
+  // case, the safe thing to do is also not to retry close() -- leaking a file
+  // descriptor is definitely better than closing the wrong file.
+  if (r == -1 && errno == EINTR) {
+    return 0;
+  }
+  return r;
+}
+
+int closeNoInt(int fd) {
+  return filterCloseReturn(close(fd));
+}
+
+int closeNoInt(NetworkSocket fd) {
+  return filterCloseReturn(netops::close(fd));
+}
+
+int fsyncNoInt(int fd) {
+  return int(wrapNoInt(fsync, fd));
+}
+
+int dupNoInt(int fd) {
+  return int(wrapNoInt(dup, fd));
+}
+
+int dup2NoInt(int oldfd, int newfd) {
+  return int(wrapNoInt(dup2, oldfd, newfd));
+}
+
+int fdatasyncNoInt(int fd) {
+#if defined(__APPLE__)
+  return int(wrapNoInt(fcntl, fd, F_FULLFSYNC));
+#elif defined(__FreeBSD__) || defined(_MSC_VER)
+  return int(wrapNoInt(fsync, fd));
+#else
+  return int(wrapNoInt(fdatasync, fd));
+#endif
+}
+
+int ftruncateNoInt(int fd, off_t len) {
+  return int(wrapNoInt(ftruncate, fd, len));
+}
+
+int truncateNoInt(const char* path, off_t len) {
+  return int(wrapNoInt(truncate, path, len));
+}
+
+int flockNoInt(int fd, int operation) {
+  return int(wrapNoInt(flock, fd, operation));
+}
+
+int shutdownNoInt(NetworkSocket fd, int how) {
+  return int(wrapNoInt(netops::shutdown, fd, how));
+}
+
+ssize_t readNoInt(int fd, void* buf, size_t count) {
+  return wrapNoInt(read, fd, buf, count);
+}
+
+ssize_t preadNoInt(int fd, void* buf, size_t count, off_t offset) {
+  return wrapNoInt(pread, fd, buf, count, offset);
+}
+
+ssize_t readvNoInt(int fd, const iovec* iov, int count) {
+  return wrapNoInt(readv, fd, iov, count);
+}
+
+ssize_t preadvNoInt(int fd, const iovec* iov, int count, off_t offset) {
+  return wrapNoInt(preadv, fd, iov, count, offset);
+}
+
+ssize_t writeNoInt(int fd, const void* buf, size_t count) {
+  return wrapNoInt(write, fd, buf, count);
+}
+
+ssize_t pwriteNoInt(int fd, const void* buf, size_t count, off_t offset) {
+  return wrapNoInt(pwrite, fd, buf, count, offset);
+}
+
+ssize_t writevNoInt(int fd, const iovec* iov, int count) {
+  return wrapNoInt(writev, fd, iov, count);
+}
+
+ssize_t pwritevNoInt(int fd, const iovec* iov, int count, off_t offset) {
+  return wrapNoInt(pwritev, fd, iov, count, offset);
+}
+
+ssize_t readFull(int fd, void* buf, size_t count) {
+  return wrapFull(read, fd, buf, count);
+}
+
+ssize_t preadFull(int fd, void* buf, size_t count, off_t offset) {
+  return wrapFull(pread, fd, buf, count, offset);
+}
+
+ssize_t writeFull(int fd, const void* buf, size_t count) {
+  return wrapFull(write, fd, const_cast<void*>(buf), count);
+}
+
+ssize_t pwriteFull(int fd, const void* buf, size_t count, off_t offset) {
+  return wrapFull(pwrite, fd, const_cast<void*>(buf), count, offset);
+}
+
+ssize_t readvFull(int fd, iovec* iov, int count) {
+  return wrapvFull(readv, fd, iov, count);
+}
+
+ssize_t preadvFull(int fd, iovec* iov, int count, off_t offset) {
+  return wrapvFull(preadv, fd, iov, count, offset);
+}
+
+ssize_t writevFull(int fd, iovec* iov, int count) {
+  return wrapvFull(writev, fd, iov, count);
+}
+
+ssize_t pwritevFull(int fd, iovec* iov, int count, off_t offset) {
+  return wrapvFull(pwritev, fd, iov, count, offset);
+}
+
+int writeFileAtomicNoThrow(
+    StringPiece filename,
+    iovec* iov,
+    int count,
+    mode_t permissions,
+    SyncType syncType) {
+  // We write the data to a temporary file name first, then atomically rename
+  // it into place.  This ensures that the file contents will always be valid,
+  // even if we crash or are killed partway through writing out data.
+  //
+  // Create a buffer that will contain two things:
+  // - A nul-terminated version of the filename
+  // - The temporary file name
+  std::vector<char> pathBuffer;
+  // Note that we have to explicitly pass in the size here to make
+  // sure the nul byte gets included in the data.
+  constexpr folly::StringPiece suffix(".XXXXXX\0", 8);
+  pathBuffer.resize((2 * filename.size()) + 1 + suffix.size());
+  // Copy in the filename and then a nul terminator
+  memcpy(pathBuffer.data(), filename.data(), filename.size());
+  pathBuffer[filename.size()] = '\0';
+  const char* const filenameCStr = pathBuffer.data();
+  // Now prepare the temporary path template
+  char* const tempPath = pathBuffer.data() + filename.size() + 1;
+  memcpy(tempPath, filename.data(), filename.size());
+  memcpy(tempPath + filename.size(), suffix.data(), suffix.size());
+
+  auto tmpFD = mkstemp(tempPath);
+  if (tmpFD == -1) {
+    return errno;
+  }
+  bool success = false;
+  SCOPE_EXIT {
+    if (tmpFD != -1) {
+      close(tmpFD);
+    }
+    if (!success) {
+      unlink(tempPath);
+    }
+  };
+
+  auto rc = writevFull(tmpFD, iov, count);
+  if (rc == -1) {
+    return errno;
+  }
+
+  rc = fchmod(tmpFD, permissions);
+  if (rc == -1) {
+    return errno;
+  }
+
+  // To guarantee atomicity across power failues on POSIX file systems,
+  // the temporary file must be explicitly sync'ed before the rename.
+  if (syncType == SyncType::WITH_SYNC) {
+    rc = fsyncNoInt(tmpFD);
+    if (rc == -1) {
+      return errno;
+    }
+  }
+
+  // Close the file before renaming to make sure all data has
+  // been successfully written.
+  rc = close(tmpFD);
+  tmpFD = -1;
+  if (rc == -1) {
+    return errno;
+  }
+
+  rc = rename(tempPath, filenameCStr);
+  if (rc == -1) {
+    return errno;
+  }
+  success = true;
+  return 0;
+}
+
+void writeFileAtomic(
+    StringPiece filename,
+    iovec* iov,
+    int count,
+    mode_t permissions,
+    SyncType syncType) {
+  auto rc = writeFileAtomicNoThrow(filename, iov, count, permissions, syncType);
+  if (rc != 0) {
+    auto msg = std::string(__func__) + "() failed to update " + filename.str();
+    throw std::system_error(rc, std::generic_category(), msg);
+  }
+}
+
+void writeFileAtomic(
+    StringPiece filename,
+    ByteRange data,
+    mode_t permissions,
+    SyncType syncType) {
+  iovec iov;
+  iov.iov_base = const_cast<unsigned char*>(data.data());
+  iov.iov_len = data.size();
+  writeFileAtomic(filename, &iov, 1, permissions, syncType);
+}
+
+void writeFileAtomic(
+    StringPiece filename,
+    StringPiece data,
+    mode_t permissions,
+    SyncType syncType) {
+  writeFileAtomic(filename, ByteRange(data), permissions, syncType);
+}
+
+} // namespace folly


### PR DESCRIPTION
## Summary

Folly became once again incompatible with the Android NDK, which caused our CI to fail to produce sample APK builds on release. I managed to repro this on my machine and it's working again now.

Sadly, I had to patch another file manually because something about the template parameter inference wasn't working ...

## Test Plan

```
./gradlew :sample:assembleDebug
```

