### PR TITLE
Implement requestResponse for websocket connection

### DIFF
--- a/desktop/app/src/utils/js-client-server-utils/websocketClientFlipperConnection.tsx
+++ b/desktop/app/src/utils/js-client-server-utils/websocketClientFlipperConnection.tsx
@@ -61,8 +61,20 @@ export class WebsocketClientFlipperConnection<M>
 
   requestResponse(payload: Payload<string, M>): Single<Payload<string, M>> {
     return new Single((subscriber) => {
-      const callId =
-        payload.data != null ? JSON.parse(payload.data).id : undefined;
+      const {id: callId = undefined, method = undefined} =
+        payload.data != null ? JSON.parse(payload.data) : {};
+
+      subscriber.onSubscribe(() => {});
+
+      if (method === 'getPlugins') {
+        subscriber.onComplete({
+          data: JSON.stringify({
+            success: {plugins: this.plugins},
+          }),
+        });
+        return;
+      }
+
       this.websocket.send(
         JSON.stringify({
           type: 'call',
@@ -71,7 +83,6 @@ export class WebsocketClientFlipperConnection<M>
         }),
       );
 
-      subscriber.onSubscribe(() => {});
       this.websocket.on('message', (message: string) => {
         const {app, payload} = JSON.parse(message);
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This allow websocket client to receive and reply messages from desktop client.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. This should just be a brief oneline we can mention in our release notes: https://github.com/facebook/flipper/releases -->

Implement requestResponse for websocket connection, allowing websocket client to receive and reply messages from desktop client

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI / output of the test runner and how you invoked it. -->

Tested with custom websocket client, allow communicating getPlugins, init, deinit, etc.
But I think it's better to have dedicated unit tests for this (currently there's none?), let me know what you think.