### PR TITLE
Updated dependencies to latest versions and updated filenames in FlipperKit

### DIFF
--- a/iOS/FlipperKit.xcodeproj/project.pbxproj
+++ b/iOS/FlipperKit.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		027369E09714D434B8C421F6 /* libPods-FlipperKit.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0D8E34F2706E57CC3C186A67 /* libPods-FlipperKit.a */; };
-		53915CB22152E3040090EEA6 /* SonarResponder.h in Headers */ = {isa = PBXBuildFile; fileRef = 53915C972152E3030090EEA6 /* SonarResponder.h */; };
+		53915CB22152E3040090EEA6 /* FlipperResponder.h in Headers */ = {isa = PBXBuildFile; fileRef = 53915C972152E3030090EEA6 /* FlipperResponder.h */; };
 		53915CB32152E3040090EEA6 /* SKStateUpdateCPPWrapper.mm in Sources */ = {isa = PBXBuildFile; fileRef = 53915C982152E3030090EEA6 /* SKStateUpdateCPPWrapper.mm */; };
 		53915CB42152E3040090EEA6 /* FlipperDiagnosticsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 53915C992152E3030090EEA6 /* FlipperDiagnosticsViewController.m */; };
 		53915CB52152E3040090EEA6 /* FlipperClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 53915C9A2152E3030090EEA6 /* FlipperClient.h */; };
@@ -16,31 +16,28 @@
 		53915CB72152E3040090EEA6 /* SKStateUpdateCPPWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 53915C9C2152E3030090EEA6 /* SKStateUpdateCPPWrapper.h */; };
 		53915CB82152E3040090EEA6 /* FlipperPlugin.h in Headers */ = {isa = PBXBuildFile; fileRef = 53915C9D2152E3030090EEA6 /* FlipperPlugin.h */; };
 		53915CB92152E3040090EEA6 /* FlipperUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 53915C9E2152E3030090EEA6 /* FlipperUtil.m */; };
-		53915CBA2152E3040090EEA6 /* SKPortForwardingServer.h in Headers */ = {isa = PBXBuildFile; fileRef = 53915CA12152E3040090EEA6 /* SKPortForwardingServer.h */; };
-		53915CBB2152E3040090EEA6 /* SKPortForwardingCommon.h in Headers */ = {isa = PBXBuildFile; fileRef = 53915CA22152E3040090EEA6 /* SKPortForwardingCommon.h */; };
-		53915CBC2152E3040090EEA6 /* SKPortForwardingServer.m in Sources */ = {isa = PBXBuildFile; fileRef = 53915CA32152E3040090EEA6 /* SKPortForwardingServer.m */; };
+		53915CBA2152E3040090EEA6 /* FKPortForwardingServer.h in Headers */ = {isa = PBXBuildFile; fileRef = 53915CA12152E3040090EEA6 /* FKPortForwardingServer.h */; };
+		53915CBB2152E3040090EEA6 /* FKPortForwardingCommon.h in Headers */ = {isa = PBXBuildFile; fileRef = 53915CA22152E3040090EEA6 /* FKPortForwardingCommon.h */; };
+		53915CBC2152E3040090EEA6 /* FKPortForwardingServer.m in Sources */ = {isa = PBXBuildFile; fileRef = 53915CA32152E3040090EEA6 /* FKPortForwardingServer.m */; };
 		53915CBD2152E3040090EEA6 /* FBCxxFollyDynamicConvert.mm in Sources */ = {isa = PBXBuildFile; fileRef = 53915CA52152E3040090EEA6 /* FBCxxFollyDynamicConvert.mm */; };
 		53915CBE2152E3040090EEA6 /* FBCxxFollyDynamicConvert.h in Headers */ = {isa = PBXBuildFile; fileRef = 53915CA62152E3040090EEA6 /* FBCxxFollyDynamicConvert.h */; };
 		53915CBF2152E3040090EEA6 /* FlipperStateUpdateListener.h in Headers */ = {isa = PBXBuildFile; fileRef = 53915CA72152E3040090EEA6 /* FlipperStateUpdateListener.h */; };
 		53915CC02152E3040090EEA6 /* FlipperCppBridgingConnection.mm in Sources */ = {isa = PBXBuildFile; fileRef = 53915CA92152E3040090EEA6 /* FlipperCppBridgingConnection.mm */; };
