### PR TITLE
Bump Travis Node to 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
     - language: node_js
       os: linux
       node_js:
-        - "11"
+        - "12"
 
       install:
         - cd website
@@ -30,13 +30,13 @@ matrix:
     - language: node_js
       os: linux
       node_js:
-        - "11"
+        - "12"
 
       install:
         - cd desktop
         - yarn
 
-      script:        
+      script:
         - yarn lint
         - yarn test
         - yarn build --linux --version=$TRAVIS_BUILD_NUMBER


### PR DESCRIPTION
Summary:
Looks like jsdom for jest wants either 10 or 12, but not 11. ¯\_(ツ)_/¯

Test Plan:
Watch Travis signal.
