### PR TITLE
Imported <DescriptorMapping> and <InspectorFlipperPlugin>

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -74,6 +74,9 @@ initializing SoLoader (for loading the C++ part of Flipper) and starting a `Flip
 import com.facebook.flipper.android.AndroidFlipperClient;
 import com.facebook.flipper.android.utils.FlipperUtils;
 import com.facebook.flipper.core.FlipperClient;
+import com.facebook.flipper.plugins.inspector.DescriptorMapping;
+import com.facebook.flipper.plugins.inspector.InspectorFlipperPlugin;
+
 
 public class MyApplication extends Application {
 


### PR DESCRIPTION
Fixed cannot find symbols: `DescriptorMapping` and `InspectorFlipperPlugin`
