### PR TITLE
Add button to copy highlighted requests to routes (mock requests)

### DIFF
--- a/desktop/plugins/network/ManageMockResponsePanel.tsx
+++ b/desktop/plugins/network/ManageMockResponsePanel.tsx
@@ -18,24 +18,24 @@ import {
   colors,
   Panel,
 } from 'flipper';
-import React, {useContext, useState, useMemo, useEffect} from 'react';
+import React, { useContext, useState, useMemo, useEffect } from 'react';
 
-import {Route, Request, Response} from './types';
+import { Route, Request, Response } from './types';
 
-import {MockResponseDetails} from './MockResponseDetails';
-import {NetworkRouteContext} from './index';
-import {RequestId} from './types';
+import { MockResponseDetails } from './MockResponseDetails';
+import { NetworkRouteContext } from './index';
+import { RequestId } from './types';
 
 type Props = {
-  routes: {[id: string]: Route};
+  routes: { [id: string]: Route };
   highlightedRows: Set<string> | null | undefined;
-  requests: {[id: string]: Request};
-  responses: {[id: string]: Response};
+  requests: { [id: string]: Request };
+  responses: { [id: string]: Response };
 };
 
-const ColumnSizes = {route: 'flex'};
+const ColumnSizes = { route: 'flex' };
 
