### PR TITLE
Add support for deleting  a shared preference

### DIFF
--- a/android/src/main/java/com/facebook/flipper/plugins/sharedpreferences/SharedPreferencesFlipperPlugin.java
+++ b/android/src/main/java/com/facebook/flipper/plugins/sharedpreferences/SharedPreferencesFlipperPlugin.java
@@ -13,8 +13,6 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Build;
 import android.preference.PreferenceManager;
-import android.util.Log;
-
 import com.facebook.flipper.core.FlipperConnection;
 import com.facebook.flipper.core.FlipperObject;
 import com.facebook.flipper.core.FlipperPlugin;
@@ -211,7 +209,7 @@ public class SharedPreferencesFlipperPlugin implements FlipperPlugin {
             SharedPreferences sharedPrefs = getSharedPreferencesFor(sharedPreferencesName);
             Object originalValue = sharedPrefs.getAll().get(preferenceName);
             SharedPreferences.Editor editor = sharedPrefs.edit();
-Log.e("AAA","AAA SET "+sharedPreferencesName+" "+preferenceName);
+
             if (originalValue instanceof Boolean) {
               editor.putBoolean(preferenceName, params.getBoolean("preferenceValue"));
             } else if (originalValue instanceof Long) {
@@ -242,8 +240,6 @@ Log.e("AAA","AAA SET "+sharedPreferencesName+" "+preferenceName);
                 String preferenceName = params.getString("preferenceName");
                 SharedPreferences sharedPrefs = getSharedPreferencesFor(sharedPreferencesName);
                 SharedPreferences.Editor editor = sharedPrefs.edit();
-                Log.e("AAA","AAA DELETE "+sharedPreferencesName+" "+preferenceName);
-
                 editor.remove(preferenceName);
                 editor.apply();
                 responder.success(getFlipperObjectFor(sharedPreferencesName));

--- a/android/src/main/java/com/facebook/flipper/plugins/sharedpreferences/SharedPreferencesFlipperPlugin.java
+++ b/android/src/main/java/com/facebook/flipper/plugins/sharedpreferences/SharedPreferencesFlipperPlugin.java
@@ -13,6 +13,8 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Build;
 import android.preference.PreferenceManager;
+import android.util.Log;
+
 import com.facebook.flipper.core.FlipperConnection;
 import com.facebook.flipper.core.FlipperObject;
 import com.facebook.flipper.core.FlipperPlugin;
@@ -209,7 +211,7 @@ public class SharedPreferencesFlipperPlugin implements FlipperPlugin {
             SharedPreferences sharedPrefs = getSharedPreferencesFor(sharedPreferencesName);
             Object originalValue = sharedPrefs.getAll().get(preferenceName);
             SharedPreferences.Editor editor = sharedPrefs.edit();
-
+Log.e("AAA","AAA SET "+sharedPreferencesName+" "+preferenceName);
             if (originalValue instanceof Boolean) {
               editor.putBoolean(preferenceName, params.getBoolean("preferenceValue"));
             } else if (originalValue instanceof Long) {
@@ -229,6 +231,24 @@ public class SharedPreferencesFlipperPlugin implements FlipperPlugin {
             responder.success(getFlipperObjectFor(sharedPreferencesName));
           }
         });
+
+        connection.receive(
+            "deleteSharedPreference",
+            new FlipperReceiver() {
+              @Override
+              public void onReceive(FlipperObject params, FlipperResponder responder)
+                      throws IllegalArgumentException {
+                String sharedPreferencesName = params.getString("sharedPreferencesName");
+                String preferenceName = params.getString("preferenceName");
+                SharedPreferences sharedPrefs = getSharedPreferencesFor(sharedPreferencesName);
+                SharedPreferences.Editor editor = sharedPrefs.edit();
+                Log.e("AAA","AAA DELETE "+sharedPreferencesName+" "+preferenceName);
+
+                editor.remove(preferenceName);
+                editor.apply();
+                responder.success(getFlipperObjectFor(sharedPreferencesName));
+              }
+            });
   }
 
   @Override

--- a/desktop/app/src/ui/components/data-inspector/DataInspector.tsx
+++ b/desktop/app/src/ui/components/data-inspector/DataInspector.tsx
@@ -8,24 +8,24 @@
  */
 
 import DataDescription from './DataDescription';
-import { MenuTemplate } from '../ContextMenu';
-import { Component } from 'react';
+import {MenuTemplate} from '../ContextMenu';
+import {Component} from 'react';
 import ContextMenu from '../ContextMenu';
 import Tooltip from '../Tooltip';
 import styled from '@emotion/styled';
 import createPaste from '../../../fb-stubs/createPaste';
-import { reportInteraction } from '../../../utils/InteractionTracker';
-import DataPreview, { DataValueExtractor, InspectorName } from './DataPreview';
-import { getSortedKeys } from './utils';
-import { colors } from '../colors';
-import { clipboard } from 'electron';
+import {reportInteraction} from '../../../utils/InteractionTracker';
+import DataPreview, {DataValueExtractor, InspectorName} from './DataPreview';
+import {getSortedKeys} from './utils';
+import {colors} from '../colors';
+import {clipboard} from 'electron';
 import deepEqual from 'deep-equal';
 import React from 'react';
-import { TooltipOptions } from '../TooltipProvider';
+import {TooltipOptions} from '../TooltipProvider';
 
-export { DataValueExtractor } from './DataPreview';
+export {DataValueExtractor} from './DataPreview';
 
-const BaseContainer = styled.div<{ depth?: number; disabled?: boolean }>(
+const BaseContainer = styled.div<{depth?: number; disabled?: boolean}>(
   (props) => ({
     fontFamily: 'Menlo, monospace',
     fontSize: 11,
@@ -150,35 +150,35 @@ const defaultValueExtractor: DataValueExtractor = (value: any) => {
   const type = typeof value;
 
   if (type === 'number') {
-    return { mutable: true, type: 'number', value };
+    return {mutable: true, type: 'number', value};
   }
 
   if (type === 'string') {
-    return { mutable: true, type: 'string', value };
+    return {mutable: true, type: 'string', value};
   }
 
   if (type === 'boolean') {
-    return { mutable: true, type: 'boolean', value };
+    return {mutable: true, type: 'boolean', value};
   }
 
   if (type === 'undefined') {
-    return { mutable: true, type: 'undefined', value };
+    return {mutable: true, type: 'undefined', value};
   }
 
   if (value === null) {
-    return { mutable: true, type: 'null', value };
+    return {mutable: true, type: 'null', value};
   }
 
   if (Array.isArray(value)) {
-    return { mutable: true, type: 'array', value };
+    return {mutable: true, type: 'array', value};
   }
 
   if (Object.prototype.toString.call(value) === '[object Date]') {
-    return { mutable: true, type: 'date', value };
+    return {mutable: true, type: 'date', value};
   }
 
   if (type === 'object') {
-    return { mutable: true, type: 'object', value };
+    return {mutable: true, type: 'object', value};
   }
 };
 
@@ -237,20 +237,20 @@ const diffMetadataExtractor: DiffMetadataExtractor = (
   diff?: any,
 ) => {
   if (diff == null) {
-    return [{ data: data[key] }];
+    return [{data: data[key]}];
   }
 
   const val = data[key];
   const diffVal = diff[key];
   if (!data.hasOwnProperty(key)) {
-    return [{ data: diffVal, status: 'removed' }];
+    return [{data: diffVal, status: 'removed'}];
   }
   if (!diff.hasOwnProperty(key)) {
-    return [{ data: val, status: 'added' }];
+    return [{data: val, status: 'added'}];
   }
 
   if (isPureObject(diffVal) && isPureObject(val)) {
-    return [{ data: val, diff: diffVal }];
+    return [{data: val, diff: diffVal}];
   }
 
   if (diffVal !== val) {
@@ -258,12 +258,12 @@ const diffMetadataExtractor: DiffMetadataExtractor = (
     // the value from the diff prop
     // The property name still exists, but the values may be different.
     return [
-      { data: val, status: 'added' },
-      { data: diffVal, status: 'removed' },
+      {data: val, status: 'added'},
+      {data: diffVal, status: 'removed'},
     ];
   }
 
-  return Object.prototype.hasOwnProperty.call(data, key) ? [{ data: val }] : [];
+  return Object.prototype.hasOwnProperty.call(data, key) ? [{data: val}] : [];
 };
 
 function isComponentExpanded(
@@ -311,11 +311,11 @@ export default class DataInspector extends Component<DataInspectorProps> {
     path: Array<string>;
     ancestry: Array<Object>;
   } = {
-      expanded: {},
-      depth: 0,
-      path: [],
-      ancestry: [],
-    };
+    expanded: {},
+    depth: 0,
+    path: [],
+    ancestry: [],
+  };
 
   interaction: (name: string, data?: any) => void;
 
@@ -331,7 +331,7 @@ export default class DataInspector extends Component<DataInspectorProps> {
   }
 
   shouldComponentUpdate(nextProps: DataInspectorProps) {
-    const { props } = this;
+    const {props} = this;
 
     // check if any expanded paths effect this subtree
     if (nextProps.expanded !== props.expanded) {
@@ -363,7 +363,7 @@ export default class DataInspector extends Component<DataInspectorProps> {
   }
 
   isExpanded(pathParts: Array<string>) {
-    const { expanded } = this.props;
+    const {expanded} = this.props;
 
     // if we no expanded object then expand everything
     if (expanded == null) {
@@ -387,7 +387,7 @@ export default class DataInspector extends Component<DataInspectorProps> {
   }
 
   setExpanded(pathParts: Array<string>, isExpanded: boolean) {
-    const { expanded, onExpanded } = this.props;
+    const {expanded, onExpanded} = this.props;
     if (!onExpanded || !expanded) {
       return;
     }
@@ -418,7 +418,7 @@ export default class DataInspector extends Component<DataInspectorProps> {
   extractValue = (data: any, depth: number) => {
     let res;
 
-    const { extractValue } = this.props;
+    const {extractValue} = this.props;
     if (extractValue) {
       res = extractValue(data, depth);
     }
@@ -449,7 +449,7 @@ export default class DataInspector extends Component<DataInspectorProps> {
 
     // the data inspector makes values read only when setValue isn't set so we just need to set it
     // to null and the readOnly status will be propagated to all children
-    let { setValue } = this.props;
+    let {setValue} = this.props;
 
     const res = this.extractValue(data, depth);
     const resDiff = this.extractValue(diff, depth);
@@ -462,7 +462,7 @@ export default class DataInspector extends Component<DataInspectorProps> {
         setValue = null;
       }
 
-      ({ type, value, extra } = res);
+      ({type, value, extra} = res);
     } else {
       return null;
     }
@@ -476,11 +476,11 @@ export default class DataInspector extends Component<DataInspectorProps> {
       isExpandable &&
       (resDiff != null
         ? isComponentExpanded(
-          value,
-          resDiff.type,
-          resDiff.value,
-          expandRoot === true || this.isExpanded(path),
-        )
+            value,
+            resDiff.type,
+            resDiff.value,
+            expandRoot === true || this.isExpanded(path),
+          )
         : expandRoot === true || this.isExpanded(path));
 
     let expandGlyph = '';
@@ -505,7 +505,7 @@ export default class DataInspector extends Component<DataInspectorProps> {
 
       const diffValue = diff && resDiff ? resDiff.value : null;
 
-      const keys = getSortedKeys({ ...value, ...diffValue });
+      const keys = getSortedKeys({...value, ...diffValue});
 
       const Added = styled.div({
         backgroundColor: colors.tealTint70,
@@ -646,7 +646,7 @@ export default class DataInspector extends Component<DataInspectorProps> {
       },
     );
 
-    if (!isExpandable) {
+    if (!isExpandable && onDelete) {
       contextMenuItems.push(
         {
           label: 'Delete',

--- a/desktop/app/src/ui/components/data-inspector/DataInspector.tsx
+++ b/desktop/app/src/ui/components/data-inspector/DataInspector.tsx
@@ -647,12 +647,10 @@ export default class DataInspector extends Component<DataInspectorProps> {
     );
 
     if (!isExpandable && onDelete) {
-      contextMenuItems.push(
-        {
-          label: 'Delete',
-          click: () => { this.handleDelete(this.props.path) },
-        },
-      );
+      contextMenuItems.push({
+        label: 'Delete',
+        click: () => this.handleDelete(this.props.path),
+      });
     }
 
     return (

--- a/desktop/app/src/ui/components/data-inspector/ManagedDataInspector.tsx
+++ b/desktop/app/src/ui/components/data-inspector/ManagedDataInspector.tsx
@@ -7,11 +7,11 @@
  * @format
  */
 
-import {DataInspectorExpanded} from './DataInspector';
-import {PureComponent} from 'react';
+import { DataInspectorExpanded } from './DataInspector';
+import { PureComponent } from 'react';
 import DataInspector from './DataInspector';
 import React from 'react';
-import {DataValueExtractor} from './DataPreview';
+import { DataValueExtractor } from './DataPreview';
 
 type ManagedDataInspectorProps = {
   /**
@@ -37,6 +37,10 @@ type ManagedDataInspectorProps = {
    */
   setValue?: (path: Array<string>, val: any) => void;
   /**
+   * Callback when a delete action is invoked.
+   */
+  onDelete?: (path: Array<string>) => void;
+  /**
    * Whether all objects and arrays should be collapsed by default.
    */
   collapsed?: boolean;
@@ -59,7 +63,7 @@ type ManagedDataInspectorState = {
 export default class ManagedDataInspector extends PureComponent<
   ManagedDataInspectorProps,
   ManagedDataInspectorState
-> {
+  > {
   constructor(props: ManagedDataInspectorProps, context: Object) {
     super(props, context);
     this.state = {
@@ -68,7 +72,7 @@ export default class ManagedDataInspector extends PureComponent<
   }
 
   onExpanded = (expanded: DataInspectorExpanded) => {
-    this.setState({expanded});
+    this.setState({ expanded });
   };
 
   render() {
@@ -80,6 +84,7 @@ export default class ManagedDataInspector extends PureComponent<
         setValue={this.props.setValue}
         expanded={this.state.expanded}
         onExpanded={this.onExpanded}
+        onDelete={this.props.onDelete}
         expandRoot={this.props.expandRoot}
         collapsed={this.props.collapsed}
         tooltips={this.props.tooltips}

--- a/desktop/app/src/ui/components/data-inspector/ManagedDataInspector.tsx
+++ b/desktop/app/src/ui/components/data-inspector/ManagedDataInspector.tsx
@@ -7,11 +7,11 @@
  * @format
  */
 
-import { DataInspectorExpanded } from './DataInspector';
-import { PureComponent } from 'react';
+import {DataInspectorExpanded} from './DataInspector';
+import {PureComponent} from 'react';
 import DataInspector from './DataInspector';
 import React from 'react';
-import { DataValueExtractor } from './DataPreview';
+import {DataValueExtractor} from './DataPreview';
 
 type ManagedDataInspectorProps = {
   /**
@@ -63,7 +63,7 @@ type ManagedDataInspectorState = {
 export default class ManagedDataInspector extends PureComponent<
   ManagedDataInspectorProps,
   ManagedDataInspectorState
-  > {
+> {
   constructor(props: ManagedDataInspectorProps, context: Object) {
     super(props, context);
     this.state = {
@@ -72,7 +72,7 @@ export default class ManagedDataInspector extends PureComponent<
   }
 
   onExpanded = (expanded: DataInspectorExpanded) => {
-    this.setState({ expanded });
+    this.setState({expanded});
   };
 
   render() {

--- a/desktop/plugins/shared_preferences/index.js
+++ b/desktop/plugins/shared_preferences/index.js
@@ -213,14 +213,14 @@ export default class extends FlipperPlugin<SharedPreferencesState> {
     this.client
       .call('deleteSharedPreference', {
         sharedPreferencesName: this.state.selectedPreferences,
-        preferenceName: path[0]
+        preferenceName: path[0],
       })
       .then((results: SharedPreferences) => {
         const update = {
           name: this.state.selectedPreferences,
           preferences: results,
         };
-        this.dispatchAction({ update, type: 'UpdateSharedPreferences' });
+        this.dispatchAction({update, type: 'UpdateSharedPreferences'});
       });
   };
 

--- a/desktop/plugins/shared_preferences/index.js
+++ b/desktop/plugins/shared_preferences/index.js
@@ -18,16 +18,16 @@ import {
   styled,
   Select,
 } from 'flipper';
-import {FlipperPlugin} from 'flipper';
+import { FlipperPlugin } from 'flipper';
 
-import {clone} from 'lodash';
+import { clone } from 'lodash';
 
 type SharedPreferencesChangeEvent = {|
   preferences: string,
-  name: string,
-  time: number,
-  deleted: boolean,
-  value: string,
+    name: string,
+      time: number,
+        deleted: boolean,
+          value: string,
 |};
 
 export type SharedPreferences = {|
@@ -45,7 +45,7 @@ type SharedPreferencesMap = {
 
 type SharedPreferencesState = {|
   selectedPreferences: ?string,
-  sharedPreferences: SharedPreferencesMap,
+    sharedPreferences: SharedPreferencesMap,
 |};
 
 const CHANGELOG_COLUMNS = {
@@ -93,7 +93,7 @@ export default class extends FlipperPlugin<SharedPreferencesState> {
   reducers = {
     UpdateSharedPreferences(state: SharedPreferencesState, results: Object) {
       const update = results.update;
-      const entry = state.sharedPreferences[update.name] || {changesList: []};
+      const entry = state.sharedPreferences[update.name] || { changesList: [] };
       entry.preferences = update.preferences;
       state.sharedPreferences[update.name] = entry;
       return {
@@ -156,17 +156,17 @@ export default class extends FlipperPlugin<SharedPreferencesState> {
   init() {
     this.client
       .call('getAllSharedPreferences')
-      .then((results: {[name: string]: SharedPreferences}) => {
+      .then((results: { [name: string]: SharedPreferences }) => {
         Object.entries(results).forEach(([name, prefs]) => {
-          const update = {name: name, preferences: prefs};
-          this.dispatchAction({update, type: 'UpdateSharedPreferences'});
+          const update = { name: name, preferences: prefs };
+          this.dispatchAction({ update, type: 'UpdateSharedPreferences' });
         });
       });
 
     this.client.subscribe(
       'sharedPreferencesChange',
       (change: SharedPreferencesChangeEvent) => {
-        this.dispatchAction({change, type: 'ChangeSharedPreferences'});
+        this.dispatchAction({ change, type: 'ChangeSharedPreferences' });
       },
     );
   }
@@ -198,7 +198,7 @@ export default class extends FlipperPlugin<SharedPreferencesState> {
           name: this.state.selectedPreferences,
           preferences: results,
         };
-        this.dispatchAction({update, type: 'UpdateSharedPreferences'});
+        this.dispatchAction({ update, type: 'UpdateSharedPreferences' });
       });
   };
 
@@ -207,6 +207,25 @@ export default class extends FlipperPlugin<SharedPreferencesState> {
       selected: selected,
       type: 'UpdateSelectedSharedPreferences',
     });
+  };
+
+  onDel = (path: Array<string>) => {
+
+    this.client
+      .call('deleteSharedPreference', {
+        sharedPreferencesName: this.state.selectedPreferences,
+        preferenceName: path[0]
+      })
+      .then((results: SharedPreferences) => {
+        const update = {
+          name: this.state.selectedPreferences,
+          preferences: results,
+        };
+        this.dispatchAction({ update, type: 'UpdateSharedPreferences' });
+      });
+
+    //deleteSharedPreference
+    //alert(key)
   };
 
   render() {
@@ -223,7 +242,7 @@ export default class extends FlipperPlugin<SharedPreferencesState> {
     return (
       <RootColumn grow={true}>
         <Heading>
-          <span style={{marginRight: '16px'}}>Preference File</span>
+          <span style={{ marginRight: '16px' }}>Preference File</span>
           <Select
             options={Object.keys(this.state.sharedPreferences)
               .sort((a, b) => (a.toLowerCase() > b.toLowerCase() ? 1 : -1))
@@ -241,6 +260,7 @@ export default class extends FlipperPlugin<SharedPreferencesState> {
             <ManagedDataInspector
               data={entry.preferences}
               setValue={this.onSharedPreferencesChanged}
+              onDelete={this.onDel}
             />
           </InspectorColumn>
           <ChangelogColumn>

--- a/desktop/plugins/shared_preferences/index.js
+++ b/desktop/plugins/shared_preferences/index.js
@@ -18,16 +18,16 @@ import {
   styled,
   Select,
 } from 'flipper';
-import { FlipperPlugin } from 'flipper';
+import {FlipperPlugin} from 'flipper';
 
-import { clone } from 'lodash';
+import {clone} from 'lodash';
 
 type SharedPreferencesChangeEvent = {|
   preferences: string,
-    name: string,
-      time: number,
-        deleted: boolean,
-          value: string,
+  name: string,
+  time: number,
+  deleted: boolean,
+  value: string,
 |};
 
 export type SharedPreferences = {|
@@ -45,7 +45,7 @@ type SharedPreferencesMap = {
 
 type SharedPreferencesState = {|
   selectedPreferences: ?string,
-    sharedPreferences: SharedPreferencesMap,
+  sharedPreferences: SharedPreferencesMap,
 |};
 
 const CHANGELOG_COLUMNS = {
@@ -93,7 +93,7 @@ export default class extends FlipperPlugin<SharedPreferencesState> {
   reducers = {
     UpdateSharedPreferences(state: SharedPreferencesState, results: Object) {
       const update = results.update;
-      const entry = state.sharedPreferences[update.name] || { changesList: [] };
+      const entry = state.sharedPreferences[update.name] || {changesList: []};
       entry.preferences = update.preferences;
       state.sharedPreferences[update.name] = entry;
       return {
@@ -156,17 +156,17 @@ export default class extends FlipperPlugin<SharedPreferencesState> {
   init() {
     this.client
       .call('getAllSharedPreferences')
-      .then((results: { [name: string]: SharedPreferences }) => {
+      .then((results: {[name: string]: SharedPreferences}) => {
         Object.entries(results).forEach(([name, prefs]) => {
-          const update = { name: name, preferences: prefs };
-          this.dispatchAction({ update, type: 'UpdateSharedPreferences' });
+          const update = {name: name, preferences: prefs};
+          this.dispatchAction({update, type: 'UpdateSharedPreferences'});
         });
       });
 
     this.client.subscribe(
       'sharedPreferencesChange',
       (change: SharedPreferencesChangeEvent) => {
-        this.dispatchAction({ change, type: 'ChangeSharedPreferences' });
+        this.dispatchAction({change, type: 'ChangeSharedPreferences'});
       },
     );
   }
@@ -198,7 +198,7 @@ export default class extends FlipperPlugin<SharedPreferencesState> {
           name: this.state.selectedPreferences,
           preferences: results,
         };
-        this.dispatchAction({ update, type: 'UpdateSharedPreferences' });
+        this.dispatchAction({update, type: 'UpdateSharedPreferences'});
       });
   };
 
@@ -209,8 +209,7 @@ export default class extends FlipperPlugin<SharedPreferencesState> {
     });
   };
 
-  onDel = (path: Array<string>) => {
-
+  onSharedPreferencesDeleted = (path: Array<string>) => {
     this.client
       .call('deleteSharedPreference', {
         sharedPreferencesName: this.state.selectedPreferences,
@@ -223,9 +222,6 @@ export default class extends FlipperPlugin<SharedPreferencesState> {
         };
         this.dispatchAction({ update, type: 'UpdateSharedPreferences' });
       });
-
-    //deleteSharedPreference
-    //alert(key)
   };
 
   render() {
@@ -242,7 +238,7 @@ export default class extends FlipperPlugin<SharedPreferencesState> {
     return (
       <RootColumn grow={true}>
         <Heading>
-          <span style={{ marginRight: '16px' }}>Preference File</span>
+          <span style={{marginRight: '16px'}}>Preference File</span>
           <Select
             options={Object.keys(this.state.sharedPreferences)
               .sort((a, b) => (a.toLowerCase() > b.toLowerCase() ? 1 : -1))
@@ -260,7 +256,7 @@ export default class extends FlipperPlugin<SharedPreferencesState> {
             <ManagedDataInspector
               data={entry.preferences}
               setValue={this.onSharedPreferencesChanged}
-              onDelete={this.onDel}
+              onDelete={this.onSharedPreferencesDeleted}
             />
           </InspectorColumn>
           <ChangelogColumn>

--- a/iOS/Plugins/FlipperKitUserDefaultsPlugin/FKUserDefaultsPlugin.m
+++ b/iOS/Plugins/FlipperKitUserDefaultsPlugin/FKUserDefaultsPlugin.m
@@ -82,6 +82,15 @@ static NSString* const kAppSuiteUserDefaultsName = @"App Suite UserDefaults";
                                     forKey:preferenceName];
               [responder success:[sharedPreferences dictionaryRepresentation]];
             }];
+  
+  [connection receive:@"deleteSharedPreference"
+            withBlock:^(NSDictionary* params, id<FlipperResponder> responder) {
+              NSUserDefaults* sharedPreferences =
+                  [self sharedPreferencesForParams:params];
+              NSString* preferenceName = params[@"preferenceName"];
+              [sharedPreferences removeObjectForKey:preferenceName];
+              [responder success:[sharedPreferences dictionaryRepresentation]];
+            }];
 }
 
 - (void)didDisconnect {


### PR DESCRIPTION
## Summary

This change makes it possible to remove preferences. I also added a `Delete` context menu option to `DataInspector` because I needed it to implement this feature. @passy confirmed that it makes sense to add this because delete is a common action.

Fixes #451 

