### PR TITLE
Build and upload dmg on release

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,4 +1,4 @@
-name: Publish Sample App
+name: Publish Android Sample App On Release
 
 on:
   release:

--- a/.github/workflows/dmg-release.yml
+++ b/.github/workflows/dmg-release.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         node-version: '12.x'
     - name: Build
-      run: yarn build --mac-dmg
+      run: yarn build --mac --mac-dmg
     - name: Upload
       uses: skx/github-action-publish-binaries@master
       env:

--- a/.github/workflows/dmg-release.yml
+++ b/.github/workflows/dmg-release.yml
@@ -1,0 +1,24 @@
+name: Publish DMG App On Release
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '12.x'
+    - name: Build
+      run: yarn build --mac-dmg
+    - name: Upload
+      uses: skx/github-action-publish-binaries@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        args: 'dist/Flipper-mac.dmg'


### PR DESCRIPTION
Had to remove this from the internal build process as this is now running on Linux where the tool for bundling `dmg`s sadly doesn't exist.
