### PR TITLE
flipper-js-client-sdk: fix undefined this on connectPlugin and disconnectPlugin

### DIFF
--- a/flipper-js-client-sdk/src/api.ts
+++ b/flipper-js-client-sdk/src/api.ts
@@ -123,12 +123,12 @@ export abstract class FlipperClient {
     this._isConnected = true;
     Array.from(this.plugins.values())
       .filter((plugin) => plugin.runInBackground())
-      .map(this.connectPlugin);
+      .map(this.connectPlugin, this);
   }
 
   onDisconnect() {
     this._isConnected = false;
-    Array.from(this.plugins.values()).map(this.disconnectPlugin);
+    Array.from(this.plugins.values()).map(this.disconnectPlugin, this);
   }
 
   abstract start(appName: string): void;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

`this` is not defined for `connectPlugin` and `disconnectPlugin` because `Array.prototype.map` [replace `this` to `undefined` if not specified](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map):

> If a thisArg parameter is provided, it will be used as callback's this value. Otherwise, the value undefined will be used as its this value. The this value ultimately observable by callback is determined according to the usual rules for determining the this seen by a function.

![image](https://user-images.githubusercontent.com/1536976/91691584-72b24c80-eb9a-11ea-88f1-984f2be8ab4a.png)


## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. This should just be a brief oneline we can mention in our release notes: https://github.com/facebook/flipper/releases -->

flipper-js-client-sdk: Fix undefined this due to array map

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI / output of the test runner and how you invoked it. -->

Tried creating custom client and connecting to websocket server