### PR TITLE
Add HTTP Status Code to mock response for Route

### DIFF
--- a/android/plugins/network/src/main/java/com/facebook/flipper/plugins/network/FlipperOkhttpInterceptor.java
+++ b/android/plugins/network/src/main/java/com/facebook/flipper/plugins/network/FlipperOkhttpInterceptor.java
@@ -228,10 +228,12 @@ public class FlipperOkhttpInterceptor
     if (TextUtils.isEmpty(requestUrl) || TextUtils.isEmpty(method)) {
       return null;
     }
+    final int statusCode = route.getInt("status");
 
     final ResponseInfo mockResponse = new ResponseInfo();
     mockResponse.body = data.getBytes();
     mockResponse.statusCode = HttpURLConnection.HTTP_OK;
+    mockResponse.statusCode = statusCode;
     mockResponse.statusReason = "OK";
     if (headersArray != null) {
       final List<NetworkReporter.Header> headers = new ArrayList<>();

--- a/desktop/plugins/network/MockResponseDetails.tsx
+++ b/desktop/plugins/network/MockResponseDetails.tsx
@@ -239,7 +239,7 @@ export function MockResponseDetails({id, route, isDuplicated}: Props) {
   );
   const [nextHeaderId, setNextHeaderId] = useState(0);
 
-  const {requestUrl, requestMethod, responseData} = route;
+  const {requestUrl, requestMethod, responseData, responseStatus} = route;
   return (
     <Container>
       <FlexRow style={{width: '100%'}}>
@@ -260,6 +260,18 @@ export function MockResponseDetails({id, route, isDuplicated}: Props) {
           onChange={(event) =>
             networkRouteManager.modifyRoute(id, {
               requestUrl: event.target.value,
+            })
+          }
+        />
+      </FlexRow>
+      <FlexRow style={{width: '20%'}}>
+        <StyledInput
+          type="text"
+          placeholder="STATUS"
+          value={responseStatus}
+          onChange={(event) =>
+            networkRouteManager.modifyRoute(id, {
+              responseStatus: event.target.value,
             })
           }
         />

--- a/desktop/plugins/network/index.tsx
+++ b/desktop/plugins/network/index.tsx
@@ -235,6 +235,7 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
               requestMethod: 'GET',
               responseData: '',
               responseHeaders: {},
+              responseStatus: "200",
             };
             draftState.nextRouteId = nextRouteId + 1;
           }),
@@ -354,6 +355,7 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
           method: route.requestMethod,
           data: route.responseData,
           headers: [...Object.values(route.responseHeaders)],
+          status: route.responseStatus,
         })),
       });
     }

--- a/desktop/plugins/network/index.tsx
+++ b/desktop/plugins/network/index.tsx
@@ -7,9 +7,9 @@
  * @format
  */
 
