### PR TITLE
Fix ApplicationWrapper activity weakRef leak

### DIFF
--- a/android/src/main/java/com/facebook/flipper/plugins/inspector/ApplicationWrapper.java
+++ b/android/src/main/java/com/facebook/flipper/plugins/inspector/ApplicationWrapper.java
@@ -54,19 +54,7 @@ public class ApplicationWrapper implements Application.ActivityLifecycleCallback
   public void onActivityResumed(Activity activity) {}
 
   @Override
-  public void onActivityPaused(Activity activity) {
-    if (activity.isFinishing()) {
-      final Iterator<WeakReference<Activity>> activityIterator = mActivities.iterator();
-
-      while (activityIterator.hasNext()) {
-        if (activityIterator.next().get() == activity) {
-          activityIterator.remove();
-        }
-      }
-
-      notifyListener();
-    }
-  }
+  public void onActivityPaused(Activity activity) {}
 
   @Override
   public void onActivityStopped(Activity activity) {}
@@ -75,7 +63,16 @@ public class ApplicationWrapper implements Application.ActivityLifecycleCallback
   public void onActivitySaveInstanceState(Activity activity, Bundle outState) {}
 
   @Override
-  public void onActivityDestroyed(Activity activity) {}
+  public void onActivityDestroyed(Activity activity) {
+    final Iterator<WeakReference<Activity>> activityIterator = mActivities.iterator();
+
+    while (activityIterator.hasNext()) {
+      if (activityIterator.next().get() == activity) {
+        activityIterator.remove();
+      }
+    }
+    notifyListener();
+  }
 
   private void notifyListener() {
     if (mListener != null) {


### PR DESCRIPTION
Fix for #1300

The weak refs were not being cleared in two cases:

- On config changes, isFinishing() would be false in onPause()
- When calling finish() from Activity.onCreate(), onPause() isn't guaranteed to be called.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. This should just be a brief oneline we can mention in our release notes: https://github.com/facebook/flipper/releases -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI / output of the test runner and how you invoked it. -->

