### PR TITLE
escape app name to account for special characters in name (closes #1252)

### DIFF
--- a/desktop/app/src/utils/__tests__/clientUtils.node.tsx
+++ b/desktop/app/src/utils/__tests__/clientUtils.node.tsx
@@ -48,3 +48,21 @@ test('client id deconstruction error logged', () => {
   });
   expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
 });
+
+test('special characters in app name handled correctly', () => {
+  const consoleErrorSpy = jest.spyOn(global.console, 'error');
+
+  const testClient = {
+    app: '#myGreat#App&',
+    os: 'iOS',
+    device: 'iPhone Simulator',
+    device_id: 'EC431B79-69F1-4705-9FE5-9AE5D96378E1',
+  };
+  const clientId = buildClientId(testClient);
+
+  const deconstructedClientId = deconstructClientId(clientId);
+
+  expect(deconstructedClientId).toStrictEqual(testClient);
+
+  expect(consoleErrorSpy).toHaveBeenCalledTimes(0);
+});

--- a/desktop/app/src/utils/clientUtils.tsx
+++ b/desktop/app/src/utils/clientUtils.tsx
@@ -72,14 +72,16 @@ export function buildClientId(clientInfo: {
       );
     }
   }
-  return `${clientInfo.app}#${clientInfo.os}#${clientInfo.device}#${clientInfo.device_id}`;
+  const escapedName = escape(clientInfo.app);
+  return `${escapedName}#${clientInfo.os}#${clientInfo.device}#${clientInfo.device_id}`;
 }
 
 export function deconstructClientId(clientId: string): ClientIdConstituents {
   if (!clientId || clientId.split('#').length !== 4) {
     console.error(`Attempted to deconstruct invalid clientId: "${clientId}"`);
   }
-  const [app, os, device, device_id] = clientId.split('#');
+  let [app, os, device, device_id] = clientId.split('#');
+  app = unescape(app);
   return {
     app,
     os,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
App Names can contain special characters. Escape them (and unescape later) so that device ID strings don't break. 

Simpler is better - thanks to @mweststrate for keeping me out of the rabbit hole
## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. This should just be a brief oneline we can mention in our release notes: https://github.com/facebook/flipper/releases -->
Escape app name to account for special characters in name
## Test Plan
Added test to test character escaping: `cd desktop && yarn test -- -i app/src/utils/__tests__/clientUtils.node.tsx`
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI / output of the test runner and how you invoked it. -->

closes #1252 