### PR TITLE
Fix obsolete usages in build.gradle

### DIFF
--- a/react-native/react-native-flipper/android/build.gradle
+++ b/react-native/react-native-flipper/android/build.gradle
@@ -139,8 +139,10 @@ afterEvaluate { project ->
 
     android.libraryVariants.all { variant ->
         def name = variant.name.capitalize()
-        task "jar${name}"(type: Jar, dependsOn: variant.javaCompile) {
-            from variant.javaCompile.destinationDir
+        def javaCompileTask = variant.javaCompileProvider.get()
+        
+        task "jar${name}"(type: Jar, dependsOn: javaCompileTask) {
+            from javaCompileTask.destinationDir
         }
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
Remove warning `'variant.getJavaCompile()' is obsolete and has been replaced with 'variant.getJavaCompileProvider()'.`

## Changelog

- swithed from `variant.getJavaCompile()` to `variant.getJavaCompileProvider()`

## Test Plan

n/a
