### PR TITLE
Fix artifact path in android-sample.yml

### DIFF
--- a/.github/workflows/android-sample.yml
+++ b/.github/workflows/android-sample.yml
@@ -19,4 +19,4 @@ jobs:
       uses: actions/upload-artifact@v1
       with:
         name: sample-app.apk
-        path: dist/Flipper-mac.zip
+        path: android/sample/build/outputs/apk/debug/sample-debug.apk


### PR DESCRIPTION
This workflow is currently building the android app and then trying to upload the mac app (which isn't built) which is failing.

I think it should be uploading the android app instead.
