### PR TITLE
Bump AS plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.0'
+        classpath 'com.android.tools.build:gradle:4.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$KOTLIN_VERSION"
     }
 }


### PR DESCRIPTION
Summary: New stable Android Studio is out, requires new plugin.

Reviewed By: jknoxville

Differential Revision: D23578599

