### PR TITLE
Remove "Expected Behavior" section from template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -17,11 +17,6 @@ labels: 'Type: Bug Report'
   Steps to reproduce the behavior.
 -->
 
-## Expected Behavior
-<!--
-  A clear and concise description of what you expected to happen.
--->
-
 ## Environment
 <!--
   Tell us about your Android/iOS Version, Flipper Desktop version,


### PR DESCRIPTION
This seems to only encourage snark. I've yet to see this being used productively.
