### PR TITLE
Do not run tests for "doctor" and "pkg" separately

### DIFF
--- a/.github/workflows/nodejs-doctor.yml
+++ b/.github/workflows/nodejs-doctor.yml
@@ -18,9 +18,6 @@ jobs:
     - name: install
       working-directory: ${{env.doctor-directory}}
       run: yarn
-    - name: test
-      working-directory: ${{env.doctor-directory}}
-      run: yarn test
     - name: run
       working-directory: ${{env.doctor-directory}}
       run: yarn run run

--- a/.github/workflows/nodejs-pkg.yml
+++ b/.github/workflows/nodejs-pkg.yml
@@ -18,9 +18,6 @@ jobs:
     - name: install
       working-directory: ${{env.pkg-directory}}
       run: yarn
-    - name: test
-      working-directory: ${{env.pkg-directory}}
-      run: yarn test
     - name: run
       working-directory: ${{env.pkg-directory}}
       run: bin/run


### PR DESCRIPTION
Summary: Tests for all the packages are already being run by the "yarn test" in the root package. So disabling running them separately.

Differential Revision: D20868138