-		53915CC12152E3040090EEA6 /* SonarCppWrapperPlugin.h in Headers */ = {isa = PBXBuildFile; fileRef = 53915CAA2152E3040090EEA6 /* SonarCppWrapperPlugin.h */; };
+		53915CC12152E3040090EEA6 /* FlipperCppWrapperPlugin.h in Headers */ = {isa = PBXBuildFile; fileRef = 53915CAA2152E3040090EEA6 /* FlipperCppWrapperPlugin.h */; };
 		53915CC22152E3040090EEA6 /* FlipperCppBridgingConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 53915CAB2152E3040090EEA6 /* FlipperCppBridgingConnection.h */; };
-		53915CC32152E3040090EEA6 /* SonarCppBridgingResponder.mm in Sources */ = {isa = PBXBuildFile; fileRef = 53915CAC2152E3040090EEA6 /* SonarCppBridgingResponder.mm */; };
-		53915CC42152E3040090EEA6 /* SonarCppBridgingResponder.h in Headers */ = {isa = PBXBuildFile; fileRef = 53915CAD2152E3040090EEA6 /* SonarCppBridgingResponder.h */; };
+		53915CC32152E3040090EEA6 /* FlipperCppBridgingResponder.mm in Sources */ = {isa = PBXBuildFile; fileRef = 53915CAC2152E3040090EEA6 /* FlipperCppBridgingResponder.mm */; };
+		53915CC42152E3040090EEA6 /* FlipperCppBridgingResponder.h in Headers */ = {isa = PBXBuildFile; fileRef = 53915CAD2152E3040090EEA6 /* FlipperCppBridgingResponder.h */; };
 		53915CC52152E3040090EEA6 /* SKMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 53915CAE2152E3040090EEA6 /* SKMacros.h */; };
 		53915CC62152E3040090EEA6 /* FlipperClient.mm in Sources */ = {isa = PBXBuildFile; fileRef = 53915CAF2152E3040090EEA6 /* FlipperClient.mm */; };
 		53915CC72152E3040090EEA6 /* FlipperDiagnosticsViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 53915CB02152E3040090EEA6 /* FlipperDiagnosticsViewController.h */; };
-		53915CC82152E3040090EEA6 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 53915CB12152E3040090EEA6 /* Info.plist */; };
 		53915CCA2152E31C0090EEA6 /* Plugins in Resources */ = {isa = PBXBuildFile; fileRef = 53915CC92152E31C0090EEA6 /* Plugins */; };
 		53D4C51220A5B89900613A96 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 53D4C51120A5B89900613A96 /* Foundation.framework */; };
