### PR TITLE
Fix tests runInit.node.ts failing on Windows

### DIFF
--- a/desktop/pkg/src/__tests__/runInit.node.ts
+++ b/desktop/pkg/src/__tests__/runInit.node.ts
@@ -18,7 +18,7 @@ beforeEach(() => {
     // no implementation
   }
   function writeFile(name: string, contents: string) {
-    files[name] = contents;
+    files[name.replace(/\\/g, '/')] = contents;
   }
 
   files = {};


### PR DESCRIPTION
Summary: Normalize paths so snapshots look the same on mac and win

Differential Revision: D21722773