-import { padStart } from 'lodash';
-import React, { createContext } from 'react';
-import { MenuItemConstructorOptions } from 'electron';
+import {padStart} from 'lodash';
+import React, {createContext} from 'react';
+import {MenuItemConstructorOptions} from 'electron';
 
 import {
   ContextMenu,
@@ -30,25 +30,25 @@ import {
   TableBodyRow,
   produce,
 } from 'flipper';
-import { Request, RequestId, Response, Route } from './types';
-import { convertRequestToCurlCommand, getHeaderValue, decodeBody } from './utils';
+import {Request, RequestId, Response, Route} from './types';
+import {convertRequestToCurlCommand, getHeaderValue, decodeBody} from './utils';
 import RequestDetails from './RequestDetails';
-import { clipboard } from 'electron';
-import { URL } from 'url';
-import { DefaultKeyboardAction } from 'app/src/MenuBar';
-import { MockResponseDialog } from './MockResponseDialog';
+import {clipboard} from 'electron';
+import {URL} from 'url';
+import {DefaultKeyboardAction} from 'app/src/MenuBar';
+import {MockResponseDialog} from './MockResponseDialog';
 
 const LOCALSTORAGE_MOCK_ROUTE_LIST_KEY = '__NETWORK_CACHED_MOCK_ROUTE_LIST';
 
 type PersistedState = {
-  requests: { [id: string]: Request };
-  responses: { [id: string]: Response };
+  requests: {[id: string]: Request};
+  responses: {[id: string]: Response};
 };
 
 type State = {
   selectedIds: Array<RequestId>;
   searchTerm: string;
-  routes: { [id: string]: Route };
+  routes: {[id: string]: Route};
   nextRouteId: number;
   isMockResponseSupported: boolean;
   showMockResponseDialog: boolean;
@@ -65,23 +65,23 @@ const COLUMN_SIZE = {
 };
 
 const COLUMN_ORDER = [
-  { key: 'requestTimestamp', visible: true },
-  { key: 'responseTimestamp', visible: false },
-  { key: 'domain', visible: true },
-  { key: 'method', visible: true },
-  { key: 'status', visible: true },
-  { key: 'size', visible: true },
-  { key: 'duration', visible: true },
+  {key: 'requestTimestamp', visible: true},
+  {key: 'responseTimestamp', visible: false},
+  {key: 'domain', visible: true},
+  {key: 'method', visible: true},
+  {key: 'status', visible: true},
+  {key: 'size', visible: true},
+  {key: 'duration', visible: true},
 ];
 
 const COLUMNS = {
-  requestTimestamp: { value: 'Request Time' },
-  responseTimestamp: { value: 'Response Time' },
-  domain: { value: 'Domain' },
-  method: { value: 'Method' },
-  status: { value: 'Status' },
-  size: { value: 'Size' },
-  duration: { value: 'Duration' },
+  requestTimestamp: {value: 'Request Time'},
+  responseTimestamp: {value: 'Response Time'},
+  domain: {value: 'Domain'},
+  method: {value: 'Method'},
+  status: {value: 'Status'},
+  size: {value: 'Size'},
+  duration: {value: 'Duration'},
 };
 
 const mockingStyle = {
@@ -115,9 +115,9 @@ export interface NetworkRouteManager {
   removeRoute(id: string): void;
 }
 const nullNetworkRouteManager: NetworkRouteManager = {
-  addRoute() { },
-  modifyRoute(_id: string, _routeChange: Partial<Route>) { },
-  removeRoute(_id: string) { },
+  addRoute() {},
+  modifyRoute(_id: string, _routeChange: Partial<Route>) {},
+  removeRoute(_id: string) {},
 };
 export const NetworkRouteContext = createContext<NetworkRouteManager>(
   nullNetworkRouteManager,
@@ -139,8 +139,8 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
     ) {
       return previous + (values.status >= 400 ? 1 : 0);
     },
-      0);
-    return Promise.resolve({ NUMBER_NETWORK_FAILURES: failures });
+    0);
+    return Promise.resolve({NUMBER_NETWORK_FAILURES: failures});
   }
 
   static persistedStateReducer(
@@ -151,11 +151,11 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
     switch (method) {
       case 'newRequest':
         return Object.assign({}, persistedState, {
-          requests: { ...persistedState.requests, [data.id]: data as Request },
+          requests: {...persistedState.requests, [data.id]: data as Request},
         });
       case 'newResponse':
         return Object.assign({}, persistedState, {
-          responses: { ...persistedState.responses, [data.id]: data as Response },
+          responses: {...persistedState.responses, [data.id]: data as Response},
         });
       default:
         return persistedState;
@@ -247,7 +247,7 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
             if (!draftState.routes.hasOwnProperty(id)) {
               return;
             }
-            draftState.routes[id] = { ...draftState.routes[id], ...routeChange };
+            draftState.routes[id] = {...draftState.routes[id], ...routeChange};
             informClientMockChange(draftState.routes);
           }),
         );
@@ -265,7 +265,7 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
     };
   }
 
