### PR TITLE
Update setup doc for react native swift

### DIFF
--- a/docs/getting-started/react-native-ios.md
+++ b/docs/getting-started/react-native-ios.md
@@ -58,6 +58,12 @@ def flipper_post_install(installer)
   app_project = Xcodeproj::Project.open(file_name)
   app_project.native_targets.each do |target|
     target.build_configurations.each do |config|
+      cflags = config.build_settings['OTHER_CFLAGS'] || '$(inherited) '
+      unless cflags.include? '-DFB_SONARKIT_ENABLED=1'
+        puts 'Adding -DFB_SONARKIT_ENABLED=1 in OTHER_CFLAGS...'
+        cflags << '-DFB_SONARKIT_ENABLED=1'
+      end
+      config.build_settings['OTHER_CFLAGS'] = cflags
       if (config.build_settings['OTHER_SWIFT_FLAGS'])
         unless config.build_settings['OTHER_SWIFT_FLAGS'].include? '-DFB_SONARKIT_ENABLED'
           puts 'Adding -DFB_SONARKIT_ENABLED ...'

--- a/docs/getting-started/react-native-ios.md
+++ b/docs/getting-started/react-native-ios.md
@@ -90,7 +90,7 @@ target 'your-app-name' do
   # For enabling Flipper.
   # Note that if you use_framework!, flipper will not work.
   # Disable these lines if you are doing use_framework!
-  flipper_pods()
+  add_flipper_pods()
   post_install do |installer|
     flipper_post_install(installer)
   end


### PR DESCRIPTION
## Summary

If you are using swift in react native, the flipper doc has some issues:

1. Missing flags #341 which makes flipper totally ignored so that it can not connect
2. There are 2 wrong lines in `initializeFlipper` function. Need to comment them out to pass the build.

(Maybe) fixes https://github.com/facebook/flipper/issues/948

Also merge changes from https://github.com/facebook/react-native/commit/e5497ca8f6e3b240948fdbeef0ac2a710f25bb56

## Changelog

[doc] Update setup doc for react native swift

## Test Plan

Use flipper for react native without issues

