### PR TITLE
Bump plugin versions to match Flipper version

### DIFF
--- a/desktop/plugins/cpu/package.json
+++ b/desktop/plugins/cpu/package.json
@@ -2,7 +2,7 @@
   "$schema": "https://fbflipper.com/schemas/plugin-package/v2.json",
   "name": "flipper-plugin-device-cpu",
   "id": "DeviceCPU",
-  "version": "1.0.0",
+  "version": "0.46.0",
   "main": "dist/bundle.js",
   "flipperBundlerEntry": "index.tsx",
   "license": "MIT",

--- a/desktop/plugins/crash_reporter/package.json
+++ b/desktop/plugins/crash_reporter/package.json
@@ -2,7 +2,7 @@
   "$schema": "https://fbflipper.com/schemas/plugin-package/v2.json",
   "name": "flipper-plugin-crash-reporter",
   "id": "CrashReporter",
-  "version": "0.1.0",
+  "version": "0.46.0",
   "description": "A plugin which will display a crash",
   "main": "dist/bundle.js",
   "flipperBundlerEntry": "index.js",

--- a/desktop/plugins/databases/package.json
+++ b/desktop/plugins/databases/package.json
@@ -2,7 +2,7 @@
   "$schema": "https://fbflipper.com/schemas/plugin-package/v2.json",
   "name": "flipper-plugin-databases",
   "id": "Databases",
-  "version": "1.0.0",
+  "version": "0.46.0",
   "title": "Databases",
   "icon": "internet",
   "main": "dist/bundle.js",

--- a/desktop/plugins/example/package.json
+++ b/desktop/plugins/example/package.json
@@ -2,7 +2,7 @@
   "$schema": "https://fbflipper.com/schemas/plugin-package/v2.json",
   "name": "flipper-plugin-example",
   "id": "flipper-plugin-example",
-  "version": "1.0.0",
+  "version": "0.46.0",
   "description": "An example for a Flipper plugin",
   "main": "dist/bundle.js",
   "flipperBundlerEntry": "index.tsx",

--- a/desktop/plugins/fresco/package.json
+++ b/desktop/plugins/fresco/package.json
@@ -2,7 +2,7 @@
   "$schema": "https://fbflipper.com/schemas/plugin-package/v2.json",
   "name": "flipper-plugin-fresco",
   "id": "Fresco",
-  "version": "1.0.0",
+  "version": "0.46.0",
   "main": "dist/bundle.js",
   "flipperBundlerEntry": "index.tsx",
   "license": "MIT",

--- a/desktop/plugins/hermesdebuggerrn/package.json
+++ b/desktop/plugins/hermesdebuggerrn/package.json
@@ -2,7 +2,7 @@
   "$schema": "https://fbflipper.com/schemas/plugin-package/v2.json",
   "name": "flipper-plugin-hermesdebuggerrn",
   "id": "flipper-plugin-hermesdebuggerrn",
-  "version": "1.0.0",
+  "version": "0.46.0",
   "main": "dist/bundle.js",
   "flipperBundlerEntry": "index.tsx",
   "license": "MIT",

--- a/desktop/plugins/kaios-allocations/package.json
+++ b/desktop/plugins/kaios-allocations/package.json
@@ -2,7 +2,7 @@
   "$schema": "https://fbflipper.com/schemas/plugin-package/v2.json",
   "name": "flipper-plugin-kaios-big-allocations",
   "id": "flipper-plugin-kaios-big-allocations",
-  "version": "1.0.0",
+  "version": "0.46.0",
   "main": "dist/bundle.js",
   "flipperBundlerEntry": "index.tsx",
   "license": "MIT",

--- a/desktop/plugins/kaios-ram/package.json
+++ b/desktop/plugins/kaios-ram/package.json
@@ -2,7 +2,7 @@
   "$schema": "https://fbflipper.com/schemas/plugin-package/v2.json",
   "name": "flipper-plugin-kaios-graphs",
   "id": "kaios-graphs",
-  "version": "1.0.0",
+  "version": "0.46.0",
   "main": "dist/bundle.js",
   "flipperBundlerEntry": "index.tsx",
   "license": "MIT",

--- a/desktop/plugins/layout/package.json
+++ b/desktop/plugins/layout/package.json
@@ -2,7 +2,7 @@
   "$schema": "https://fbflipper.com/schemas/plugin-package/v2.json",
   "name": "flipper-plugin-inspector",
   "id": "Inspector",
-  "version": "1.0.0",
+  "version": "0.46.0",
   "main": "dist/bundle.js",
   "flipperBundlerEntry": "index.tsx",
   "license": "MIT",

--- a/desktop/plugins/leak_canary/package.json
+++ b/desktop/plugins/leak_canary/package.json
@@ -2,7 +2,7 @@
   "$schema": "https://fbflipper.com/schemas/plugin-package/v2.json",
   "name": "flipper-plugin-leak-canary",
   "id": "LeakCanary",
-  "version": "1.0.0",
+  "version": "0.46.0",
   "main": "dist/bundle.js",
   "flipperBundlerEntry": "index.tsx",
   "license": "MIT",

