### PR TITLE
Fix link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Older yarn versions might show an error / hang with the message 'Waiting for the
 
 # Documentation
 
-Find the full documentation for this project at [fbflipper.com](https://fbflipper.com/docs).
+Find the full documentation for this project at [fbflipper.com](https://fbflipper.com/docs/features/index/).
 
 Our documentation is built with [Docusaurus](https://docusaurus.io/). You can build
 it locally by running this:

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Older yarn versions might show an error / hang with the message 'Waiting for the
 
 # Documentation
 
-Find the full documentation for this project at [fbflipper.com](https://fbflipper.com/docs/features/index/).
+Find the full documentation for this project at [fbflipper.com](https://fbflipper.com/).
 
 Our documentation is built with [Docusaurus](https://docusaurus.io/). You can build
 it locally by running this:


### PR DESCRIPTION
## Summary

Link to documentation in the README is broken. I have replaced it with a working one.

## Changelog

Fixed link to the docs in README

## Test Plan

Check out both links in the browser.
