### PR TITLE
fix links redirects to "Getting started guide"

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This repository includes all parts of Flipper. This includes:
 
 # Getting started
 
-Please refer to our [Getting Started guide](https://fbflipper.com/docs/getting-started.html) to set up Flipper.
+Please refer to our [Getting Started guide](https://fbflipper.com/docs/getting-started/index.html) to set up Flipper.
 
 ## Requirements
 

--- a/desktop/app/src/MenuBar.tsx
+++ b/desktop/app/src/MenuBar.tsx
@@ -361,7 +361,7 @@ function getTemplate(
           label: 'Getting started',
           click: function () {
             shell.openExternal(
-              'https://fbflipper.com/docs/getting-started.html',
+              'https://fbflipper.com/docs/getting-started/index.html',
             );
           },
         },

--- a/desktop/app/src/chrome/WelcomeScreen.tsx
+++ b/desktop/app/src/chrome/WelcomeScreen.tsx
@@ -167,7 +167,7 @@ export default class WelcomeScreen extends PureComponent<Props, State> {
             onClick={() =>
               shell &&
               shell.openExternal(
-                'https://fbflipper.com/docs/getting-started.html',
+                'https://fbflipper.com/docs/getting-started/index.html',
               )
             }>
             <Icon size={20} name="tools" color={brandColors.Flipper} />


### PR DESCRIPTION
## Summary

Getting Started Guide links are broken on 3 files.

## Changelog

Links changed to https://fbflipper.com/docs/getting-started/index.html

it was before  https://fbflipper.com/docs/getting-started.html

## Test Plan


