### PR TITLE
Remove the Yogakit change from post install

### DIFF
--- a/docs/getting-started/ios-native.md
+++ b/docs/getting-started/ios-native.md
@@ -48,13 +48,6 @@ target 'MyApp' do
 
   # This post_install hook adds the -DFB_SONARKIT_ENABLED=1 flag to OTHER_CFLAGS, necessary to expose Flipper classes in the header files
   post_install do |installer|
-    installer.pods_project.targets.each do |target|
-      if target.name == 'YogaKit'
-        target.build_configurations.each do |config|
-          config.build_settings['SWIFT_VERSION'] = '4.1'
-        end
-      end
-    end
     file_name = Dir.glob("*.xcodeproj")[0]
     app_project = Xcodeproj::Project.open(file_name)
     app_project.native_targets.each do |target|

--- a/docs/getting-started/react-native-ios.md
+++ b/docs/getting-started/react-native-ios.md
@@ -26,13 +26,6 @@ end
 
 # Post Install processing for Flipper
 def flipper_post_install(installer)
-  installer.pods_project.targets.each do |target|
-    if target.name == 'YogaKit'
-      target.build_configurations.each do |config|
-        config.build_settings['SWIFT_VERSION'] = '4.1'
-      end
-    end
-  end
   file_name = Dir.glob("*.xcodeproj")[0]
   app_project = Xcodeproj::Project.open(file_name)
   app_project.native_targets.each do |target|

--- a/iOS/Sample/Podfile
+++ b/iOS/Sample/Podfile
@@ -35,13 +35,6 @@ target 'Sample' do
 
   # It also adds -DFB_SONARKIT_ENABLED=1 flag to OTHER_CFLAGS, necessary to build expose Flipper classes in the header files
   post_install do |installer|
-    installer.pods_project.targets.each do |target|
-      if target.name == 'YogaKit'
-        target.build_configurations.each do |config|
-          config.build_settings['SWIFT_VERSION'] = '4.1'
-        end
-      end
-    end
     file_name = Dir.glob("*.xcodeproj")[0]
     app_project = Xcodeproj::Project.open(file_name)
     app_project.native_targets.each do |target|

--- a/iOS/SampleSwift/Podfile
+++ b/iOS/SampleSwift/Podfile
@@ -33,13 +33,6 @@ target 'SampleSwift' do
   # end
 
   post_install do |installer|
-    installer.pods_project.targets.each do |target|
-      if target.name == 'YogaKit'
-        target.build_configurations.each do |config|
-          config.build_settings['SWIFT_VERSION'] = '4.1'
-        end
-      end
-    end
     file_name = Dir.glob("*.xcodeproj")[0]
     app_project = Xcodeproj::Project.open(file_name)
     app_project.native_targets.each do |target|


### PR DESCRIPTION
Summary: YogaKit's version is compatible recent version of swift and also before the last release its swift version was not mentioned, which caused issues, but now there is no need to set the swift version.

Differential Revision: D21054723

