### PR TITLE
Fix IOS crash in Network Plugin due to incorrect processing of data U…

### DIFF
--- a/iOS/Plugins/FlipperKitNetworkPlugin/FlipperKitNetworkPlugin/FlipperKitNetworkPlugin.mm
+++ b/iOS/Plugins/FlipperKitNetworkPlugin/FlipperKitNetworkPlugin/FlipperKitNetworkPlugin.mm
@@ -78,6 +78,11 @@
 }
 
 - (void)didObserveResponse:(SKResponseInfo*)response {
+  // Only track HTTP(S) calls, data URLs cannot be casted to NSHTTPURLResponse
+  if (![response.response isKindOfClass:[NSHTTPURLResponse class]]) {
+    return;
+  }
+
   NSHTTPURLResponse* httpResponse = (NSHTTPURLResponse*)response.response;
 
   NSMutableArray<NSDictionary<NSString*, id>*>* headers = [NSMutableArray new];

--- a/iOS/Plugins/FlipperKitNetworkPlugin/FlipperKitNetworkPlugin/SKResponseInfo.m
+++ b/iOS/Plugins/FlipperKitNetworkPlugin/FlipperKitNetworkPlugin/SKResponseInfo.m
@@ -29,6 +29,11 @@
 }
 
 + (BOOL)shouldStripReponseBodyWithResponse:(NSURLResponse*)response {
+  // Only HTTP(S) responses have Content-Type headers
+  if (![response isKindOfClass:[NSHTTPURLResponse class]]) {
+    return NO;
+  }
+
   NSHTTPURLResponse* httpResponse = (NSHTTPURLResponse*)response;
   NSString* contentType = httpResponse.allHeaderFields[@"content-type"];
   if (!contentType) {

--- a/iOS/Plugins/FlipperKitNetworkPlugin/FlipperKitNetworkPlugin/SKResponseInfo.m
+++ b/iOS/Plugins/FlipperKitNetworkPlugin/FlipperKitNetworkPlugin/SKResponseInfo.m
@@ -31,7 +31,7 @@
 + (BOOL)shouldStripReponseBodyWithResponse:(NSURLResponse*)response {
   // Only HTTP(S) responses have Content-Type headers
   if (![response isKindOfClass:[NSHTTPURLResponse class]]) {
-    return NO;
+    return YES;
   }
 
   NSHTTPURLResponse* httpResponse = (NSHTTPURLResponse*)response;


### PR DESCRIPTION
Fix IOS crash in Network Plugin due to incorrect processing of data URLs (#974)

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
Fix #974 by skipping response processing in FlipperKitNetworkPlugin.mm if the response is not an instance of NSHTTPURLResponse, which data URLs are not. My assumption is that data URLs are not the ones Flipper Network Plugin users are interested in, given the type of information being extracted in the didObserveResponse method which are only present in NSHTTPURLReponse types.

## Changelog
Fix IOS crash in Network Plugin due to unchecked casting of data URLs
<!-- Help reviewers and the release process by writing your own changelog entry. This should just be a brief oneline we can mention in our release notes: https://github.com/facebook/flipper/releases -->

## Test plan
1. `npx react-native init issue974 --version react-native@0.62.1`
2. `cd issue974/ios/Pods/FlipperKit/iOS/Plugins/`
3. `curl -L https://patch-diff.githubusercontent.com/raw/facebook/flipper/pull/978.patch | git apply -v -p3`
4.  `cd ../../../../../`
5. `curl -L https://github.com/facebook/flipper/files/4434063/rn-data-uri-test.patch.txt | git apply -v
react-native run-ios`
6. Verify that the app does not crash the IOS app with 
```
Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: 
'-[NSURLResponse allHeaderFields]: unrecognized selector sent to instance <memaddr>'
```

#### The React Native app patch used to verify the PR working and resolving the issue #974
[rn-data-uri-test.patch.txt](https://github.com/facebook/flipper/files/4434063/rn-data-uri-test.patch.txt)