### PR TITLE
Master PR: Enable physical iOS devices

### DIFF
--- a/desktop/app/src/dispatcher/iOSDevice.tsx
+++ b/desktop/app/src/dispatcher/iOSDevice.tsx
@@ -56,7 +56,7 @@ function forwardPort(port: number, multiplexChannelPort: number) {
   ]);
 }
 // start port forwarding server for real device connections
-const portForwarders: Array<ChildProcess> = GK.get('flipper_ios_device_support')
+const portForwarders: Array<ChildProcess> = true
   ? [forwardPort(8089, 8079), forwardPort(8088, 8078)]
   : [];
 

--- a/desktop/app/src/utils/iOSContainerUtility.tsx
+++ b/desktop/app/src/utils/iOSContainerUtility.tsx
@@ -14,7 +14,6 @@ import {notNull} from './typeUtils';
 const unsafeExec = promisify(child_process.exec);
 import {killOrphanedInstrumentsProcesses} from './processCleanup';
 import {reportPlatformFailures} from './metrics';
-import config from '../fb-stubs/config';
 
 const idbPath = '/usr/local/bin/idb';
 // Use debug to get helpful logs when idb fails
@@ -30,7 +29,7 @@ export type DeviceTarget = {
 };
 
 function isAvailable(): boolean {
-  return config.isFBBuild;
+  return true;
 }
 
 function safeExec(command: string): Promise<{stdout: string; stderr: string}> {


### PR DESCRIPTION
## Summary

This is to fix https://github.com/facebook/flipper/issues/262

Currently a work in progress, there are various fixes to make before the feature can be enabled by default.

## Changelog

Now physical iOS devices are supported in open-source Flipper.

## Test Plan

* Verified connection is made and network inspector works.