-		6AE55F0A77A5644AADF2CEA6 /* libPods-SonarKit.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 104CB87D17FDFDC934630C14 /* libPods-SonarKit.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		0D8E34F2706E57CC3C186A67 /* libPods-FlipperKit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-FlipperKit.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		104CB87D17FDFDC934630C14 /* libPods-SonarKit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-SonarKit.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		22B8670D786EA50E30082023 /* Pods-FlipperKit.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FlipperKit.debug.xcconfig"; path = "Pods/Target Support Files/Pods-FlipperKit/Pods-FlipperKit.debug.xcconfig"; sourceTree = "<group>"; };
-		53915C972152E3030090EEA6 /* SonarResponder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SonarResponder.h; sourceTree = "<group>"; };
+		53915C972152E3030090EEA6 /* FlipperResponder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FlipperResponder.h; sourceTree = "<group>"; };
 		53915C982152E3030090EEA6 /* SKStateUpdateCPPWrapper.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = SKStateUpdateCPPWrapper.mm; sourceTree = "<group>"; };
 		53915C992152E3030090EEA6 /* FlipperDiagnosticsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FlipperDiagnosticsViewController.m; sourceTree = "<group>"; };
 		53915C9A2152E3030090EEA6 /* FlipperClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FlipperClient.h; sourceTree = "<group>"; };
@@ -48,17 +45,17 @@
 		53915C9C2152E3030090EEA6 /* SKStateUpdateCPPWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SKStateUpdateCPPWrapper.h; sourceTree = "<group>"; };
 		53915C9D2152E3030090EEA6 /* FlipperPlugin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FlipperPlugin.h; sourceTree = "<group>"; };
 		53915C9E2152E3030090EEA6 /* FlipperUtil.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FlipperUtil.m; sourceTree = "<group>"; };
-		53915CA12152E3040090EEA6 /* SKPortForwardingServer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SKPortForwardingServer.h; sourceTree = "<group>"; };
-		53915CA22152E3040090EEA6 /* SKPortForwardingCommon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SKPortForwardingCommon.h; sourceTree = "<group>"; };
-		53915CA32152E3040090EEA6 /* SKPortForwardingServer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SKPortForwardingServer.m; sourceTree = "<group>"; };
+		53915CA12152E3040090EEA6 /* FKPortForwardingServer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FKPortForwardingServer.h; path = FlipperKit/FKPortForwarding/FKPortForwardingServer.h; sourceTree = SOURCE_ROOT; };
+		53915CA22152E3040090EEA6 /* FKPortForwardingCommon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FKPortForwardingCommon.h; path = FlipperKit/FKPortForwarding/FKPortForwardingCommon.h; sourceTree = SOURCE_ROOT; };
+		53915CA32152E3040090EEA6 /* FKPortForwardingServer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FKPortForwardingServer.m; path = FlipperKit/FKPortForwarding/FKPortForwardingServer.m; sourceTree = SOURCE_ROOT; };
 		53915CA52152E3040090EEA6 /* FBCxxFollyDynamicConvert.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = FBCxxFollyDynamicConvert.mm; sourceTree = "<group>"; };
 		53915CA62152E3040090EEA6 /* FBCxxFollyDynamicConvert.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBCxxFollyDynamicConvert.h; sourceTree = "<group>"; };
 		53915CA72152E3040090EEA6 /* FlipperStateUpdateListener.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FlipperStateUpdateListener.h; sourceTree = "<group>"; };
 		53915CA92152E3040090EEA6 /* FlipperCppBridgingConnection.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = FlipperCppBridgingConnection.mm; sourceTree = "<group>"; };
-		53915CAA2152E3040090EEA6 /* SonarCppWrapperPlugin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SonarCppWrapperPlugin.h; sourceTree = "<group>"; };
+		53915CAA2152E3040090EEA6 /* FlipperCppWrapperPlugin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FlipperCppWrapperPlugin.h; sourceTree = "<group>"; };
 		53915CAB2152E3040090EEA6 /* FlipperCppBridgingConnection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FlipperCppBridgingConnection.h; sourceTree = "<group>"; };
-		53915CAC2152E3040090EEA6 /* SonarCppBridgingResponder.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = SonarCppBridgingResponder.mm; sourceTree = "<group>"; };
-		53915CAD2152E3040090EEA6 /* SonarCppBridgingResponder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SonarCppBridgingResponder.h; sourceTree = "<group>"; };
+		53915CAC2152E3040090EEA6 /* FlipperCppBridgingResponder.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = FlipperCppBridgingResponder.mm; sourceTree = "<group>"; };
+		53915CAD2152E3040090EEA6 /* FlipperCppBridgingResponder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FlipperCppBridgingResponder.h; sourceTree = "<group>"; };
 		53915CAE2152E3040090EEA6 /* SKMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SKMacros.h; sourceTree = "<group>"; };
 		53915CAF2152E3040090EEA6 /* FlipperClient.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = FlipperClient.mm; sourceTree = "<group>"; };
 		53915CB02152E3040090EEA6 /* FlipperDiagnosticsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FlipperDiagnosticsViewController.h; sourceTree = "<group>"; };
@@ -77,7 +74,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				53D4C51220A5B89900613A96 /* Foundation.framework in Frameworks */,
-				6AE55F0A77A5644AADF2CEA6 /* libPods-SonarKit.a in Frameworks */,
 				027369E09714D434B8C421F6 /* libPods-FlipperKit.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -100,7 +96,7 @@
 			isa = PBXGroup;
 			children = (
 				53915CC92152E31C0090EEA6 /* Plugins */,
-				53915C972152E3030090EEA6 /* SonarResponder.h */,
+				53915C972152E3030090EEA6 /* FlipperResponder.h */,
 				53915C982152E3030090EEA6 /* SKStateUpdateCPPWrapper.mm */,
 				53915C992152E3030090EEA6 /* FlipperDiagnosticsViewController.m */,
 				53915C9A2152E3030090EEA6 /* FlipperClient.h */,
