### PR TITLE
Revert "fbjni 0.0.4 (#1428)"

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -59,9 +59,9 @@ android {
 
     dependencies {
         compileOnly deps.proguardAnnotations
-        implementation 'com.facebook.fbjni:fbjni:0.0.4'
-        extractHeaders 'com.facebook.fbjni:fbjni:0.0.4:headers'
-        extractJNI 'com.facebook.fbjni:fbjni:0.0.4'
+        implementation 'com.facebook.fbjni:fbjni:0.0.2'
+        extractHeaders 'com.facebook.fbjni:fbjni:0.0.2:headers'
+        extractJNI 'com.facebook.fbjni:fbjni:0.0.2'
         implementation deps.soloader
         implementation deps.jsr305
         implementation deps.supportAppCompat


### PR DESCRIPTION
This reverts commit 97adea5423b5b28b63e43137ba72c1828cbe1dac.

This is to address https://github.com/facebook/flipper/issues/1514.

Waiting for RN to upgrade fbjni on their end before un-reverting.