### PR TITLE
RegExp doesn't need underscore with \w class

### DIFF
--- a/desktop/app/src/utils/CertificateProvider.tsx
+++ b/desktop/app/src/utils/CertificateProvider.tsx
@@ -46,7 +46,7 @@ const deviceClientCertFile = 'device.crt';
 const caSubject = '/C=US/ST=CA/L=Menlo Park/O=Sonar/CN=SonarCA';
 const serverSubject = '/C=US/ST=CA/L=Menlo Park/O=Sonar/CN=localhost';
 const minCertExpiryWindowSeconds = 24 * 60 * 60;
-const allowedAppNameRegex = /^[\w._-]+$/;
+const allowedAppNameRegex = /^[\w.-]+$/;
 const logTag = 'CertificateProvider';
 /*
  * RFC2253 specifies the unamiguous x509 subject format.

--- a/desktop/app/src/utils/androidContainerUtilityInternal.tsx
+++ b/desktop/app/src/utils/androidContainerUtilityInternal.tsx
@@ -15,7 +15,7 @@
 import {UnsupportedError} from './metrics';
 import adbkit, {Client} from 'adbkit';
 
-const allowedAppNameRegex = /^[\w._-]+$/;
+const allowedAppNameRegex = /^[\w.-]+$/;
 const appNotApplicationRegex = /is not an application/;
 const appNotDebuggableRegex = /debuggable/;
 const operationNotPermittedRegex = /not permitted/;

--- a/desktop/babel-transformer/src/fb-stubs.ts
+++ b/desktop/babel-transformer/src/fb-stubs.ts
@@ -15,7 +15,7 @@ const isFBFile = (filePath: string) =>
   filePath.includes(`${path.sep}fb${path.sep}`);
 
 const requireFromFolder = (folder: string, path: string) =>
-  new RegExp(folder + '/[\\w.-_]+(.js)?$', 'g').test(path);
+  new RegExp(folder + '/[\\w.-]+(.js)?$', 'g').test(path);
 
 module.exports = () => ({
   name: 'replace-fb-stubs',

--- a/desktop/doctor/jestconfig.json
+++ b/desktop/doctor/jestconfig.json
@@ -1,7 +1,14 @@
 {
   "transform": {
-    "^.+\\.(t|j)sx?$": "ts-jest"
+    "^.+\\.[jt]sx?$": "ts-jest"
   },
-  "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
-  "moduleFileExtensions": ["ts", "tsx", "js", "jsx", "json", "node"]
+  "testRegex": "(/__tests__/.*|[./](test|spec))\\.[jt]sx?$",
+  "moduleFileExtensions": [
+    "ts",
+    "tsx",
+    "js",
+    "jsx",
+    "json",
+    "node"
+  ]
 }

--- a/desktop/doctor/src/environmentInfo.ts
+++ b/desktop/doctor/src/environmentInfo.ts
@@ -31,7 +31,7 @@ export type EnvironmentInfo = {
   };
 };
 
-async function retrieveAndParseEnvInfo(): Promise<any> {
+async function retrieveAndParseEnvInfo(): Promise<EnvironmentInfo> {
   return JSON.parse(
     await run(
       {

--- a/desktop/plugins/crash_reporter/index.js
+++ b/desktop/plugins/crash_reporter/index.js
@@ -344,13 +344,13 @@ function truncate(baseString: string, numOfChars: number): string {
 }
 
 export function parsePath(content: string): ?string {
-  const regex = /Path: *[\w\-\/\.\t\ \_\%]*\n/;
+  const regex = /Path: *[\w\/.\t\s%-]*\n/;
   const arr = regex.exec(content);
   if (!arr || arr.length <= 0) {
     return null;
   }
   const pathString = arr[0];
-  const pathRegex = /[\w\-\/\.\t\ \_\%]*\n/;
+  const pathRegex = /[\w\/\.\t\s%-]*\n/;
   const tmp = pathRegex.exec(pathString);
   if (!tmp || tmp.length == 0) {
     return null;

--- a/desktop/plugins/sections/StackTrace.js
+++ b/desktop/plugins/sections/StackTrace.js
@@ -12,7 +12,7 @@ import {colors, StackTrace} from 'flipper';
 
 const FacebookLibraries = ['Facebook'];
 
-const REGEX = /\d+\s+(?<library>(\s|\w|\.)+\w)\s+(?<address>0x\w+?)\s+(?<caller>.+) \+ (?<lineNumber>\d+)/;
+const REGEX = /\d+\s+(?<library>[\s\w\.]+\w)\s+(?<address>0x\w+?)\s+(?<caller>.+) \+ (?<lineNumber>\d+)/;
 
 function isSystemLibrary(libraryName: ?string): boolean {
   return !FacebookLibraries.includes(libraryName);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
Character class '\w' has alphabets, digits, underscore. so we don't need to write '_' character with '\w' class.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. This should just be a brief oneline we can mention in our release notes: https://github.com/facebook/flipper/releases -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI / output of the test runner and how you invoked it. -->