@@ -131,9 +127,9 @@
 		53915CA02152E3040090EEA6 /* PortForwarding */ = {
 			isa = PBXGroup;
 			children = (
-				53915CA12152E3040090EEA6 /* SKPortForwardingServer.h */,
-				53915CA22152E3040090EEA6 /* SKPortForwardingCommon.h */,
-				53915CA32152E3040090EEA6 /* SKPortForwardingServer.m */,
+				53915CA12152E3040090EEA6 /* FKPortForwardingServer.h */,
+				53915CA22152E3040090EEA6 /* FKPortForwardingCommon.h */,
+				53915CA32152E3040090EEA6 /* FKPortForwardingServer.m */,
 			);
 			path = PortForwarding;
 			sourceTree = "<group>";
@@ -151,10 +147,10 @@
 			isa = PBXGroup;
 			children = (
 				53915CA92152E3040090EEA6 /* FlipperCppBridgingConnection.mm */,
-				53915CAA2152E3040090EEA6 /* SonarCppWrapperPlugin.h */,
+				53915CAA2152E3040090EEA6 /* FlipperCppWrapperPlugin.h */,
 				53915CAB2152E3040090EEA6 /* FlipperCppBridgingConnection.h */,
-				53915CAC2152E3040090EEA6 /* SonarCppBridgingResponder.mm */,
-				53915CAD2152E3040090EEA6 /* SonarCppBridgingResponder.h */,
+				53915CAC2152E3040090EEA6 /* FlipperCppBridgingResponder.mm */,
+				53915CAD2152E3040090EEA6 /* FlipperCppBridgingResponder.h */,
 			);
 			path = CppBridge;
 			sourceTree = "<group>";
@@ -181,7 +177,6 @@
 			isa = PBXGroup;
 			children = (
 				53D4C51120A5B89900613A96 /* Foundation.framework */,
-				104CB87D17FDFDC934630C14 /* libPods-SonarKit.a */,
 				0D8E34F2706E57CC3C186A67 /* libPods-FlipperKit.a */,
 			);
 			name = Frameworks;
@@ -195,17 +190,17 @@
 			buildActionMask = 2147483647;
 			files = (
 				53915CC22152E3040090EEA6 /* FlipperCppBridgingConnection.h in Headers */,
-				53915CB22152E3040090EEA6 /* SonarResponder.h in Headers */,
+				53915CB22152E3040090EEA6 /* FlipperResponder.h in Headers */,
 				53915CB72152E3040090EEA6 /* SKStateUpdateCPPWrapper.h in Headers */,
-				53915CBB2152E3040090EEA6 /* SKPortForwardingCommon.h in Headers */,
+				53915CBB2152E3040090EEA6 /* FKPortForwardingCommon.h in Headers */,
 				53915CB52152E3040090EEA6 /* FlipperClient.h in Headers */,
 				53915CB62152E3040090EEA6 /* FlipperConnection.h in Headers */,
 				53915CB82152E3040090EEA6 /* FlipperPlugin.h in Headers */,
 				53915CC72152E3040090EEA6 /* FlipperDiagnosticsViewController.h in Headers */,
-				53915CBA2152E3040090EEA6 /* SKPortForwardingServer.h in Headers */,
-				53915CC12152E3040090EEA6 /* SonarCppWrapperPlugin.h in Headers */,
+				53915CBA2152E3040090EEA6 /* FKPortForwardingServer.h in Headers */,
+				53915CC12152E3040090EEA6 /* FlipperCppWrapperPlugin.h in Headers */,
 				53915CBF2152E3040090EEA6 /* FlipperStateUpdateListener.h in Headers */,
-				53915CC42152E3040090EEA6 /* SonarCppBridgingResponder.h in Headers */,
+				53915CC42152E3040090EEA6 /* FlipperCppBridgingResponder.h in Headers */,
 				53915CC52152E3040090EEA6 /* SKMacros.h in Headers */,
 				53915CBE2152E3040090EEA6 /* FBCxxFollyDynamicConvert.h in Headers */,
 			);
@@ -271,7 +266,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				53915CC82152E3040090EEA6 /* Info.plist in Resources */,
 				53915CCA2152E31C0090EEA6 /* Plugins in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -304,10 +298,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				53915CC32152E3040090EEA6 /* SonarCppBridgingResponder.mm in Sources */,
+				53915CC32152E3040090EEA6 /* FlipperCppBridgingResponder.mm in Sources */,
 				53915CB42152E3040090EEA6 /* FlipperDiagnosticsViewController.m in Sources */,
 				53915CB92152E3040090EEA6 /* FlipperUtil.m in Sources */,
-				53915CBC2152E3040090EEA6 /* SKPortForwardingServer.m in Sources */,
+				53915CBC2152E3040090EEA6 /* FKPortForwardingServer.m in Sources */,
 				53915CB32152E3040090EEA6 /* SKStateUpdateCPPWrapper.mm in Sources */,
 				53915CBD2152E3040090EEA6 /* FBCxxFollyDynamicConvert.mm in Sources */,
 				53915CC62152E3040090EEA6 /* FlipperClient.mm in Sources */,
@@ -469,6 +463,7 @@
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/FlipperKit/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_CPLUSPLUSFLAGS = (
 					"$(OTHER_CFLAGS)",
@@ -487,7 +482,7 @@
 					"$(inherited)",
 					"-ObjC",
 					"-l\"DoubleConversion\"",
-					"-l\"Folly\"",
+					"-l\"Flipper-Folly\"",
 					"-l\"glog\"",
 					"-l\"stdc++\"",
 					"-DFOLLY_NO_CONFIG=1",
@@ -505,13 +500,14 @@
 				PRODUCT_BUNDLE_IDENTIFIER = FB.FlipperKit;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				USER_HEADER_SEARCH_PATHS = "";
 				"USER_HEADER_SEARCH_PATHS[arch=*]" = "${SRCROOT}/FlipperKit/** ${SRCROOT}/../xplat/**";
 				USE_HEADERMAP = YES;
-				VALID_ARCHS = "armv7s armv7 arm64";
+				VALID_ARCHS = "armv7s armv7 arm64 arm64e";
 			};
 			name = Debug;
 		};
