### PR TITLE
Bump OpenSSL-Universal pod dependency to 1.0.2.20

### DIFF
--- a/iOS/Podspecs/Flipper-Folly.podspec
+++ b/iOS/Podspecs/Flipper-Folly.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   spec.dependency 'boost-for-react-native'
   spec.dependency 'Flipper-Glog'
   spec.dependency 'Flipper-DoubleConversion'
-  spec.dependency 'OpenSSL-Universal', '1.0.2.19'
+  spec.dependency 'OpenSSL-Universal', '1.0.2.20'
   spec.dependency 'CocoaLibEvent', '~> 1.0'
   spec.compiler_flags = '-DFOLLY_HAVE_PTHREAD=1 -DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_HAVE_LIBGFLAGS=0 -DFOLLY_HAVE_LIBJEMALLOC=0 -DFOLLY_HAVE_PREADV=0 -DFOLLY_HAVE_PWRITEV=0 -DFOLLY_HAVE_TFO=0 -DFOLLY_USE_SYMBOLIZER=0
     -frtti


### PR DESCRIPTION
Per comment in https://github.com/facebook/flipper/issues/485#issuecomment-630349307 it appears that OpenSSL will have bitcode information in it now which should solve problems like those experienced in #485 and it's connected issues

## Summary

Fixes #485 for real?

Flipper depends on OpenSSL library which does not have bitcode enabled, which means that it fails on real devices as noted in #485

## Changelog

Upgrade OpenSSL dependency to one that enables bitcode

## Test Plan

This is perhaps more of a speculative PR, it's a build system thing and fundamental enough I am **assuming** (read as: possibly wrong) that CI + basic tests will show that there are no regressions. After which point the results of this can be issued as a `@next` or similar for people to see if they can remove the bitcode-disabling workarounds they've had to put in to work around #485