### PR TITLE
docs: remove broken image from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,8 +29,6 @@ We actively welcome your pull requests.
 
 ### Verifying changes to Flipper
 
-![GitHub Actions artifact downloads](static/actions-artifacts.png)
-
 After opening a pull request or pushing to a branch, the CI will generate
 build artifacts for you for Linux, MacOS and Windows. You can download them
 from the GitHub Actions checks on your Pull Request.


### PR DESCRIPTION
## Summary

The image for 'GitHub Actions artifact downloads' in `CONTRIBUTING.md` is broken. The file `static/actions-artifacts.png` referenced by the image link is not in the repo. The broken image should not be displayed until a proper image is available.

Fixes #1394

### Screenshot
![image](https://user-images.githubusercontent.com/49580849/88140196-e4e45880-cc0e-11ea-9b3e-2a490b6439f9.png)

## Changelog

Broken link from `CONTRIBUTING.md` removed.

## Test Plan

Visit [`CONTRIBUTING.md`](https://github.com/facebook/flipper/blob/master/CONTRIBUTING.md)