-  teardown() { }
+  teardown() {}
 
   onKeyboardAction = (action: string) => {
     if (action === 'clear') {
@@ -295,11 +295,11 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
   };
 
   onRowHighlighted = (selectedIds: Array<RequestId>) =>
-    this.setState({ selectedIds });
+    this.setState({selectedIds});
 
   copyRequestCurlCommand = () => {
-    const { requests } = this.props.persistedState;
-    const { selectedIds } = this.state;
+    const {requests} = this.props.persistedState;
+    const {selectedIds} = this.state;
     // Ensure there is only one row highlighted.
     if (selectedIds.length !== 1) {
       return;
@@ -314,13 +314,13 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
   };
 
   clearLogs = () => {
-    this.setState({ selectedIds: [] });
-    this.props.setPersistedState({ responses: {}, requests: {} });
+    this.setState({selectedIds: []});
+    this.props.setPersistedState({responses: {}, requests: {}});
   };
 
-  informClientMockChange = (routes: { [id: string]: Route }) => {
-    const existedIdSet: { [id: string]: { [method: string]: boolean } } = {};
-    const filteredRoutes: { [id: string]: Route } = Object.entries(routes).reduce(
+  informClientMockChange = (routes: {[id: string]: Route}) => {
+    const existedIdSet: {[id: string]: {[method: string]: boolean}} = {};
+    const filteredRoutes: {[id: string]: Route} = Object.entries(routes).reduce(
       (accRoutes, [id, route]) => {
         if (existedIdSet.hasOwnProperty(route.requestUrl)) {
           if (
@@ -332,12 +332,12 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
             ...existedIdSet[route.requestUrl],
             [route.requestMethod]: true,
           };
-          return Object.assign({ [id]: route }, accRoutes);
+          return Object.assign({[id]: route}, accRoutes);
         } else {
           existedIdSet[route.requestUrl] = {
             [route.requestMethod]: true,
           };
-          return Object.assign({ [id]: route }, accRoutes);
+          return Object.assign({[id]: route}, accRoutes);
         }
       },
       {},
@@ -362,16 +362,16 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
   };
 
   onMockButtonPressed = () => {
-    this.setState({ showMockResponseDialog: true });
+    this.setState({showMockResponseDialog: true});
   };
 
   onCloseButtonPressed = () => {
-    this.setState({ showMockResponseDialog: false });
+    this.setState({showMockResponseDialog: false});
   };
 
   renderSidebar = () => {
-    const { requests, responses } = this.props.persistedState;
-    const { selectedIds } = this.state;
+    const {requests, responses} = this.props.persistedState;
+    const {selectedIds} = this.state;
     const selectedId = selectedIds.length === 1 ? selectedIds[0] : null;
 
     if (!selectedId) {
@@ -391,7 +391,7 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
   };
 
   render() {
-    const { requests, responses } = this.props.persistedState;
+    const {requests, responses} = this.props.persistedState;
     const {
       selectedIds,
       searchTerm,
@@ -425,9 +425,9 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
 }
 
 type NetworkTableProps = {
-  requests: { [id: string]: Request };
-  responses: { [id: string]: Response };
-  routes: { [id: string]: Route };
+  requests: {[id: string]: Request};
+  responses: {[id: string]: Response};
+  routes: {[id: string]: Route};
   clear: () => void;
   copyRequestCurlCommand: () => void;
   onRowHighlighted: (keys: TableHighlightedRows) => void;
@@ -441,7 +441,7 @@ type NetworkTableProps = {
 
 type NetworkTableState = {
   sortedRows: TableRows;
-  routes: { [id: string]: Route };
+  routes: {[id: string]: Route};
 };
 
 function formatTimestamp(timestamp: number): string {
@@ -477,11 +477,11 @@ function buildRow(
 ## Request
 HTTP ${request.method} ${request.url}
 ${request.headers
-      .map(
-        ({ key, value }: { key: string; value: string }): string =>
-          `${key}: ${String(value)}`,
-      )
-      .join('\n')}`;
+  .map(
+    ({key, value}: {key: string; value: string}): string =>
+      `${key}: ${String(value)}`,
+  )
+  .join('\n')}`;
 
   const requestData = request.data ? decodeBody(request) : null;
   const responseData = response && response.data ? decodeBody(response) : null;
@@ -496,11 +496,11 @@ ${request.headers
 ## Response
 HTTP ${response.status} ${response.reason}
 ${response.headers
-        .map(
-          ({ key, value }: { key: string; value: string }): string =>
-            `${key}: ${String(value)}`,
-        )
-        .join('\n')}`;
+  .map(
+    ({key, value}: {key: string; value: string}): string =>
+      `${key}: ${String(value)}`,
+  )
+  .join('\n')}`;
   }
 
   if (responseData) {
@@ -557,8 +557,8 @@ ${response.headers
 
 function calculateState(
   props: {
-    requests: { [id: string]: Request };
-    responses: { [id: string]: Response };
+    requests: {[id: string]: Request};
+    responses: {[id: string]: Response};
   },
   nextProps: NetworkTableProps,
   rows: TableRows = [],
@@ -614,7 +614,7 @@ class NetworkTable extends PureComponent<NetworkTableProps, NetworkTableState> {
 
   constructor(props: NetworkTableProps) {
     super(props);
-    this.state = calculateState({ requests: {}, responses: {} }, props);
+    this.state = calculateState({requests: {}, responses: {}}, props);
   }
 
   UNSAFE_componentWillReceiveProps(nextProps: NetworkTableProps) {
@@ -629,18 +629,18 @@ class NetworkTable extends PureComponent<NetworkTableProps, NetworkTableState> {
       | 'checkbox'
       | 'radio';
     const separator: ContextMenuType = 'separator';
-    const { clear, copyRequestCurlCommand, highlightedRows } = this.props;
+    const {clear, copyRequestCurlCommand, highlightedRows} = this.props;
     const highlightedMenuItems =
       highlightedRows && highlightedRows.size === 1
         ? [
-          {
-            type: separator,
-          },
-          {
-            label: 'Copy as cURL',
-            click: copyRequestCurlCommand,
-          },
-        ]
+            {
+              type: separator,
+            },
+            {
+              label: 'Copy as cURL',
+              click: copyRequestCurlCommand,
+            },
+          ]
         : [];
 
     return highlightedMenuItems.concat([
@@ -715,7 +715,7 @@ class StatusColumn extends PureComponent<{
   children?: number;
 }> {
   render() {
-    const { children } = this.props;
+    const {children} = this.props;
     let glyph;
 
     if (children != null && children >= 400 && children < 600) {
@@ -742,7 +742,7 @@ class DurationColumn extends PureComponent<{
   });
 
   render() {
-    const { request, response } = this.props;
+    const {request, response} = this.props;
     const duration = response
       ? response.timestamp - request.timestamp
       : undefined;
@@ -764,7 +764,7 @@ class SizeColumn extends PureComponent<{
   });
 
   render() {
-    const { response } = this.props;
+    const {response} = this.props;
     if (response) {
       const text = formatBytes(this.getResponseLength(response));
       return <SizeColumn.Text>{text}</SizeColumn.Text>;

--- a/desktop/plugins/network/index.tsx
+++ b/desktop/plugins/network/index.tsx
@@ -7,9 +7,9 @@
  * @format
  */
 
-import {padStart} from 'lodash';
-import React, {createContext} from 'react';
-import {MenuItemConstructorOptions} from 'electron';
+import { padStart } from 'lodash';
+import React, { createContext } from 'react';
+import { MenuItemConstructorOptions } from 'electron';
 
 import {
   ContextMenu,
@@ -30,25 +30,25 @@ import {
   TableBodyRow,
   produce,
 } from 'flipper';
-import {Request, RequestId, Response, Route} from './types';
-import {convertRequestToCurlCommand, getHeaderValue, decodeBody} from './utils';
+import { Request, RequestId, Response, Route } from './types';
+import { convertRequestToCurlCommand, getHeaderValue, decodeBody } from './utils';
 import RequestDetails from './RequestDetails';
-import {clipboard} from 'electron';
-import {URL} from 'url';
-import {DefaultKeyboardAction} from 'app/src/MenuBar';
-import {MockResponseDialog} from './MockResponseDialog';
+import { clipboard } from 'electron';
+import { URL } from 'url';
+import { DefaultKeyboardAction } from 'app/src/MenuBar';
+import { MockResponseDialog } from './MockResponseDialog';
 
 const LOCALSTORAGE_MOCK_ROUTE_LIST_KEY = '__NETWORK_CACHED_MOCK_ROUTE_LIST';
 
 type PersistedState = {
-  requests: {[id: string]: Request};
-  responses: {[id: string]: Response};
+  requests: { [id: string]: Request };
+  responses: { [id: string]: Response };
 };
 
 type State = {
   selectedIds: Array<RequestId>;
   searchTerm: string;
-  routes: {[id: string]: Route};
+  routes: { [id: string]: Route };
   nextRouteId: number;
   isMockResponseSupported: boolean;
   showMockResponseDialog: boolean;
@@ -65,23 +65,23 @@ const COLUMN_SIZE = {
 };
 
 const COLUMN_ORDER = [
-  {key: 'requestTimestamp', visible: true},
-  {key: 'responseTimestamp', visible: false},
-  {key: 'domain', visible: true},
-  {key: 'method', visible: true},
-  {key: 'status', visible: true},
-  {key: 'size', visible: true},
-  {key: 'duration', visible: true},
+  { key: 'requestTimestamp', visible: true },
+  { key: 'responseTimestamp', visible: false },
+  { key: 'domain', visible: true },
+  { key: 'method', visible: true },
+  { key: 'status', visible: true },
+  { key: 'size', visible: true },
+  { key: 'duration', visible: true },
 ];
 
 const COLUMNS = {
-  requestTimestamp: {value: 'Request Time'},
-  responseTimestamp: {value: 'Response Time'},
-  domain: {value: 'Domain'},
-  method: {value: 'Method'},
-  status: {value: 'Status'},
-  size: {value: 'Size'},
-  duration: {value: 'Duration'},
+  requestTimestamp: { value: 'Request Time' },
+  responseTimestamp: { value: 'Response Time' },
+  domain: { value: 'Domain' },
+  method: { value: 'Method' },
+  status: { value: 'Status' },
+  size: { value: 'Size' },
+  duration: { value: 'Duration' },
 };
 
 const mockingStyle = {
@@ -115,9 +115,9 @@ export interface NetworkRouteManager {
   removeRoute(id: string): void;
 }
 const nullNetworkRouteManager: NetworkRouteManager = {
-  addRoute() {},
-  modifyRoute(_id: string, _routeChange: Partial<Route>) {},
-  removeRoute(_id: string) {},
+  addRoute() { },
+  modifyRoute(_id: string, _routeChange: Partial<Route>) { },
+  removeRoute(_id: string) { },
 };
 export const NetworkRouteContext = createContext<NetworkRouteManager>(
   nullNetworkRouteManager,
@@ -139,8 +139,8 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
     ) {
       return previous + (values.status >= 400 ? 1 : 0);
     },
-    0);
-    return Promise.resolve({NUMBER_NETWORK_FAILURES: failures});
+      0);
+    return Promise.resolve({ NUMBER_NETWORK_FAILURES: failures });
   }
 
   static persistedStateReducer(
@@ -151,11 +151,11 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
     switch (method) {
       case 'newRequest':
         return Object.assign({}, persistedState, {
-          requests: {...persistedState.requests, [data.id]: data as Request},
+          requests: { ...persistedState.requests, [data.id]: data as Request },
         });
       case 'newResponse':
         return Object.assign({}, persistedState, {
-          responses: {...persistedState.responses, [data.id]: data as Response},
+          responses: { ...persistedState.responses, [data.id]: data as Response },
         });
       default:
         return persistedState;
@@ -235,7 +235,7 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
               requestMethod: 'GET',
               responseData: '',
               responseHeaders: {},
-              responseStatus: "200",
+              responseStatus: '200',
             };
             draftState.nextRouteId = nextRouteId + 1;
           }),
@@ -247,7 +247,7 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
             if (!draftState.routes.hasOwnProperty(id)) {
               return;
             }
-            draftState.routes[id] = {...draftState.routes[id], ...routeChange};
+            draftState.routes[id] = { ...draftState.routes[id], ...routeChange };
             informClientMockChange(draftState.routes);
           }),
         );
@@ -265,7 +265,7 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
     };
   }
 
-  teardown() {}
+  teardown() { }
 
   onKeyboardAction = (action: string) => {
     if (action === 'clear') {
@@ -295,11 +295,11 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
   };
 
   onRowHighlighted = (selectedIds: Array<RequestId>) =>
-    this.setState({selectedIds});
+    this.setState({ selectedIds });
 
   copyRequestCurlCommand = () => {
-    const {requests} = this.props.persistedState;
-    const {selectedIds} = this.state;
+    const { requests } = this.props.persistedState;
+    const { selectedIds } = this.state;
     // Ensure there is only one row highlighted.
     if (selectedIds.length !== 1) {
       return;
@@ -314,13 +314,13 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
   };
 
   clearLogs = () => {
-    this.setState({selectedIds: []});
-    this.props.setPersistedState({responses: {}, requests: {}});
+    this.setState({ selectedIds: [] });
+    this.props.setPersistedState({ responses: {}, requests: {} });
   };
 
-  informClientMockChange = (routes: {[id: string]: Route}) => {
-    const existedIdSet: {[id: string]: {[method: string]: boolean}} = {};
-    const filteredRoutes: {[id: string]: Route} = Object.entries(routes).reduce(
+  informClientMockChange = (routes: { [id: string]: Route }) => {
+    const existedIdSet: { [id: string]: { [method: string]: boolean } } = {};
+    const filteredRoutes: { [id: string]: Route } = Object.entries(routes).reduce(
       (accRoutes, [id, route]) => {
         if (existedIdSet.hasOwnProperty(route.requestUrl)) {
           if (
@@ -332,12 +332,12 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
             ...existedIdSet[route.requestUrl],
             [route.requestMethod]: true,
           };
-          return Object.assign({[id]: route}, accRoutes);
+          return Object.assign({ [id]: route }, accRoutes);
         } else {
           existedIdSet[route.requestUrl] = {
             [route.requestMethod]: true,
           };
-          return Object.assign({[id]: route}, accRoutes);
+          return Object.assign({ [id]: route }, accRoutes);
         }
       },
       {},
@@ -362,16 +362,16 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
   };
 
   onMockButtonPressed = () => {
-    this.setState({showMockResponseDialog: true});
+    this.setState({ showMockResponseDialog: true });
   };
 
   onCloseButtonPressed = () => {
-    this.setState({showMockResponseDialog: false});
+    this.setState({ showMockResponseDialog: false });
   };
 
   renderSidebar = () => {
-    const {requests, responses} = this.props.persistedState;
-    const {selectedIds} = this.state;
+    const { requests, responses } = this.props.persistedState;
+    const { selectedIds } = this.state;
     const selectedId = selectedIds.length === 1 ? selectedIds[0] : null;
 
     if (!selectedId) {
@@ -391,7 +391,7 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
   };
 
   render() {
-    const {requests, responses} = this.props.persistedState;
+    const { requests, responses } = this.props.persistedState;
     const {
       selectedIds,
       searchTerm,
@@ -425,9 +425,9 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
 }
 
 type NetworkTableProps = {
-  requests: {[id: string]: Request};
-  responses: {[id: string]: Response};
-  routes: {[id: string]: Route};
+  requests: { [id: string]: Request };
+  responses: { [id: string]: Response };
+  routes: { [id: string]: Route };
   clear: () => void;
   copyRequestCurlCommand: () => void;
   onRowHighlighted: (keys: TableHighlightedRows) => void;
@@ -441,7 +441,7 @@ type NetworkTableProps = {
 
 type NetworkTableState = {
   sortedRows: TableRows;
-  routes: {[id: string]: Route};
+  routes: { [id: string]: Route };
 };
 
 function formatTimestamp(timestamp: number): string {
@@ -477,11 +477,11 @@ function buildRow(
 ## Request
 HTTP ${request.method} ${request.url}
 ${request.headers
-  .map(
-    ({key, value}: {key: string; value: string}): string =>
-      `${key}: ${String(value)}`,
-  )
-  .join('\n')}`;
+      .map(
+        ({ key, value }: { key: string; value: string }): string =>
+          `${key}: ${String(value)}`,
+      )
+      .join('\n')}`;
 
   const requestData = request.data ? decodeBody(request) : null;
   const responseData = response && response.data ? decodeBody(response) : null;
@@ -496,11 +496,11 @@ ${request.headers
 ## Response
 HTTP ${response.status} ${response.reason}
 ${response.headers
-  .map(
-    ({key, value}: {key: string; value: string}): string =>
-      `${key}: ${String(value)}`,
-  )
-  .join('\n')}`;
+        .map(
+          ({ key, value }: { key: string; value: string }): string =>
+            `${key}: ${String(value)}`,
+        )
+        .join('\n')}`;
   }
 
   if (responseData) {
@@ -557,8 +557,8 @@ ${response.headers
 
 function calculateState(
   props: {
-    requests: {[id: string]: Request};
-    responses: {[id: string]: Response};
+    requests: { [id: string]: Request };
+    responses: { [id: string]: Response };
   },
   nextProps: NetworkTableProps,
   rows: TableRows = [],
@@ -614,7 +614,7 @@ class NetworkTable extends PureComponent<NetworkTableProps, NetworkTableState> {
 
   constructor(props: NetworkTableProps) {
     super(props);
-    this.state = calculateState({requests: {}, responses: {}}, props);
+    this.state = calculateState({ requests: {}, responses: {} }, props);
   }
 
   UNSAFE_componentWillReceiveProps(nextProps: NetworkTableProps) {
@@ -629,18 +629,18 @@ class NetworkTable extends PureComponent<NetworkTableProps, NetworkTableState> {
       | 'checkbox'
       | 'radio';
     const separator: ContextMenuType = 'separator';
-    const {clear, copyRequestCurlCommand, highlightedRows} = this.props;
+    const { clear, copyRequestCurlCommand, highlightedRows } = this.props;
     const highlightedMenuItems =
       highlightedRows && highlightedRows.size === 1
         ? [
-            {
-              type: separator,
-            },
-            {
-              label: 'Copy as cURL',
-              click: copyRequestCurlCommand,
-            },
-          ]
+          {
+            type: separator,
+          },
+          {
+            label: 'Copy as cURL',
+            click: copyRequestCurlCommand,
+          },
+        ]
         : [];
 
     return highlightedMenuItems.concat([
@@ -715,7 +715,7 @@ class StatusColumn extends PureComponent<{
   children?: number;
 }> {
   render() {
-    const {children} = this.props;
+    const { children } = this.props;
     let glyph;
 
     if (children != null && children >= 400 && children < 600) {
@@ -742,7 +742,7 @@ class DurationColumn extends PureComponent<{
   });
 
   render() {
-    const {request, response} = this.props;
+    const { request, response } = this.props;
     const duration = response
       ? response.timestamp - request.timestamp
       : undefined;
@@ -764,7 +764,7 @@ class SizeColumn extends PureComponent<{
   });
 
   render() {
-    const {response} = this.props;
+    const { response } = this.props;
     if (response) {
       const text = formatBytes(this.getResponseLength(response));
       return <SizeColumn.Text>{text}</SizeColumn.Text>;

--- a/desktop/plugins/network/types.tsx
+++ b/desktop/plugins/network/types.tsx
@@ -60,4 +60,5 @@ export type Route = {
   requestMethod: string;
   responseData: string;
   responseHeaders: {[id: string]: Header};
+  responseStatus: string;
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Mock requests can currently only return an HTTP Status Code of 200.  This is not sufficient to take full advantage of the mocking feature.  It would be more useful to specify a status code for the response.  Then not only can the original request be tested, but failure of the call could be tested as well.

This is described in Issue #1423 [https://github.com/facebook/flipper/issues/1423]

## Changelog

Allow user to change response code for a mock request

## Test Plan

Here is a video demonstrating the change
[Uploading response-status-code.mp4.zip…]

Here is a screenshot showing where the new HTTP status code is entered for the mock request:
![image](https://user-images.githubusercontent.com/337874/89370139-a1c1c500-d6a5-11ea-9a55-e5e99ba37af5.png)

This screenshot shows a mock response with an alternate return code:
![image](https://user-images.githubusercontent.com/337874/89370265-ecdbd800-d6a5-11ea-82e7-10afbd5dd939.png)

