### PR TITLE
Check whether the request url is null or not to avoid error. 

### DIFF
--- a/desktop/plugins/network/index.tsx
+++ b/desktop/plugins/network/index.tsx
@@ -455,6 +455,11 @@ function buildRow(
   if (request == null) {
     return null;
   }
+
+  if (request.url == null) {
+    return null;
+  }
+  
   const url = new URL(request.url);
   const domain = url.host + url.pathname;
   const friendlyName = getHeaderValue(request.headers, 'X-FB-Friendly-Name');

--- a/desktop/plugins/network/index.tsx
+++ b/desktop/plugins/network/index.tsx
@@ -459,7 +459,7 @@ function buildRow(
   if (request.url == null) {
     return null;
   }
-  
+
   const url = new URL(request.url);
   const domain = url.host + url.pathname;
   const friendlyName = getHeaderValue(request.headers, 'X-FB-Friendly-Name');


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
### The existing issue
[The `buildRow` function in `network/index.js`](https://github.com/facebook/flipper/blob/c7ff6f6266c712ca6152d4038f8b960914282ddb/desktop/plugins/network/index.tsx#L458) doesn't check if the url is valid. However, 
since the `request` data comes from the App which developers are building, 
there will be an error, if the `request.url` is `null` or `undefined`. 

![image](https://user-images.githubusercontent.com/7471672/81561808-5c536b80-93c6-11ea-846b-3aa76d726350.png)

When this error occurs,  the `NetworkTable` can't go back to normal even I try to  click `Clear error and try again`.  Only after killing the Flipper desktop and restart again, it can work again. 
![error](https://user-images.githubusercontent.com/7471672/81563438-d553c280-93c8-11ea-86be-883fa457dda3.gif)

### How to fix 

In order to make `Flipper` desktop more stable, I think it is better to check the url is valid and avoid the crash. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. This should just be a brief oneline we can mention in our release notes: https://github.com/facebook/flipper/releases -->
-  check the url in the `buildRow` function in `network/index.js`

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI / output of the test runner and how you invoked it. -->

- [x] Using the same input `request` data, `Flipper` will not show this row and it works as normal. 
![image](https://user-images.githubusercontent.com/7471672/81562713-e819c780-93c7-11ea-809d-cf6893c58a68.png)

