### PR TITLE
Remove easywsclient reference

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -7,7 +7,6 @@
 
 include ':android'
 include ':folly'
-include ':easywsclient'
 include ':sonarcpp'
 include ':sample'
 include ':tutorial'
@@ -18,7 +17,6 @@ include ':rsocket'
 include ':third-party'
 include ':noop'
 
-project(':easywsclient').projectDir = file('libs/easywsclient')
 project(':sonarcpp').projectDir = file('xplat')
 project(':sample').projectDir = file('android/sample')
 project(':tutorial').projectDir = file('android/tutorial')


### PR DESCRIPTION
Summary:
This got removed a while ago but will cause new checkouts to fail
syncing.

Test Plan:
grep & CI
