### PR TITLE
[Flipper][Android] Better error handling

### DIFF
--- a/desktop/app/src/dispatcher/androidDevice.tsx
+++ b/desktop/app/src/dispatcher/androidDevice.tsx
@@ -19,10 +19,12 @@ import which from 'which';
 import {promisify} from 'util';
 import {ServerPorts} from '../reducers/application';
 import {Client as ADBClient} from 'adbkit';
+import {addNotification} from '../reducers/notifications';
 
 function createDevice(
   adbClient: ADBClient,
   device: any,
+  store: Store,
   ports?: ServerPorts,
 ): Promise<AndroidDevice | undefined> {
   return new Promise((resolve, reject) => {
@@ -79,7 +81,26 @@ function createDevice(
         ) {
           console.debug('Device still connecting: ' + device.id);
         } else {
+          const isAuthorizationError = (e?.message as string)?.includes(
+            'device unauthorized',
+          );
           console.error('Failed to initialize device: ' + device.id, e);
+          store.dispatch(
+            addNotification({
+              client: null,
+              notification: {
+                id: 'androidDeviceConnectionError' + device.id,
+                title: 'Could not connect to ' + device.id,
+                severity: 'error',
+                message: `Failed to connect to '${device.id}': ${
+                  isAuthorizationError
+                    ? 'make sure to authorize debugging on the phone'
+                    : JSON.stringify(e, null, 2)
+                }`,
+              },
+              pluginId: 'androidDevice',
+            }),
+          );
         }
         resolve(undefined); // not ready yet, we will find it in the next tick
       });
@@ -92,7 +113,7 @@ export async function getActiveAndroidDevices(
   const client = await getAdbClient(store);
   const androidDevices = await client.listDevices();
   const devices = await Promise.all(
-    androidDevices.map((device) => createDevice(client, device)),
+    androidDevices.map((device) => createDevice(client, device, store)),
   );
   return devices.filter(Boolean) as any;
 }
@@ -201,6 +222,7 @@ export default (store: Store, logger: Logger) => {
     const androidDevice = await createDevice(
       adbClient,
       deviceData,
+      store,
       store.getState().application.serverPorts,
     );
     if (!androidDevice) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Show a notification if device connect failed, or if USB debugging hasn't been authorized

When trying to run Flipper on my linux device, it didn't connect to my phone ootb. `adb devices` showed the device, and the flipper console did show an error, which, correctly stated that the device isn't authorized, but I missed the popup on my phone. This hopefully removes one hindrance for others in the future when connecting Flipper to Android.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. This should just be a brief oneline we can mention in our release notes: https://github.com/facebook/flipper/releases -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI / output of the test runner and how you invoked it. -->

Before (no hint in Flipper UI):

![Screenshot from 2020-08-18 12-11-27](https://user-images.githubusercontent.com/1820292/90509026-9ca65080-e150-11ea-9119-2ba68633566a.png)

After:
Desktop notification + notification in notifications section

![Screenshot from 2020-08-18 12-47-10](https://user-images.githubusercontent.com/1820292/90509353-1b02f280-e151-11ea-899a-47d59ec93dcc.png)
![Screenshot from 2020-08-18 12-47-40](https://user-images.githubusercontent.com/1820292/90509358-1d654c80-e151-11ea-82c0-e86c5c34390d.png)

(sorry, had a movie, but can't access paste and GH doesn't allow them)


