### PR TITLE
[circleci] Fix Android build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ executors:
     resource_class: large
 
     environment:
-      _JAVA_OPTIONS: "-Xmx1500m -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -XX:ParallelGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2"
+      _JAVA_OPTIONS: "-Xmx1500m -XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -XX:ParallelGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2"
       TERM: 'dumb'
 
 jobs:


### PR DESCRIPTION
Summary:
This started failing in early August when this was deployed:
https://support.circleci.com/hc/en-us/articles/360048152911-Java-Builds-Fail-With-Unrecognized-VM-option-UseCGroupMemoryLimitForHeap-

Test Plan:
CI
