### PR TITLE
Build mac dmg in Action

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -29,7 +29,7 @@ jobs:
       run: yarn build --linux
     - name: build macos
       if: matrix.os == 'macos-latest'
-      run: yarn build --mac
+      run: yarn build --mac --mac-dmg
     - name: build windows
       if: matrix.os == 'windows-latest'
       run: yarn build --win


### PR DESCRIPTION
Summary:
`build --mac` no longer implies building the DMG so the upload step currently fails.

Test Plan:
Green check mark.