@@ -546,6 +542,7 @@
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/FlipperKit/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_CPLUSPLUSFLAGS = (
 					"$(OTHER_CFLAGS)",
@@ -564,7 +561,7 @@
 					"$(inherited)",
 					"-ObjC",
 					"-l\"DoubleConversion\"",
-					"-l\"Folly\"",
+					"-l\"Flipper-Folly\"",
 					"-l\"glog\"",
 					"-l\"stdc++\"",
 					"-DFOLLY_NO_CONFIG=1",
@@ -582,11 +579,12 @@
 				PRODUCT_BUNDLE_IDENTIFIER = FB.FlipperKit;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				USER_HEADER_SEARCH_PATHS = "";
 				USE_HEADERMAP = YES;
-				VALID_ARCHS = "armv7s armv7 arm64";
+				VALID_ARCHS = "armv7s armv7 arm64 arm64e";
 			};
 			name = Release;
 		};

--- a/iOS/FlipperKit.xcodeproj/xcshareddata/xcschemes/FlipperKit.xcscheme
+++ b/iOS/FlipperKit.xcodeproj/xcshareddata/xcschemes/FlipperKit.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1150"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "53D19A0420A4BA3600A371E3"
+               BuildableName = "FlipperKit.framework"
+               BlueprintName = "FlipperKit"
+               ReferencedContainer = "container:FlipperKit.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "53D19A0420A4BA3600A371E3"
+            BuildableName = "FlipperKit.framework"
+            BlueprintName = "FlipperKit"
+            ReferencedContainer = "container:FlipperKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/iOS/Podfile
+++ b/iOS/Podfile
@@ -1,7 +1,7 @@
 # Uncomment the next line to define a global platform for your project
 source 'https://github.com/facebook/Sonar.git'
 source 'https://github.com/CocoaPods/Specs'
-platform :ios, '9.0'
+platform :ios, '10.0'
 swift_version = "4.1"
 target 'FlipperKit' do
   # Uncomment the next line if you're using Swift or would like to use dynamic frameworks
@@ -11,10 +11,10 @@ target 'FlipperKit' do
   pod 'Flipper', :path => '../Flipper.podspec'
   # Pods for SonarKit
   pod 'Flipper-PeerTalk', '~>0.0'
-  pod 'Flipper-RSocket', '~>0.10'
+  pod 'Flipper-RSocket', '~>1.1'
   pod 'DoubleConversion', '~>1.1'
   pod 'glog', '~>0.3'
