### PR TITLE
Add jest coverage reporters

### DIFF
--- a/desktop/.gitignore
+++ b/desktop/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 *.tsbuildinfo
 /static/defaultPlugins/index.json
 /app/src/defaultPlugins/index.tsx
+/coverage

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -104,7 +104,12 @@
       "^flipper-pkg$": "<rootDir>/pkg/src",
       "^flipper-pkg-lib$": "<rootDir>/pkg-lib/src"
     },
-    "clearMocks": true
+    "clearMocks": true,
+    "coverageReporters": [
+      "json-summary",
+      "lcov",
+      "html"
+    ]
   },
   "devDependencies": {
     "@babel/code-frame": "^7.8.3",


### PR DESCRIPTION
Summary:
I want to track that data continuously.
HTML is useful to investigate, lcov got loads of external tools that
support it and JSON is quite useful to parse and write to a DB.

Test Plan:
```
yarn test --coverage
open coverage/index.html
```
