### PR TITLE
Fix tests failing on github

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -11,6 +11,7 @@ jobs:
       desktop-directory: ./desktop
 
     strategy:
+      fail-fast: false
       matrix:
         node-version: [12.x]
         os: ['ubuntu-latest', 'windows-latest', 'macos-latest']

--- a/desktop/app/src/ui/components/data-inspector/__tests__/DataInspector.node.tsx
+++ b/desktop/app/src/ui/components/data-inspector/__tests__/DataInspector.node.tsx
@@ -10,7 +10,11 @@
 import * as React from 'react';
 import {render, fireEvent, waitFor} from '@testing-library/react';
 
-jest.mock('../../../../fb/Logger');
+try {
+  jest.mock('../../../../fb/Logger');
+} catch {
+  jest.mock('../../../../fb-stubs/Logger');
+}
 import ManagedDataInspector from '../ManagedDataInspector';
 
 const mocks = {


### PR DESCRIPTION
Summary: Fixed tests failing on github. Our custom transformation for 'fb-stubs' is not applied for tests and jest.mocks in particular, and therefore we need to try mock both 'fb' and 'fb-stubs' object depending on where the test is running.

Differential Revision: D21352524

