### PR TITLE
Fix scoped symlink module resolution

### DIFF
--- a/desktop/pkg-lib/src/__tests__/getWatchFolders.node.ts
+++ b/desktop/pkg-lib/src/__tests__/getWatchFolders.node.ts
@@ -44,6 +44,11 @@ describe('getWatchFolders', () => {
           fb_plugin_module_2: mockfs.symlink({
             path: '../plugins/fb/fb_plugin_module_2',
           }),
+          '@scoped': {
+            local_module_3: mockfs.symlink({
+              path: '../../local_module_3',
+            }),
+          },
         },
         local_module_1: {
           'package.json': '{"dependencies": {"installed_module_1": "1.0.0"}}',
@@ -52,9 +57,13 @@ describe('getWatchFolders', () => {
           'package.json':
             '{"dependencies": {"fb_plugin_module_1": "1.0.0", "plugin_module_1": "1.0.0"}}',
         },
+        local_module_3: {
+          'package.json': '{"dependencies": {"installed_module_1": "1.0.0"}}',
+        },
         plugins: {
           plugin_module_1: {
-            'package.json': '{"dependencies": {"local_module_2": "1.0.0"}}',
+            'package.json':
+              '{"dependencies": {"local_module_2": "1.0.0", "@scoped/local_module_3": "1.0.0"}}',
           },
           plugin_module_2: {
             'package.json': '{"dependencies": {"fb_plugin_module_1": "1.0.0"}}',
@@ -102,6 +111,7 @@ describe('getWatchFolders', () => {
           "/test/root/plugins/fb/node_modules",
           "/test/root/plugins/plugin_module_1",
           "/test/root/plugins/plugin_module_2",
+          "/test/root/local_module_3",
         ]
       `);
     } finally {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fixes #1481 

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. This should just be a brief oneline we can mention in our release notes: https://github.com/facebook/flipper/releases -->

Fix symlinked scoped module resolving to outer directory

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI / output of the test runner and how you invoked it. -->

Added one more case to the existing test case for `getWatchFolders.ts`

```
❯ yarn run test:debug getWatchFolders
yarn run v1.22.4
$ yarn build:pkg && node --inspect node_modules/.bin/jest --runInBand getWatchFolders
$ cd pkg && yarn build
$ tsc -b
Debugger listening on ws://127.0.0.1:9229/41e16e0b-8a44-42fe-93ac-9dd9d06e418d
For help, see: https://nodejs.org/en/docs/inspector
 PASS  pkg-lib/src/__tests__/getWatchFolders.node.ts
  getWatchFolders
    ✓ getWatchFolders correctly resolves symlinked packages (12 ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   1 passed, 1 total
Time:        2.358 s
Ran all test suites matching /getWatchFolders/i.
✨  Done in 8.60s.
```