-const Columns = {route: {value: 'Route', resizable: false}};
+const Columns = { route: { value: 'Route', resizable: false } };
 
 const AddRouteButton = styled(FlexBox)({
   color: colors.blackAlpha50,
@@ -88,8 +88,8 @@ const Icon = styled(Glyph)({
 });
 
 // return ids that have the same pair of requestUrl and method; this will return only the duplicate
-function _duplicateIds(routes: {[id: string]: Route}): Array<RequestId> {
-  const idSet: {[id: string]: {[method: string]: boolean}} = {};
+function _duplicateIds(routes: { [id: string]: Route }): Array<RequestId> {
+  const idSet: { [id: string]: { [method: string]: boolean } } = {};
   return Object.entries(routes).reduce((acc: Array<RequestId>, [id, route]) => {
     if (idSet.hasOwnProperty(route.requestUrl)) {
       if (idSet[route.requestUrl].hasOwnProperty(route.requestMethod)) {
@@ -101,14 +101,14 @@ function _duplicateIds(routes: {[id: string]: Route}): Array<RequestId> {
       };
       return acc;
     } else {
-      idSet[route.requestUrl] = {[route.requestMethod]: true};
+      idSet[route.requestUrl] = { [route.requestMethod]: true };
       return acc;
     }
   }, []);
 }
 
 function _buildRows(
-  routes: {[id: string]: Route},
+  routes: { [id: string]: Route },
   duplicatedIds: Array<string>,
   handleRemoveId: (id: string) => void,
 ) {
@@ -148,12 +148,12 @@ function RouteRow(props: {
           <Icon name="caution-triangle" color={colors.yellow} />
         )}
         {props.text.length === 0 ? (
-          <TextEllipsis style={{color: colors.blackAlpha50}}>
+          <TextEllipsis style={{ color: colors.blackAlpha50 }}>
             untitled
           </TextEllipsis>
         ) : (
-          <TextEllipsis>{props.text}</TextEllipsis>
-        )}
+            <TextEllipsis>{props.text}</TextEllipsis>
+          )}
       </FlexRow>
     </FlexRow>
   );
@@ -164,7 +164,7 @@ function ManagedMockResponseRightPanel(props: {
   route: Route;
   isDuplicated: boolean;
 }) {
-  const {id, route, isDuplicated} = props;
+  const { id, route, isDuplicated } = props;
   return (
     <Panel
       grow={true}
@@ -186,7 +186,7 @@ export function ManageMockResponsePanel(props: Props) {
   const [selectedId, setSelectedId] = useState<RequestId | null>(null);
   const [currentRouteSize, setCurrentRouteSize] = useState(0);
 
-  const {routes} = props.routes;
+  const { routes } = props.routes;
   useEffect(() => {
     const keys = Object.keys(props.routes);
     const routeSize = keys.length;
@@ -198,7 +198,7 @@ export function ManageMockResponsePanel(props: Props) {
     }
     setCurrentRouteSize(routeSize);
   }, [routes]);
-  const duplicatedIds = useMemo(() => _duplicateIds(props.routes), [routes]);
+  const duplicatedIds = useMemo(() => _duplicateIds(props.routes), [props.routes]);
   return (
     <Container>
       <LeftPanel>

--- a/desktop/plugins/network/ManageMockResponsePanel.tsx
+++ b/desktop/plugins/network/ManageMockResponsePanel.tsx
@@ -198,7 +198,7 @@ export function ManageMockResponsePanel(props: Props) {
     }
     setCurrentRouteSize(routeSize);
   }, [routes]);
-  const duplicatedIds = useMemo(() => _duplicateIds(props.routes), [props.routes]);
+  const duplicatedIds = useMemo(() => _duplicateIds(props.routes), [routes]);
   return (
     <Container>
       <LeftPanel>

--- a/desktop/plugins/network/ManageMockResponsePanel.tsx
+++ b/desktop/plugins/network/ManageMockResponsePanel.tsx
@@ -186,7 +186,6 @@ export function ManageMockResponsePanel(props: Props) {
   const [selectedId, setSelectedId] = useState<RequestId | null>(null);
   const [currentRouteSize, setCurrentRouteSize] = useState(0);
 
-  const { routes } = props.routes;
   useEffect(() => {
     const keys = Object.keys(props.routes);
     const routeSize = keys.length;
@@ -197,8 +196,8 @@ export function ManageMockResponsePanel(props: Props) {
       setSelectedId(keys[routeSize - 1]);
     }
     setCurrentRouteSize(routeSize);
-  }, [routes]);
-  const duplicatedIds = useMemo(() => _duplicateIds(props.routes), [routes]);
+  }, [props.routes]);
+  const duplicatedIds = useMemo(() => _duplicateIds(props.routes), [props.routes]);
   return (
     <Container>
       <LeftPanel>

--- a/desktop/plugins/network/ManageMockResponsePanel.tsx
+++ b/desktop/plugins/network/ManageMockResponsePanel.tsx
@@ -18,24 +18,24 @@ import {
   colors,
   Panel,
 } from 'flipper';
-import React, { useContext, useState, useMemo, useEffect } from 'react';
+import React, {useContext, useState, useMemo, useEffect} from 'react';
 
-import { Route, Request, Response } from './types';
+import {Route, Request, Response} from './types';
 
-import { MockResponseDetails } from './MockResponseDetails';
-import { NetworkRouteContext } from './index';
-import { RequestId } from './types';
+import {MockResponseDetails} from './MockResponseDetails';
+import {NetworkRouteContext} from './index';
+import {RequestId} from './types';
 
 type Props = {
-  routes: { [id: string]: Route };
+  routes: {[id: string]: Route};
   highlightedRows: Set<string> | null | undefined;
-  requests: { [id: string]: Request };
-  responses: { [id: string]: Response };
+  requests: {[id: string]: Request};
+  responses: {[id: string]: Response};
 };
 
-const ColumnSizes = { route: 'flex' };
+const ColumnSizes = {route: 'flex'};
 
-const Columns = { route: { value: 'Route', resizable: false } };
+const Columns = {route: {value: 'Route', resizable: false}};
 
 const AddRouteButton = styled(FlexBox)({
   color: colors.blackAlpha50,
@@ -88,8 +88,8 @@ const Icon = styled(Glyph)({
 });
 
 // return ids that have the same pair of requestUrl and method; this will return only the duplicate
-function _duplicateIds(routes: { [id: string]: Route }): Array<RequestId> {
-  const idSet: { [id: string]: { [method: string]: boolean } } = {};
+function _duplicateIds(routes: {[id: string]: Route}): Array<RequestId> {
+  const idSet: {[id: string]: {[method: string]: boolean}} = {};
   return Object.entries(routes).reduce((acc: Array<RequestId>, [id, route]) => {
     if (idSet.hasOwnProperty(route.requestUrl)) {
       if (idSet[route.requestUrl].hasOwnProperty(route.requestMethod)) {
@@ -101,14 +101,14 @@ function _duplicateIds(routes: { [id: string]: Route }): Array<RequestId> {
       };
       return acc;
     } else {
-      idSet[route.requestUrl] = { [route.requestMethod]: true };
+      idSet[route.requestUrl] = {[route.requestMethod]: true};
       return acc;
     }
   }, []);
 }
 
 function _buildRows(
-  routes: { [id: string]: Route },
+  routes: {[id: string]: Route},
   duplicatedIds: Array<string>,
   handleRemoveId: (id: string) => void,
 ) {
@@ -148,12 +148,12 @@ function RouteRow(props: {
           <Icon name="caution-triangle" color={colors.yellow} />
         )}
         {props.text.length === 0 ? (
-          <TextEllipsis style={{ color: colors.blackAlpha50 }}>
+          <TextEllipsis style={{color: colors.blackAlpha50}}>
             untitled
           </TextEllipsis>
         ) : (
-            <TextEllipsis>{props.text}</TextEllipsis>
-          )}
+          <TextEllipsis>{props.text}</TextEllipsis>
+        )}
       </FlexRow>
     </FlexRow>
   );
@@ -164,7 +164,7 @@ function ManagedMockResponseRightPanel(props: {
   route: Route;
   isDuplicated: boolean;
 }) {
-  const { id, route, isDuplicated } = props;
+  const {id, route, isDuplicated} = props;
   return (
     <Panel
       grow={true}
@@ -197,7 +197,9 @@ export function ManageMockResponsePanel(props: Props) {
     }
     setCurrentRouteSize(routeSize);
   }, [props.routes]);
-  const duplicatedIds = useMemo(() => _duplicateIds(props.routes), [props.routes]);
+  const duplicatedIds = useMemo(() => _duplicateIds(props.routes), [
+    props.routes,
+  ]);
   return (
     <Container>
       <LeftPanel>

--- a/desktop/plugins/network/MockResponseDialog.tsx
+++ b/desktop/plugins/network/MockResponseDialog.tsx
@@ -10,12 +10,15 @@
 import {FlexColumn, Button, styled} from 'flipper';
 
 import {ManageMockResponsePanel} from './ManageMockResponsePanel';
-import {Route} from './types';
+import {Route, Request, Response} from './types';
 import React from 'react';
 
 type Props = {
   routes: {[id: string]: Route};
   onHide: () => void;
+  highlightedRows: Set<string> | null | undefined;
+  requests: {[id: string]: Request};
+  responses: {[id: string]: Response};
 };
 
 const Title = styled('div')({
@@ -39,7 +42,12 @@ export function MockResponseDialog(props: Props) {
   return (
     <Container>
       <Title>Mock Network Responses</Title>
-      <ManageMockResponsePanel routes={props.routes} />
+      <ManageMockResponsePanel
+        routes={props.routes}
+        highlightedRows={props.highlightedRows}
+        requests={props.requests}
+        responses={props.responses}
+      />
       <Row>
         <Button compact padded onClick={props.onHide}>
           Close

--- a/desktop/plugins/network/index.tsx
+++ b/desktop/plugins/network/index.tsx
@@ -7,9 +7,9 @@
  * @format
  */
 
-import {padStart} from 'lodash';
-import React, {createContext} from 'react';
-import {MenuItemConstructorOptions} from 'electron';
+import { padStart } from 'lodash';
+import React, { createContext } from 'react';
+import { MenuItemConstructorOptions } from 'electron';
 
 import {
   ContextMenu,
@@ -57,14 +57,14 @@ export const BodyOptions = {
 type State = {
   selectedIds: Array<RequestId>;
   searchTerm: string;
-  routes: {[id: string]: Route};
+  routes: { [id: string]: Route };
   nextRouteId: number;
   isMockResponseSupported: boolean;
   showMockResponseDialog: boolean;
   detailBodyFormat: string;
   highlightedRows: Set<string> | null | undefined;
-  requests: {[id: string]: Request};
-  responses: {[id: string]: Response};
+  requests: { [id: string]: Request };
+  responses: { [id: string]: Response };
 };
 
 const COLUMN_SIZE = {
@@ -78,23 +78,23 @@ const COLUMN_SIZE = {
 };
 
 const COLUMN_ORDER = [
-  {key: 'requestTimestamp', visible: true},
-  {key: 'responseTimestamp', visible: false},
-  {key: 'domain', visible: true},
-  {key: 'method', visible: true},
-  {key: 'status', visible: true},
-  {key: 'size', visible: true},
-  {key: 'duration', visible: true},
+  { key: 'requestTimestamp', visible: true },
+  { key: 'responseTimestamp', visible: false },
+  { key: 'domain', visible: true },
+  { key: 'method', visible: true },
+  { key: 'status', visible: true },
+  { key: 'size', visible: true },
+  { key: 'duration', visible: true },
 ];
 
 const COLUMNS = {
-  requestTimestamp: {value: 'Request Time'},
-  responseTimestamp: {value: 'Response Time'},
-  domain: {value: 'Domain'},
-  method: {value: 'Method'},
-  status: {value: 'Status'},
-  size: {value: 'Size'},
-  duration: {value: 'Duration'},
+  requestTimestamp: { value: 'Request Time' },
+  responseTimestamp: { value: 'Response Time' },
+  domain: { value: 'Domain' },
+  method: { value: 'Method' },
+  status: { value: 'Status' },
+  size: { value: 'Size' },
+  duration: { value: 'Duration' },
 };
 
 const mockingStyle = {
@@ -128,19 +128,19 @@ export interface NetworkRouteManager {
   removeRoute(id: string): void;
   copyHighlightedCalls(
     highlightedRows: Set<string>,
-    requests: {[id: string]: Request},
-    responses: {[id: string]: Response},
+    requests: { [id: string]: Request },
+    responses: { [id: string]: Response },
   ): void;
 }
 const nullNetworkRouteManager: NetworkRouteManager = {
-  addRoute() {},
-  modifyRoute(_id: string, _routeChange: Partial<Route>) {},
-  removeRoute(_id: string) {},
+  addRoute() { },
+  modifyRoute(_id: string, _routeChange: Partial<Route>) { },
+  removeRoute(_id: string) { },
   copyHighlightedCalls(
     highlightedRows: Set<string>,
-    requests: {[id: string]: Request},
-    responses: {[id: string]: Response},
-  ) {},
+    requests: { [id: string]: Request },
+    responses: { [id: string]: Response },
+  ) { },
 };
 export const NetworkRouteContext = createContext<NetworkRouteManager>(
   nullNetworkRouteManager,
@@ -163,8 +163,8 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
     ) {
       return previous + (values.status >= 400 ? 1 : 0);
     },
-    0);
-    return Promise.resolve({NUMBER_NETWORK_FAILURES: failures});
+      0);
+    return Promise.resolve({ NUMBER_NETWORK_FAILURES: failures });
   }
 
   static persistedStateReducer(
@@ -175,7 +175,7 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
     switch (method) {
       case 'newRequest':
         return Object.assign({}, persistedState, {
-          requests: {...persistedState.requests, [data.id]: data as Request},
+          requests: { ...persistedState.requests, [data.id]: data as Request },
         });
       case 'newResponse':
         const response: Response = data as Response;
@@ -207,7 +207,7 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
           const followupChunk: ResponseFollowupChunk = message as ResponseFollowupChunk;
           const partialResponseEntry = persistedState.partialResponses[
             followupChunk.id
-          ] ?? {followupChunks: []};
+          ] ?? { followupChunks: [] };
           const newPartialResponseEntry = {
             ...partialResponseEntry,
             followupChunks: {
@@ -274,12 +274,12 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
     const allChunks: string[] =
       response.data != null
         ? [
-            response.data,
-            ...Object.entries(partialResponseEntry.followupChunks)
-              // It's important to parseInt here or it sorts lexicographically
-              .sort((a, b) => parseInt(a[0], 10) - parseInt(b[0], 10))
-              .map(([_k, v]: [string, string]) => v),
-          ]
+          response.data,
+          ...Object.entries(partialResponseEntry.followupChunks)
+            // It's important to parseInt here or it sorts lexicographically
+            .sort((a, b) => parseInt(a[0], 10) - parseInt(b[0], 10))
+            .map(([_k, v]: [string, string]) => v),
+        ]
         : [];
     const data = combineBase64Chunks(allChunks);
 
@@ -389,7 +389,7 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
             if (!draftState.routes.hasOwnProperty(id)) {
               return;
             }
-            draftState.routes[id] = {...draftState.routes[id], ...routeChange};
+            draftState.routes[id] = { ...draftState.routes[id], ...routeChange };
             informClientMockChange(draftState.routes);
           }),
         );
@@ -406,8 +406,8 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
       },
       copyHighlightedCalls(
         highlightedRows: Set<string> | null | undefined,
-        requests: {[id: string]: Request},
-        responses: {[id: string]: Response},
+        requests: { [id: string]: Request },
+        responses: { [id: string]: Response },
       ) {
         setState(
           produce((draftState: State) => {
@@ -415,7 +415,7 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
             highlightedRows?.forEach((row) => {
               const response = responses[row];
               // convert headers
-              const headers: {[id: string]: Header} = {};
+              const headers: { [id: string]: Header } = {};
               response.headers.forEach((e) => {
                 headers[e.key] = e;
               });
@@ -441,7 +441,7 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
     };
   }
 
-  teardown() {}
+  teardown() { }
 
   onKeyboardAction = (action: string) => {
     if (action === 'clear') {
@@ -471,11 +471,11 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
   };
 
   onRowHighlighted = (selectedIds: Array<RequestId>) =>
-    this.setState({selectedIds});
+    this.setState({ selectedIds });
 
   copyRequestCurlCommand = () => {
-    const {requests} = this.props.persistedState;
-    const {selectedIds} = this.state;
+    const { requests } = this.props.persistedState;
+    const { selectedIds } = this.state;
     // Ensure there is only one row highlighted.
     if (selectedIds.length !== 1) {
       return;
@@ -490,13 +490,13 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
   };
 
   clearLogs = () => {
-    this.setState({selectedIds: []});
-    this.props.setPersistedState({responses: {}, requests: {}});
+    this.setState({ selectedIds: [] });
+    this.props.setPersistedState({ responses: {}, requests: {} });
   };
 
-  informClientMockChange = (routes: {[id: string]: Route}) => {
-    const existedIdSet: {[id: string]: {[method: string]: boolean}} = {};
-    const filteredRoutes: {[id: string]: Route} = Object.entries(routes).reduce(
+  informClientMockChange = (routes: { [id: string]: Route }) => {
+    const existedIdSet: { [id: string]: { [method: string]: boolean } } = {};
+    const filteredRoutes: { [id: string]: Route } = Object.entries(routes).reduce(
       (accRoutes, [id, route]) => {
         if (existedIdSet.hasOwnProperty(route.requestUrl)) {
           if (
@@ -508,12 +508,12 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
             ...existedIdSet[route.requestUrl],
             [route.requestMethod]: true,
           };
-          return Object.assign({[id]: route}, accRoutes);
+          return Object.assign({ [id]: route }, accRoutes);
         } else {
           existedIdSet[route.requestUrl] = {
             [route.requestMethod]: true,
           };
-          return Object.assign({[id]: route}, accRoutes);
+          return Object.assign({ [id]: route }, accRoutes);
         }
       },
       {},
@@ -538,11 +538,11 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
   };
 
   onMockButtonPressed = () => {
-    this.setState({showMockResponseDialog: true});
+    this.setState({ showMockResponseDialog: true });
   };
 
   onCloseButtonPressed = () => {
-    this.setState({showMockResponseDialog: false});
+    this.setState({ showMockResponseDialog: false });
   };
 
   onSelectFormat = (bodyFormat: string) => {
@@ -550,8 +550,13 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
   };
 
   renderSidebar = () => {
+<<<<<<< HEAD
     const {requests, responses} = this.props.persistedState;
     const {selectedIds, detailBodyFormat} = this.state;
+=======
+    const { requests, responses } = this.props.persistedState;
+    const { selectedIds } = this.state;
+>>>>>>> more fixes
     const selectedId = selectedIds.length === 1 ? selectedIds[0] : null;
 
     if (!selectedId) {
@@ -573,7 +578,7 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
   };
 
   render() {
-    const {requests, responses} = this.props.persistedState;
+    const { requests, responses } = this.props.persistedState;
     const {
       selectedIds,
       searchTerm,
@@ -607,9 +612,9 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
 }
 
 type NetworkTableProps = {
-  requests: {[id: string]: Request};
-  responses: {[id: string]: Response};
-  routes: {[id: string]: Route};
+  requests: { [id: string]: Request };
+  responses: { [id: string]: Response };
+  routes: { [id: string]: Route };
   clear: () => void;
   copyRequestCurlCommand: () => void;
   onRowHighlighted: (keys: TableHighlightedRows) => void;
@@ -623,10 +628,10 @@ type NetworkTableProps = {
 
 type NetworkTableState = {
   sortedRows: TableRows;
-  routes: {[id: string]: Route};
+  routes: { [id: string]: Route };
   highlightedRows: Set<string> | null | undefined;
-  requests: {[id: string]: Request};
-  responses: {[id: string]: Response};
+  requests: { [id: string]: Request };
+  responses: { [id: string]: Response };
 };
 
 function formatTimestamp(timestamp: number): string {
@@ -667,11 +672,11 @@ function buildRow(
 ## Request
 HTTP ${request.method} ${request.url}
 ${request.headers
-  .map(
-    ({key, value}: {key: string; value: string}): string =>
-      `${key}: ${String(value)}`,
-  )
-  .join('\n')}`;
+      .map(
+        ({ key, value }: { key: string; value: string }): string =>
+          `${key}: ${String(value)}`,
+      )
+      .join('\n')}`;
 
   const requestData = request.data ? decodeBody(request) : null;
   const responseData = response && response.data ? decodeBody(response) : null;
@@ -686,11 +691,11 @@ ${request.headers
 ## Response
 HTTP ${response.status} ${response.reason}
 ${response.headers
-  .map(
-    ({key, value}: {key: string; value: string}): string =>
-      `${key}: ${String(value)}`,
-  )
-  .join('\n')}`;
+        .map(
+          ({ key, value }: { key: string; value: string }): string =>
+            `${key}: ${String(value)}`,
+        )
+        .join('\n')}`;
   }
 
   if (responseData) {
@@ -747,8 +752,8 @@ ${response.headers
 
 function calculateState(
   props: {
-    requests: {[id: string]: Request};
-    responses: {[id: string]: Response};
+    requests: { [id: string]: Request };
+    responses: { [id: string]: Response };
   },
   nextProps: NetworkTableProps,
   rows: TableRows = [],
@@ -812,7 +817,7 @@ class NetworkTable extends PureComponent<NetworkTableProps, NetworkTableState> {
 
   constructor(props: NetworkTableProps) {
     super(props);
-    this.state = calculateState({requests: {}, responses: {}}, props);
+    this.state = calculateState({ requests: {}, responses: {} }, props);
   }
 
   UNSAFE_componentWillReceiveProps(nextProps: NetworkTableProps) {
@@ -827,18 +832,18 @@ class NetworkTable extends PureComponent<NetworkTableProps, NetworkTableState> {
       | 'checkbox'
       | 'radio';
     const separator: ContextMenuType = 'separator';
-    const {clear, copyRequestCurlCommand, highlightedRows} = this.props;
+    const { clear, copyRequestCurlCommand, highlightedRows } = this.props;
     const highlightedMenuItems =
       highlightedRows && highlightedRows.size === 1
         ? [
-            {
-              type: separator,
-            },
-            {
-              label: 'Copy as cURL',
-              click: copyRequestCurlCommand,
-            },
-          ]
+          {
+            type: separator,
+          },
+          {
+            label: 'Copy as cURL',
+            click: copyRequestCurlCommand,
+          },
+        ]
         : [];
 
     return highlightedMenuItems.concat([
@@ -916,7 +921,7 @@ class StatusColumn extends PureComponent<{
   children?: number;
 }> {
   render() {
-    const {children} = this.props;
+    const { children } = this.props;
     let glyph;
 
     if (children != null && children >= 400 && children < 600) {
@@ -943,7 +948,7 @@ class DurationColumn extends PureComponent<{
   });
 
   render() {
-    const {request, response} = this.props;
+    const { request, response } = this.props;
     const duration = response
       ? response.timestamp - request.timestamp
       : undefined;
@@ -965,7 +970,7 @@ class SizeColumn extends PureComponent<{
   });
 
   render() {
-    const {response} = this.props;
+    const { response } = this.props;
     if (response) {
       const text = formatBytes(this.getResponseLength(response));
       return <SizeColumn.Text>{text}</SizeColumn.Text>;

--- a/desktop/plugins/network/index.tsx
+++ b/desktop/plugins/network/index.tsx
@@ -7,9 +7,9 @@
  * @format
  */
 
-import { padStart } from 'lodash';
-import React, { createContext } from 'react';
-import { MenuItemConstructorOptions } from 'electron';
+import {padStart} from 'lodash';
+import React, {createContext} from 'react';
+import {MenuItemConstructorOptions} from 'electron';
 
 import {
   ContextMenu,
@@ -57,14 +57,14 @@ export const BodyOptions = {
 type State = {
   selectedIds: Array<RequestId>;
   searchTerm: string;
-  routes: { [id: string]: Route };
+  routes: {[id: string]: Route};
   nextRouteId: number;
   isMockResponseSupported: boolean;
   showMockResponseDialog: boolean;
   detailBodyFormat: string;
   highlightedRows: Set<string> | null | undefined;
-  requests: { [id: string]: Request };
-  responses: { [id: string]: Response };
+  requests: {[id: string]: Request};
+  responses: {[id: string]: Response};
 };
 
 const COLUMN_SIZE = {
@@ -78,23 +78,23 @@ const COLUMN_SIZE = {
 };
 
 const COLUMN_ORDER = [
-  { key: 'requestTimestamp', visible: true },
-  { key: 'responseTimestamp', visible: false },
-  { key: 'domain', visible: true },
-  { key: 'method', visible: true },
-  { key: 'status', visible: true },
-  { key: 'size', visible: true },
-  { key: 'duration', visible: true },
+  {key: 'requestTimestamp', visible: true},
+  {key: 'responseTimestamp', visible: false},
+  {key: 'domain', visible: true},
+  {key: 'method', visible: true},
+  {key: 'status', visible: true},
+  {key: 'size', visible: true},
+  {key: 'duration', visible: true},
 ];
 
 const COLUMNS = {
-  requestTimestamp: { value: 'Request Time' },
-  responseTimestamp: { value: 'Response Time' },
-  domain: { value: 'Domain' },
-  method: { value: 'Method' },
-  status: { value: 'Status' },
-  size: { value: 'Size' },
-  duration: { value: 'Duration' },
+  requestTimestamp: {value: 'Request Time'},
+  responseTimestamp: {value: 'Response Time'},
+  domain: {value: 'Domain'},
+  method: {value: 'Method'},
+  status: {value: 'Status'},
+  size: {value: 'Size'},
+  duration: {value: 'Duration'},
 };
 
 const mockingStyle = {
@@ -128,19 +128,19 @@ export interface NetworkRouteManager {
   removeRoute(id: string): void;
   copyHighlightedCalls(
     highlightedRows: Set<string>,
-    requests: { [id: string]: Request },
-    responses: { [id: string]: Response },
+    requests: {[id: string]: Request},
+    responses: {[id: string]: Response},
   ): void;
 }
 const nullNetworkRouteManager: NetworkRouteManager = {
-  addRoute() { },
-  modifyRoute(_id: string, _routeChange: Partial<Route>) { },
-  removeRoute(_id: string) { },
+  addRoute() {},
+  modifyRoute(_id: string, _routeChange: Partial<Route>) {},
+  removeRoute(_id: string) {},
   copyHighlightedCalls(
     highlightedRows: Set<string>,
-    requests: { [id: string]: Request },
-    responses: { [id: string]: Response },
-  ) { },
+    requests: {[id: string]: Request},
+    responses: {[id: string]: Response},
+  ) {},
 };
 export const NetworkRouteContext = createContext<NetworkRouteManager>(
   nullNetworkRouteManager,
@@ -163,8 +163,8 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
     ) {
       return previous + (values.status >= 400 ? 1 : 0);
     },
-      0);
-    return Promise.resolve({ NUMBER_NETWORK_FAILURES: failures });
+    0);
+    return Promise.resolve({NUMBER_NETWORK_FAILURES: failures});
   }
 
   static persistedStateReducer(
@@ -175,7 +175,7 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
     switch (method) {
       case 'newRequest':
         return Object.assign({}, persistedState, {
-          requests: { ...persistedState.requests, [data.id]: data as Request },
+          requests: {...persistedState.requests, [data.id]: data as Request},
         });
       case 'newResponse':
         const response: Response = data as Response;
@@ -207,7 +207,7 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
           const followupChunk: ResponseFollowupChunk = message as ResponseFollowupChunk;
           const partialResponseEntry = persistedState.partialResponses[
             followupChunk.id
-          ] ?? { followupChunks: [] };
+          ] ?? {followupChunks: []};
           const newPartialResponseEntry = {
             ...partialResponseEntry,
             followupChunks: {
@@ -274,12 +274,12 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
     const allChunks: string[] =
       response.data != null
         ? [
-          response.data,
-          ...Object.entries(partialResponseEntry.followupChunks)
-            // It's important to parseInt here or it sorts lexicographically
-            .sort((a, b) => parseInt(a[0], 10) - parseInt(b[0], 10))
-            .map(([_k, v]: [string, string]) => v),
-        ]
+            response.data,
+            ...Object.entries(partialResponseEntry.followupChunks)
+              // It's important to parseInt here or it sorts lexicographically
+              .sort((a, b) => parseInt(a[0], 10) - parseInt(b[0], 10))
+              .map(([_k, v]: [string, string]) => v),
+          ]
         : [];
     const data = combineBase64Chunks(allChunks);
 
@@ -389,7 +389,7 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
             if (!draftState.routes.hasOwnProperty(id)) {
               return;
             }
-            draftState.routes[id] = { ...draftState.routes[id], ...routeChange };
+            draftState.routes[id] = {...draftState.routes[id], ...routeChange};
             informClientMockChange(draftState.routes);
           }),
         );
@@ -406,8 +406,8 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
       },
       copyHighlightedCalls(
         highlightedRows: Set<string> | null | undefined,
-        requests: { [id: string]: Request },
-        responses: { [id: string]: Response },
+        requests: {[id: string]: Request},
+        responses: {[id: string]: Response},
       ) {
         setState(
           produce((draftState: State) => {
@@ -415,7 +415,7 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
             highlightedRows?.forEach((row) => {
               const response = responses[row];
               // convert headers
-              const headers: { [id: string]: Header } = {};
+              const headers: {[id: string]: Header} = {};
               response.headers.forEach((e) => {
                 headers[e.key] = e;
               });
@@ -441,7 +441,7 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
     };
   }
 
-  teardown() { }
+  teardown() {}
 
   onKeyboardAction = (action: string) => {
     if (action === 'clear') {
@@ -471,11 +471,11 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
   };
 
   onRowHighlighted = (selectedIds: Array<RequestId>) =>
-    this.setState({ selectedIds });
+    this.setState({selectedIds});
 
   copyRequestCurlCommand = () => {
-    const { requests } = this.props.persistedState;
-    const { selectedIds } = this.state;
+    const {requests} = this.props.persistedState;
+    const {selectedIds} = this.state;
     // Ensure there is only one row highlighted.
     if (selectedIds.length !== 1) {
       return;
@@ -490,13 +490,13 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
   };
 
   clearLogs = () => {
-    this.setState({ selectedIds: [] });
-    this.props.setPersistedState({ responses: {}, requests: {} });
+    this.setState({selectedIds: []});
+    this.props.setPersistedState({responses: {}, requests: {}});
   };
 
-  informClientMockChange = (routes: { [id: string]: Route }) => {
-    const existedIdSet: { [id: string]: { [method: string]: boolean } } = {};
-    const filteredRoutes: { [id: string]: Route } = Object.entries(routes).reduce(
+  informClientMockChange = (routes: {[id: string]: Route}) => {
+    const existedIdSet: {[id: string]: {[method: string]: boolean}} = {};
+    const filteredRoutes: {[id: string]: Route} = Object.entries(routes).reduce(
       (accRoutes, [id, route]) => {
         if (existedIdSet.hasOwnProperty(route.requestUrl)) {
           if (
@@ -508,12 +508,12 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
             ...existedIdSet[route.requestUrl],
             [route.requestMethod]: true,
           };
-          return Object.assign({ [id]: route }, accRoutes);
+          return Object.assign({[id]: route}, accRoutes);
         } else {
           existedIdSet[route.requestUrl] = {
             [route.requestMethod]: true,
           };
-          return Object.assign({ [id]: route }, accRoutes);
+          return Object.assign({[id]: route}, accRoutes);
         }
       },
       {},
@@ -538,11 +538,11 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
   };
 
   onMockButtonPressed = () => {
-    this.setState({ showMockResponseDialog: true });
+    this.setState({showMockResponseDialog: true});
   };
 
   onCloseButtonPressed = () => {
-    this.setState({ showMockResponseDialog: false });
+    this.setState({showMockResponseDialog: false});
   };
 
   onSelectFormat = (bodyFormat: string) => {
@@ -551,12 +551,17 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
 
   renderSidebar = () => {
 <<<<<<< HEAD
+<<<<<<< HEAD
     const {requests, responses} = this.props.persistedState;
     const {selectedIds, detailBodyFormat} = this.state;
 =======
     const { requests, responses } = this.props.persistedState;
     const { selectedIds } = this.state;
 >>>>>>> more fixes
+=======
+    const {requests, responses} = this.props.persistedState;
+    const {selectedIds} = this.state;
+>>>>>>> fix lint errors
     const selectedId = selectedIds.length === 1 ? selectedIds[0] : null;
 
     if (!selectedId) {
@@ -578,7 +583,7 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
   };
 
   render() {
-    const { requests, responses } = this.props.persistedState;
+    const {requests, responses} = this.props.persistedState;
     const {
       selectedIds,
       searchTerm,
@@ -612,9 +617,9 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
 }
 
 type NetworkTableProps = {
-  requests: { [id: string]: Request };
-  responses: { [id: string]: Response };
-  routes: { [id: string]: Route };
+  requests: {[id: string]: Request};
+  responses: {[id: string]: Response};
+  routes: {[id: string]: Route};
   clear: () => void;
   copyRequestCurlCommand: () => void;
   onRowHighlighted: (keys: TableHighlightedRows) => void;
@@ -628,10 +633,10 @@ type NetworkTableProps = {
 
 type NetworkTableState = {
   sortedRows: TableRows;
-  routes: { [id: string]: Route };
+  routes: {[id: string]: Route};
   highlightedRows: Set<string> | null | undefined;
-  requests: { [id: string]: Request };
-  responses: { [id: string]: Response };
+  requests: {[id: string]: Request};
+  responses: {[id: string]: Response};
 };
 
 function formatTimestamp(timestamp: number): string {
@@ -672,11 +677,11 @@ function buildRow(
 ## Request
 HTTP ${request.method} ${request.url}
 ${request.headers
-      .map(
-        ({ key, value }: { key: string; value: string }): string =>
-          `${key}: ${String(value)}`,
-      )
-      .join('\n')}`;
+  .map(
+    ({key, value}: {key: string; value: string}): string =>
+      `${key}: ${String(value)}`,
+  )
+  .join('\n')}`;
 
   const requestData = request.data ? decodeBody(request) : null;
   const responseData = response && response.data ? decodeBody(response) : null;
@@ -691,11 +696,11 @@ ${request.headers
 ## Response
 HTTP ${response.status} ${response.reason}
 ${response.headers
-        .map(
-          ({ key, value }: { key: string; value: string }): string =>
-            `${key}: ${String(value)}`,
-        )
-        .join('\n')}`;
+  .map(
+    ({key, value}: {key: string; value: string}): string =>
+      `${key}: ${String(value)}`,
+  )
+  .join('\n')}`;
   }
 
   if (responseData) {
@@ -752,8 +757,8 @@ ${response.headers
 
 function calculateState(
   props: {
-    requests: { [id: string]: Request };
-    responses: { [id: string]: Response };
+    requests: {[id: string]: Request};
+    responses: {[id: string]: Response};
   },
   nextProps: NetworkTableProps,
   rows: TableRows = [],
@@ -817,7 +822,7 @@ class NetworkTable extends PureComponent<NetworkTableProps, NetworkTableState> {
 
   constructor(props: NetworkTableProps) {
     super(props);
-    this.state = calculateState({ requests: {}, responses: {} }, props);
+    this.state = calculateState({requests: {}, responses: {}}, props);
   }
 
   UNSAFE_componentWillReceiveProps(nextProps: NetworkTableProps) {
@@ -832,18 +837,18 @@ class NetworkTable extends PureComponent<NetworkTableProps, NetworkTableState> {
       | 'checkbox'
       | 'radio';
     const separator: ContextMenuType = 'separator';
-    const { clear, copyRequestCurlCommand, highlightedRows } = this.props;
+    const {clear, copyRequestCurlCommand, highlightedRows} = this.props;
     const highlightedMenuItems =
       highlightedRows && highlightedRows.size === 1
         ? [
-          {
-            type: separator,
-          },
-          {
-            label: 'Copy as cURL',
-            click: copyRequestCurlCommand,
-          },
-        ]
+            {
+              type: separator,
+            },
+            {
+              label: 'Copy as cURL',
+              click: copyRequestCurlCommand,
+            },
+          ]
         : [];
 
     return highlightedMenuItems.concat([
@@ -921,7 +926,7 @@ class StatusColumn extends PureComponent<{
   children?: number;
 }> {
   render() {
-    const { children } = this.props;
+    const {children} = this.props;
     let glyph;
 
     if (children != null && children >= 400 && children < 600) {
@@ -948,7 +953,7 @@ class DurationColumn extends PureComponent<{
   });
 
   render() {
-    const { request, response } = this.props;
+    const {request, response} = this.props;
     const duration = response
       ? response.timestamp - request.timestamp
       : undefined;
@@ -970,7 +975,7 @@ class SizeColumn extends PureComponent<{
   });
 
   render() {
-    const { response } = this.props;
+    const {response} = this.props;
     if (response) {
       const text = formatBytes(this.getResponseLength(response));
       return <SizeColumn.Text>{text}</SizeColumn.Text>;

--- a/desktop/plugins/network/index.tsx
+++ b/desktop/plugins/network/index.tsx
@@ -409,8 +409,8 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
         requests: {[id: string]: Request},
         responses: {[id: string]: Response},
       ) {
-        setState(
-          produce((draftState: State) => {
+        setState((state) => {
+          const nextState = produce(state, (state: State) => {
             // iterate through highlighted rows
             highlightedRows?.forEach((row) => {
               const response = responses[row];
@@ -424,19 +424,20 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
               const responseData =
                 response && response.data ? decodeBody(response) : null;
 
-              const nextRouteId = draftState.nextRouteId;
-              draftState.routes[nextRouteId.toString()] = {
+              const nextRouteId = state.nextRouteId;
+              state.routes[nextRouteId.toString()] = {
                 requestUrl: requests[row].url,
                 requestMethod: requests[row].method,
                 responseData: responseData as string,
                 responseHeaders: headers,
                 responseStatus: responses[row].status.toString(),
               };
-              draftState.nextRouteId = nextRouteId + 1;
-              informClientMockChange(draftState.routes);
+              state.nextRouteId = nextRouteId + 1;
             });
-          }),
-        );
+          });
+          informClientMockChange(nextState.routes);
+          return nextState;
+        });
       },
     };
   }
@@ -550,18 +551,8 @@ export default class extends FlipperPlugin<State, any, PersistedState> {
   };
 
   renderSidebar = () => {
-<<<<<<< HEAD
-<<<<<<< HEAD
     const {requests, responses} = this.props.persistedState;
     const {selectedIds, detailBodyFormat} = this.state;
-=======
-    const { requests, responses } = this.props.persistedState;
-    const { selectedIds } = this.state;
->>>>>>> more fixes
-=======
-    const {requests, responses} = this.props.persistedState;
-    const {selectedIds} = this.state;
->>>>>>> fix lint errors
     const selectedId = selectedIds.length === 1 ? selectedIds[0] : null;
 
     if (!selectedId) {

--- a/desktop/plugins/network/types.tsx
+++ b/desktop/plugins/network/types.tsx
@@ -69,7 +69,7 @@ export type Route = {
   requestMethod: string;
   responseData: string;
   responseHeaders: {[id: string]: Header};
-  responseStatus: string;
+  responseStatus?: string;
 };
 
 export type PersistedState = {


### PR DESCRIPTION
## Summary

Add feature to Network mocks in the Network Plugin which would allow a user to highlight network requests and copy into new routes (mocks).

For many production apps, network requests can contain many headers (easily 20 or more) and a large amount of data  returned in the response (1000's of characters).  Creating mocks for these manually is time consuming and error prone.

It would be better to make mocks automatically by allowing the user to highlight desired requests and have them automatically copied into new routes, also copying the headers and the response data.

## Changelog

Allow user to create new routes by highlighting existing network requests in the Network plugin

## Test Plan

Tested this change manually by running through the following scenario using the sample Android app:

1). Run a GET request from the Sample app.  Verify that the request/response is correct.  Highlight the request to be copied.

![request-screen](https://user-images.githubusercontent.com/337874/89750945-baf6b700-da93-11ea-86f6-3ec600e1727d.png)

2). Go to the Mock dialog by clicking on the "Mock" button

![mock-screen](https://user-images.githubusercontent.com/337874/89750979-e8436500-da93-11ea-9dde-8717436a03bb.png)

3).  Click on "Copy Highlighted Call" to create a mock Route from the selected request.  Verify that the "data" and "headers" tab panels are correct.

![mock-screen-2](https://user-images.githubusercontent.com/337874/89751029-132db900-da94-11ea-9419-6294a304f232.png)

![mock-screen-3](https://user-images.githubusercontent.com/337874/89751053-29d41000-da94-11ea-85db-a034a20e5c18.png)

Close the Dialog

4).  Run the request again from the sample app and verify that a mock request is returned with the correct data.

![response-mock-1](https://user-images.githubusercontent.com/337874/89751083-4cfebf80-da94-11ea-8523-192ebdc869f6.png)

![response-mock-2](https://user-images.githubusercontent.com/337874/89751092-58ea8180-da94-11ea-85fe-82b7a660789f.png)




