### PR TITLE
Add chocolatey as a way to install openssl for windows

### DIFF
--- a/docs/getting-started/index.mdx
+++ b/docs/getting-started/index.mdx
@@ -15,7 +15,7 @@ To use Flipper, you need to add the mobile SDK to your app. If you are using Rea
 
 The desktop part of Flipper doesn't need any particular setup. Simply download the latest build for [Mac](https://www.facebook.com/fbflipper/public/mac), [Linux](https://www.facebook.com/fbflipper/public/linux) or [Windows](https://www.facebook.com/fbflipper/public/windows) and launch it. In order to work properly, Flipper requires a working installation of the Android and (if where applicable) iOS development tools on your system, as well as the [OpenSSL](https://www.openssl.org) binary on your `$PATH`.
 
-OpenSSL for Windows can be downloaded [here](https://slproweb.com/products/Win32OpenSSL.html).
+A compatible OpenSSL for Windows can be downloaded [here](https://slproweb.com/products/Win32OpenSSL.html) or from Chocolatey with `choco install openssl`.
 
 Once you start Flipper and launch an emulator/simulator or connect a device, you will already be able to see the device logs in Flipper. To see app specific data, you need to integrate our native SDKs with your app.
 


### PR DESCRIPTION
We've had several reports that Chocolatey-provided openssl works well with Flipper, so recommending it here.
