### PR TITLE
Updated custom-ports.mdx

### DIFF
--- a/docs/custom-ports.mdx
+++ b/docs/custom-ports.mdx
@@ -14,7 +14,7 @@ To run the desktop app using custom ports:
 FLIPPER_PORTS=1111,2222 ./flipper
 ```
 
-To configure the Android SDK for custom ports, set the `flipper.ports` prop to your chosen ports `1111,2222` like so, and then launch the Android app.
+To configure the Android SDK for custom ports, set the `flipper.ports` prop to your chosen ports `1111,2222` like so, and then launch the Android app:
 
 ```
 adb shell su 0 setprop flipper.ports 1111,2222


### PR DESCRIPTION
Usually ':' is used before the command



## Summary

Usually while presenting a command ':' is used instead of that '.' was used.

