### PR TITLE
Add correct `Troubleshooting` page links

### DIFF
--- a/docs/getting-started/ios-native.md
+++ b/docs/getting-started/ios-native.md
@@ -234,7 +234,7 @@ Finally, you need to add plugins to your Flipper client. Above, we have only add
 
 ## Having trouble?
 
-See the [troubleshooting page](troubleshooting.html) for help with known problems.
+See the [troubleshooting page](../troubleshooting) for help with known problems.
 
 <div class="warning">
 

--- a/docs/getting-started/react-native-ios.md
+++ b/docs/getting-started/react-native-ios.md
@@ -170,7 +170,7 @@ Lastly, open the Flipper desktop app, and run `yarn ios` in your terminal.
 
 ## Troubleshooting
 
-If you can't build your app after adding Flipper, you may need to configure the Swift compiler. To do so, adding an empty Swift file in your project is the easiest way.
+See the [troubleshooting page](../troubleshooting) for help with known problems.
 
 ## Further Steps
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This PR fixes a broken `Troubleshooting` link in the iOS setup page as well as adds that link to the React Native iOS one.

## Changelog

Add correct `Troubleshooting` page links

## Test Plan

Check `docs/getting-started/native-ios` and `docs/getting-started/react-native-ios`.
