### PR TITLE
[flipper-pkg] When init, search for first level subdirectory

### DIFF
--- a/desktop/pkg/src/commands/init.ts
+++ b/desktop/pkg/src/commands/init.ts
@@ -130,9 +130,14 @@ async function verifyFlipperSearchPath(pluginDirectory: string) {
   } else {
     const config = JSON.parse(fs.readFileSync(flipperConfigPath, 'utf8'));
     const pluginPaths: string[] = config.pluginPaths ?? [];
-    const isInSearchPath = pluginPaths.some(
-      (p) => pluginDirectory === path.resolve(p.replace(/^~/, homedir())),
-    );
+    const isInSearchPath = pluginPaths.some((p) => {
+      // Match: exact path and first level subdirectory
+      const relativePath = path.relative(
+        path.resolve(p.replace(/^~/, homedir())),
+        pluginDirectory,
+      );
+      return relativePath.split('/').length === 1;
+    });
     if (!isInSearchPath) {
       if (
         (


### PR DESCRIPTION
## Summary

When running `flipper-pkg init path/plugin`, this allows to skip the `Do you wanna add this path to watching in Flipper config?`, if the path is direct first level subdirectory of any added path from Flipper `pluginPaths: []`

## Changelog

- Improve matching for watched pluginPaths when initialising new plugin

## Test Plan

1. Create folder: `~/flipper-plugins`
2. Add this folder to Flipper config `pluginPaths: ['~/flipper-plugins']`
3. Create new subfolder `test-plugin`
4. Run `flipper-pkg init test-plugin`
5. It should not ask to add this folder to pluginPaths

To verify it only works for first level subdirectory, create another folder: `/deep/test-plugin2` and re-run steps with it.

This should also keep working if we specify exactly the path for the plugin itself.