-  pod 'Flipper-Folly', '~>1.2'
+  pod 'Flipper-Folly', '~>2.2'
   pod 'CocoaAsyncSocket', '~>7.6'
 
 end

--- a/iOS/Podfile.lock
+++ b/iOS/Podfile.lock
@@ -1,0 +1,68 @@
+PODS:
+  - boost-for-react-native (1.63.0)
+  - CocoaAsyncSocket (7.6.4)
+  - CocoaLibEvent (1.0.0)
+  - DoubleConversion (1.1.5)
+  - Flipper (0.45.0):
+    - Flipper-Folly (~> 2.2)
+    - Flipper-RSocket (~> 1.1)
+  - Flipper-DoubleConversion (1.1.7)
+  - Flipper-Folly (2.2.0):
+    - boost-for-react-native
+    - CocoaLibEvent (~> 1.0)
+    - Flipper-DoubleConversion
+    - Flipper-Glog
+    - OpenSSL-Universal (= 1.0.2.19)
+  - Flipper-Glog (0.3.6)
+  - Flipper-PeerTalk (0.0.4)
+  - Flipper-RSocket (1.1.0):
+    - Flipper-Folly (~> 2.2)
+  - glog (0.3.4)
+  - OpenSSL-Universal (1.0.2.19):
+    - OpenSSL-Universal/Static (= 1.0.2.19)
+  - OpenSSL-Universal/Static (1.0.2.19)
+
+DEPENDENCIES:
+  - CocoaAsyncSocket (~> 7.6)
+  - DoubleConversion (~> 1.1)
+  - Flipper (from `../Flipper.podspec`)
+  - Flipper-Folly (~> 2.2)
+  - Flipper-PeerTalk (~> 0.0)
+  - Flipper-RSocket (~> 1.1)
+  - glog (~> 0.3)
+
+SPEC REPOS:
+  https://github.com/CocoaPods/Specs:
+    - boost-for-react-native
+    - CocoaAsyncSocket
+    - CocoaLibEvent
+    - DoubleConversion
+    - Flipper-DoubleConversion
+    - Flipper-Folly
+    - Flipper-Glog
+    - Flipper-PeerTalk
+    - Flipper-RSocket
+    - glog
+    - OpenSSL-Universal
+
+EXTERNAL SOURCES:
+  Flipper:
+    :path: "../Flipper.podspec"
+
+SPEC CHECKSUMS:
+  boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
+  CocoaAsyncSocket: 694058e7c0ed05a9e217d1b3c7ded962f4180845
+  CocoaLibEvent: 2fab71b8bd46dd33ddb959f7928ec5909f838e3f
+  DoubleConversion: e22e0762848812a87afd67ffda3998d9ef29170c
+  Flipper: 18ad3ac4a8e41db9db2ef72239b8ff4eab5b3522
+  Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
+  Flipper-Folly: c12092ea368353b58e992843a990a3225d4533c3
+  Flipper-Glog: 1dfd6abf1e922806c52ceb8701a3599a79a200a6
+  Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
+  Flipper-RSocket: 64e7431a55835eb953b0bf984ef3b90ae9fdddd7
+  glog: 1de0bb937dccdc981596d3b5825ebfb765017ded
+  OpenSSL-Universal: 8b48cc0d10c1b2923617dfe5c178aa9ed2689355
+
+PODFILE CHECKSUM: c0e22ce9737ae531ae7290d9e16882825f8ebed9
+
+COCOAPODS: 1.9.0


### PR DESCRIPTION
## Summary

I was unable to build `FlipperKit` for iOS. It looks like there's a dependency mismatch. See https://github.com/facebook/flipper/issues/1226

## Changelog

 - Updated Podfile dependencies to latest versions
 - Added a default scheme for building
 - Updated the iOS platform version to iOS 10.0 from 9
 - Updated filenames to match the new filenames

## Test Plan

Was able to successfully build:

Fixes #1226 
<img width="2032" alt="Screen Shot 2020-06-05 at 10 49 54 AM" src="https://user-images.githubusercontent.com/35780254/83890945-76107600-a71a-11ea-82fd-2d060729fa75.png">

<img width="2032" alt="Screen Shot 2020-06-05 at 10 50 25 AM" src="https://user-images.githubusercontent.com/35780254/83890931-71e45880-a71a-11ea-8b9b-4a8ebb292863.png">


