### PR TITLE
Disable cancelling all Node CI jobs if one of them failed

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -11,6 +11,7 @@ jobs:
       desktop-directory: ./desktop
 
     strategy:
+      fail-fast: false
       matrix:
         node-version: [12.x]
         os: ['ubuntu-latest', 'windows-latest', 'macos-latest']


### PR DESCRIPTION
Summary: Disable cancelling all Node CI jobs if one of them failed. This will help to detect whether build is failing on all OSes (linux, mac, windows) or only some of them.

Differential Revision: D21370606

