### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,11 +6,9 @@ updates:
     interval: weekly
     time: '13:00'
   open-pull-requests-limit: 10
-  versioning-strategy: increase-if-necessary
 - package-ecosystem: cargo
   directory: "/packer"
   schedule:
     interval: weekly
     time: '13:00'
   open-pull-requests-limit: 10
-  versioning-strategy: increase-if-necessary


### PR DESCRIPTION
Summary:
Ewww, dependabot for GitHub is incompatible with the file format documented on dependabot.com.
So the current file is invalid:

![Screenshot 2020-06-26 15 04 59](https://user-images.githubusercontent.com/9906/85865837-6b4b7d00-b7be-11ea-9e5c-49007733a0e1.png)

Test Plan:
hopeitwork

