### PR TITLE
Add support for AndroidX fragments

### DIFF
--- a/android/src/main/java/com/facebook/flipper/plugins/inspector/descriptors/ActivityDescriptor.java
+++ b/android/src/main/java/com/facebook/flipper/plugins/inspector/descriptors/ActivityDescriptor.java
@@ -8,6 +8,7 @@
 package com.facebook.flipper.plugins.inspector.descriptors;
 
 import android.app.Activity;
+import android.util.Log;
 import android.view.Window;
 import com.facebook.flipper.core.FlipperDynamic;
 import com.facebook.flipper.core.FlipperObject;
@@ -24,6 +25,8 @@ import java.util.List;
 import javax.annotation.Nullable;
 
 public class ActivityDescriptor extends NodeDescriptor<Activity> {
+
+  private static final String TAG = "ActivityDescriptor";
 
   @Override
   public void init(Activity node) {}
@@ -112,9 +115,14 @@ public class ActivityDescriptor extends NodeDescriptor<Activity> {
     }
 
     FragmentManagerAccessor fragmentManagerAccessor = compat.forFragmentManager();
-    List<Object> addedFragments = fragmentManagerAccessor.getAddedFragments(fragmentManager);
+    List<Object> addedFragments = null;
+    try {
+      addedFragments = fragmentManagerAccessor.getAddedFragments(fragmentManager);
+    } catch (Exception e) {
+      Log.e(TAG, "Failed to obtain list of fragments.", e);
+    }
     if (addedFragments == null) {
-      return Collections.EMPTY_LIST;
+      return Collections.emptyList();
     }
 
     final List<Object> dialogFragments = new ArrayList<>();

--- a/android/src/main/java/com/facebook/flipper/plugins/inspector/descriptors/utils/stethocopies/FragmentCompatUtil.java
+++ b/android/src/main/java/com/facebook/flipper/plugins/inspector/descriptors/utils/stethocopies/FragmentCompatUtil.java
@@ -8,11 +8,16 @@
 package com.facebook.flipper.plugins.inspector.descriptors.utils.stethocopies;
 
 import android.app.Activity;
+import android.util.Log;
 import android.view.View;
+
+import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nullable;
 
 public final class FragmentCompatUtil {
+  private static final String TAG = "FragmentCompatUtil";
+
   private FragmentCompatUtil() {}
 
   public static boolean isDialogFragment(Object fragment) {
@@ -79,7 +84,13 @@ public final class FragmentCompatUtil {
   @Nullable
   private static Object findFragmentForViewInFragmentManager(
       FragmentCompat compat, Object fragmentManager, View view) {
-    List<?> fragments = compat.forFragmentManager().getAddedFragments(fragmentManager);
+    List<?> fragments;
+    try {
+      fragments = compat.forFragmentManager().getAddedFragments(fragmentManager);
+    } catch (Exception e) {
+      fragments = Collections.emptyList();
+      Log.e(TAG, "Failed to obtain list of fragments.", e);
+    }
 
     if (fragments != null) {
       for (int i = 0, N = fragments.size(); i < N; ++i) {


### PR DESCRIPTION
Summary:
Fix https://github.com/facebook/flipper/issues/931

This is not how I would *like* to fix this, but it should do the job.
When the switch over to AndroidX was made, the overall abstraction
started to leak and we really need to remodel this in its entirety.
There's also the question of whether we want to support both support
fragments and AndroidX fragments or not. Right now it's kinda-sorta
supported but only under some circumstances, which is not great.

I also added some more defensive try/catches as there's some unsafe casting
involved and future changes may break this causing the entire layout to disappear.

Test Plan:
Changed the sample app to include some AndroidX fragments and they
now show up (again) in the view hierarchy:

![Screenshot 2020-04-01 13 40 53](https://user-images.githubusercontent.com/9906/78138910-915fbc00-741f-11ea-8386-4eeca9b7f932.png)


Change Log:
Fix support for AndroidX fragments in Layout Inspector.

