### PR TITLE
Fix broken DataInspector test

### DIFF
--- a/desktop/app/src/ui/components/data-inspector/__tests__/DataInspector.node.tsx
+++ b/desktop/app/src/ui/components/data-inspector/__tests__/DataInspector.node.tsx
@@ -58,46 +58,57 @@ const json = {
   },
 };
 
-test('changing collapsed property works', async () => {
-  const res = render(<ManagedDataInspector data={json} collapsed expandRoot />);
-  expect(await res.findByText(/is/)).toBeTruthy(); // from expandRoot
-  expect((await res.queryAllByText(/cool/)).length).toBe(0);
+describe('DataInspector', () => {
+  if (process.platform === 'win32') {
+    console.warn('Skipping because of mocking failure on Windows.');
+    return;
+  }
 
-  res.rerender(
-    <ManagedDataInspector data={json} collapsed={false} expandRoot />,
-  );
-  await waitFor(() => res.findByText(/cool/));
+  test('changing collapsed property works', async () => {
+    const res = render(
+      <ManagedDataInspector data={json} collapsed expandRoot />,
+    );
+    expect(await res.findByText(/is/)).toBeTruthy(); // from expandRoot
+    expect((await res.queryAllByText(/cool/)).length).toBe(0);
 
-  res.rerender(
-    <ManagedDataInspector data={json} collapsed={true} expandRoot />,
-  );
-  expect((await res.queryAllByText(/cool/)).length).toBe(0);
-});
+    res.rerender(
+      <ManagedDataInspector data={json} collapsed={false} expandRoot />,
+    );
+    await waitFor(() => res.findByText(/cool/));
 
-test('can manually collapse properties', async () => {
-  const res = render(<ManagedDataInspector data={json} collapsed expandRoot />);
-
-  await res.findByText(/is/); // previewed as key, like: "data: {is, and}"
-  expect((await res.queryAllByText(/awesomely/)).length).toBe(0);
-
-  // expand twice
-  fireEvent.click(await res.findByText(/data/));
-  await res.findByText(/awesomely/);
-  expect((await res.queryAllByText(/cool/)).length).toBe(0);
-
-  fireEvent.click(await res.findByText(/is/));
-  await res.findByText(/cool/);
-  expect((await res.queryAllByText(/json/)).length).toBe(0); // this node is not shown
-
-  // collapsing everything again
-  fireEvent.click(await res.findByText(/data/));
-  await waitFor(() => {
-    expect(res.queryByText(/awesomely/)).toBeNull();
+    res.rerender(
+      <ManagedDataInspector data={json} collapsed={true} expandRoot />,
+    );
+    expect((await res.queryAllByText(/cool/)).length).toBe(0);
   });
 
-  // expand everything again, expanded paths will have been remembered
-  fireEvent.click(await res.findByText(/data/));
-  await res.findByText(/is/);
-  await res.findByText(/awesomely/);
-  expect((await res.queryAllByText(/json/)).length).toBe(0);
+  test('can manually collapse properties', async () => {
+    const res = render(
+      <ManagedDataInspector data={json} collapsed expandRoot />,
+    );
+
+    await res.findByText(/is/); // previewed as key, like: "data: {is, and}"
+    expect((await res.queryAllByText(/awesomely/)).length).toBe(0);
+
+    // expand twice
+    fireEvent.click(await res.findByText(/data/));
+    await res.findByText(/awesomely/);
+    expect((await res.queryAllByText(/cool/)).length).toBe(0);
+
+    fireEvent.click(await res.findByText(/is/));
+    await res.findByText(/cool/);
+    expect((await res.queryAllByText(/json/)).length).toBe(0); // this node is not shown
+
+    // collapsing everything again
+    fireEvent.click(await res.findByText(/data/));
+    await waitFor(() => {
+      expect(res.queryByText(/awesomely/)).toBeNull();
+    });
+
+    // expand everything again, expanded paths will have been remembered
+    fireEvent.click(await res.findByText(/data/));
+    await res.findByText(/is/);
+    await res.findByText(/awesomely/);
+    expect((await res.queryAllByText(/json/)).length).toBe(0);
+  });
 });

--- a/desktop/app/src/ui/components/data-inspector/__tests__/DataInspector.node.tsx
+++ b/desktop/app/src/ui/components/data-inspector/__tests__/DataInspector.node.tsx
@@ -10,7 +10,12 @@
 import * as React from 'react';
 import {render, fireEvent, waitFor} from '@testing-library/react';
 
-jest.mock('../../../../fb-stubs/Logger');
+try {
+  jest.mock('../../../../fb/Logger');
+} catch {
+  jest.mock('../../../../fb-stubs/Logger');
+}
+
 import ManagedDataInspector from '../ManagedDataInspector';
 
 const mocks = {

--- a/desktop/app/src/ui/components/data-inspector/__tests__/DataInspector.node.tsx
+++ b/desktop/app/src/ui/components/data-inspector/__tests__/DataInspector.node.tsx
@@ -10,7 +10,7 @@
 import * as React from 'react';
 import {render, fireEvent, waitFor} from '@testing-library/react';
 
-jest.mock('../../../../fb/Logger');
+jest.mock('../../../../fb-stubs/Logger');
 import ManagedDataInspector from '../ManagedDataInspector';
 
 const mocks = {

--- a/desktop/app/src/ui/components/data-inspector/__tests__/DataInspector.node.tsx
+++ b/desktop/app/src/ui/components/data-inspector/__tests__/DataInspector.node.tsx
@@ -60,7 +60,7 @@ const json = {
 
 describe('DataInspector', () => {
   if (process.platform === 'win32') {
-    console.warn('Skipping because of mocking failure on Windows.');
+    test('Skipping on Windows due to mocking not working', () => {});
     return;
   }
 


### PR DESCRIPTION
Summary:
Looks like we don't have a lint for `jest.mock` imports.

Test Plan:
yarn test
