### PR TITLE
Make iOS 9 compatible again.

### DIFF
--- a/FlipperKit.podspec
+++ b/FlipperKit.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |spec|
   spec.source = { :git => 'https://github.com/facebook/Sonar.git',
                   :tag=> "v"+flipperkit_version }
   spec.module_name = 'FlipperKit'
-  spec.platforms = { :ios => "10.0" }
+  spec.platforms = { :ios => "9.0" }
   spec.default_subspecs = "Core"
 
   # This subspec is necessary since FBDefines.h is imported as <FBDefines/FBDefines.h>

--- a/iOS/Plugins/FlipperKitLayoutPlugin/FlipperKitLayoutPlugin/descriptors/SKViewDescriptor.mm
+++ b/iOS/Plugins/FlipperKitLayoutPlugin/FlipperKitLayoutPlugin/descriptors/SKViewDescriptor.mm
@@ -222,14 +222,12 @@ static NSDictionary* YGUnitEnumMap = nil;
           nil];
 }
 
-- (NSDictionary<NSString*, SKNodeUpdateData>*)dataMutationsForNode:
-    (UIView*)node {
-  return @{
+- (NSDictionary<NSString*, SKNodeUpdateData>*)dataMutationsForNode:(UIView*)node {
+  NSDictionary<NSString*, SKNodeUpdateData> *dataMutations = @{
     // UIView
     @"UIView.alpha" : ^(NSNumber* value){
         node.alpha = [value floatValue];
-}
-,
+    },
     @"UIView.backgroundColor": ^(NSNumber *value) {
       node.backgroundColor = [UIColor fromSonarValue: value];
     },
@@ -452,17 +450,21 @@ static NSDictionary* YGUnitEnumMap = nil;
     @"Accessibility.accessibilityTraits.UIAccessibilityTraitCausesPageTurn": ^(NSNumber *value) {
       node.accessibilityTraits = AccessibilityTraitsToggle(node.accessibilityTraits, UIAccessibilityTraitCausesPageTurn, [value boolValue]);
     },
-    @"Accessibility.accessibilityTraits.UIAccessibilityTraitTabBar": ^(NSNumber *value) {
-      node.accessibilityTraits = AccessibilityTraitsToggle(node.accessibilityTraits, UIAccessibilityTraitTabBar, [value boolValue]);
-    },
     @"Accessibility.accessibilityViewIsModal": ^(NSNumber *value) {
       node.accessibilityViewIsModal = [value boolValue];
     },
     @"Accessibility.shouldGroupAccessibilityChildren": ^(NSNumber *value) {
       node.shouldGroupAccessibilityChildren = [value boolValue];
     },
-}
-;
+  };
+  if (@available(iOS 10.0, *)) {
+    NSMutableDictionary<NSString*, SKNodeUpdateData> *latestDataMutations = [dataMutations mutableCopy];
+    latestDataMutations[@"Accessibility.accessibilityTraits.UIAccessibilityTraitTabBar"] = ^(NSNumber *value) {
+      node.accessibilityTraits = AccessibilityTraitsToggle(node.accessibilityTraits, UIAccessibilityTraitTabBar, [value boolValue]);
+    };
+    dataMutations = latestDataMutations;
+  }
+  return dataMutations;
 }
 
 - (NSArray<SKNamed<NSString*>*>*)attributesForNode:(UIView*)node {

--- a/iOS/Sample/Podfile
+++ b/iOS/Sample/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/facebook/Sonar.git'
 source 'https://github.com/CocoaPods/Specs'
 
 target 'Sample' do
-  platform :ios, '10.0'
+  platform :ios, '9.0'
   pod 'FlipperKit', :path => '../../FlipperKit.podspec'
   pod 'FlipperKit/FlipperKitLayoutComponentKitSupport', :path => '../../FlipperKit.podspec'
   pod 'FlipperKit/SKIOSNetworkPlugin', :path => '../../FlipperKit.podspec'


### PR DESCRIPTION
## Summary

React Native v0.62.0’s template still uses iOS 9 as deployment target, bumping it to 10 this late in the release cycle is probably not a good idea, so instead I made this tiny change to make it iOS 9 compatible again.

⚠️  I made this change on top of the `v0.32.2` **tag**, as `master` was giving me a build failure and in any case it would be better to release _just_ this change as a patch release so the RN `v0.62.0-rc.3` release can go out without having to test Flipper as thoroughly again.

## Changelog

Make FlipperKit compatible with iOS 9 again.

## Test Plan

- `pod install` with a Podfile that has iOS 9 as its deployment target passes again.
- Building the Flipper Sample works.
- Building with a RN application created with the `v0.62.0-rc.3` template works.