--- a/desktop/plugins/logs/package.json
+++ b/desktop/plugins/logs/package.json
@@ -2,7 +2,7 @@
   "$schema": "https://fbflipper.com/schemas/plugin-package/v2.json",
   "name": "flipper-plugin-device-logs",
   "id": "DeviceLogs",
-  "version": "1.0.0",
+  "version": "0.46.0",
   "main": "dist/bundle.js",
   "flipperBundlerEntry": "index.tsx",
   "license": "MIT",

--- a/desktop/plugins/navigation/package.json
+++ b/desktop/plugins/navigation/package.json
@@ -2,7 +2,7 @@
   "$schema": "https://fbflipper.com/schemas/plugin-package/v2.json",
   "name": "flipper-plugin-navigation",
   "id": "flipper-plugin-navigation",
-  "version": "0.0.1",
+  "version": "0.46.0",
   "main": "dist/bundle.js",
   "flipperBundlerEntry": "index.tsx",
   "license": "MIT",

--- a/desktop/plugins/network/package.json
+++ b/desktop/plugins/network/package.json
@@ -7,7 +7,7 @@
   "title": "Network",
   "description": "Use the Network inspector to inspect outgoing network traffic in your apps.",
   "icon": "internet",
-  "version": "1.0.0",
+  "version": "0.46.0",
   "license": "MIT",
   "keywords": [
     "flipper-plugin"

--- a/desktop/plugins/reactdevtools/package.json
+++ b/desktop/plugins/reactdevtools/package.json
@@ -2,7 +2,7 @@
   "$schema": "https://fbflipper.com/schemas/plugin-package/v2.json",
   "name": "flipper-plugin-react-devtools",
   "id": "flipper-plugin-react-devtools",
-  "version": "1.0.1",
+  "version": "0.46.0",
   "main": "dist/bundle.js",
   "flipperBundlerEntry": "index.tsx",
   "license": "MIT",

--- a/desktop/plugins/rn-tic-tac-toe/package.json
+++ b/desktop/plugins/rn-tic-tac-toe/package.json
@@ -2,7 +2,7 @@
   "$schema": "https://fbflipper.com/schemas/plugin-package/v2.json",
   "name": "flipper-plugin-react-native-tic-tac-toe",
   "id": "ReactNativeTicTacToe",
-  "version": "1.0.0",
+  "version": "0.46.0",
   "main": "dist/bundle.js",
   "flipperBundlerEntry": "index.tsx",
   "license": "MIT",

--- a/desktop/plugins/sandbox/package.json
+++ b/desktop/plugins/sandbox/package.json
@@ -3,7 +3,7 @@
   "name": "flipper-plugin-sandbox",
   "id": "Sandbox",
   "title": "Sandbox",
-  "version": "1.0.0",
+  "version": "0.46.0",
   "main": "dist/bundle.js",
   "flipperBundlerEntry": "index.tsx",
   "license": "MIT",

--- a/desktop/plugins/seamammals/package.json
+++ b/desktop/plugins/seamammals/package.json
@@ -3,7 +3,7 @@
   "name": "flipper-plugin-sea-mammals",
   "id": "sea-mammals",
   "private": true,
-  "version": "2.0.0",
+  "version": "0.46.0",
   "main": "dist/bundle.js",
   "flipperBundlerEntry": "src/index.tsx",
   "license": "MIT",

--- a/desktop/plugins/sections/package.json
+++ b/desktop/plugins/sections/package.json
@@ -7,7 +7,7 @@
     "email": "oncall+ios_componentkit@xmail.facebook.com",
     "url": "https://fb.workplace.com/groups/componentkit/"
   },
-  "version": "1.0.0",
+  "version": "0.46.0",
   "main": "dist/bundle.js",
   "flipperBundlerEntry": "index.js",
   "license": "MIT",

--- a/desktop/plugins/shared_preferences/package.json
+++ b/desktop/plugins/shared_preferences/package.json
@@ -2,7 +2,7 @@
   "$schema": "https://fbflipper.com/schemas/plugin-package/v2.json",
   "name": "flipper-plugin-preferences",
   "id": "Preferences",
-  "version": "1.0.0",
+  "version": "0.46.0",
   "main": "dist/bundle.js",
   "flipperBundlerEntry": "index.js",
   "license": "MIT",

--- a/desktop/scripts/paths.ts
+++ b/desktop/scripts/paths.ts
@@ -14,6 +14,7 @@ export const appDir = path.join(rootDir, 'app');
 export const staticDir = path.join(rootDir, 'static');
 export const defaultPluginsIndexDir = path.join(staticDir, 'defaultPlugins');
 export const pluginsDir = path.join(rootDir, 'plugins');
+export const fbPluginsDir = path.join(pluginsDir, 'fb');
 export const headlessDir = path.join(rootDir, 'headless');
 export const distDir = path.resolve(rootDir, '..', 'dist');
 export const babelTransformationsDir = path.resolve(


### PR DESCRIPTION
Summary: Bumped versions of all plugins to match current Flipper version 0.46.0.

Reviewed By: mweststrate

Differential Revision: D22042959

