### PR TITLE
Disable flow for pkg-lib and lib output folders

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -6,9 +6,11 @@
 .*\.ts
 .*/node_modules/.*
 <PROJECT_ROOT>/scripts/.*
+<PROJECT_ROOT>/desktop/.*/lib/.*
 <PROJECT_ROOT>/desktop/scripts/.*
 <PROJECT_ROOT>/desktop/static/.*
 <PROJECT_ROOT>/desktop/pkg/.*
+<PROJECT_ROOT>/desktop/pkg-lib/.*
 <PROJECT_ROOT>/desktop/doctor/.*
 <PROJECT_ROOT>/desktop/app/.*
 <PROJECT_ROOT>/desktop/babel-transformer/.*


### PR DESCRIPTION
Summary: Currently flow linter is failing on GitHub. This diff disables flow for pkg-lib and lib output folders where it is failing currently.

Differential Revision: D21129580

