### PR TITLE
[flipper] Add "debugging" to dmg upload

### DIFF
--- a/.github/workflows/dmg-release.yml
+++ b/.github/workflows/dmg-release.yml
@@ -36,10 +36,11 @@ jobs:
       uses: actions/download-artifact@v1
       with:
         name: 'Flipper-mac.dmg'
-        path: 'dist/Flipper-mac.dmg'
+        path: 'Flipper-mac.dmg'
+    - run: ls -la Flipper-mac.dmg
     - name: Publish
       uses: skx/github-action-publish-binaries@master
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        args: 'dist/Flipper-mac.dmg'
+        args: 'Flipper-mac.dmg'


### PR DESCRIPTION
Summary:

Really no clue why this isn't working. Manually running the exact
same curl command works just fine. Adding an `ls` and removing paths
because why not.

Test Plan:
Next release, sadly.
