### PR TITLE
DMG upload experiments

### DIFF
--- a/.github/workflows/dmg-release.yml
+++ b/.github/workflows/dmg-release.yml
@@ -37,10 +37,28 @@ jobs:
       with:
         name: 'Flipper-mac.dmg'
         path: 'Flipper-mac.dmg'
+    - run: dd if=/dev/zero bs=1024k count=1024 of=1g.dmg
+    - run: dd if=/dev/zero bs=1024k count=10240 of=10g.dmg
     - run: ls -la Flipper-mac.dmg
     - name: Publish
       uses: skx/github-action-publish-binaries@master
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        args: 'Flipper-mac.dmg'
+        args: '*.dmg'
+  publish:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+    - name: Download
+      uses: actions/download-artifact@v1
+      with:
+        name: 'Flipper-mac.dmg'
+        path: 'Flipper-mac.dmg'
+    - name: GitHub Upload Release Artifacts
+      uses: Roang-zero1/github-upload-release-artifacts-action@v2.1.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        args: '*.dmg'


### PR DESCRIPTION
Summary:
Following some advice to add debugging steps from here: https://github.com/skx/github-action-publish-binaries/issues/19

Also adding an alternative upload action as the issue clearly stems from
something specific to the cURL version on the Action host. This uses
a completely different tool (ghr) for uploading.

Test Plan:
testinprod
