### PR TITLE
Fix repo name in Podfile

### DIFF
--- a/Flipper.podspec
+++ b/Flipper.podspec
@@ -8,10 +8,10 @@ Pod::Spec.new do |spec|
   spec.name = 'Flipper'
   spec.version = flipperkit_version
   spec.license = { :type => 'MIT' }
-  spec.homepage = 'https://github.com/facebook/sonar'
+  spec.homepage = 'https://github.com/facebook/flipper'
   spec.summary = 'SonarKit core cpp code with network implementation'
   spec.authors = 'Facebook'
-  spec.source = { :git => 'https://github.com/facebook/Sonar.git',
+  spec.source = { :git => 'https://github.com/facebook/flipper.git',
                   :tag => 'v'+flipperkit_version }
   spec.module_name = 'Flipper'
   spec.public_header_files = 'xplat/Flipper/*.h','xplat/utils/*.h'

--- a/FlipperKit.podspec
+++ b/FlipperKit.podspec
@@ -10,11 +10,11 @@ Pod::Spec.new do |spec|
   spec.name = 'FlipperKit'
   spec.version = flipperkit_version
   spec.license = { :type => 'MIT' }
-  spec.homepage = 'https://github.com/facebook/Sonar'
+  spec.homepage = 'https://github.com/facebook/flipper'
   spec.summary = 'Sonar iOS podspec'
   spec.authors = 'Facebook'
   spec.static_framework = true
-  spec.source = { :git => 'https://github.com/facebook/Sonar.git',
+  spec.source = { :git => 'https://github.com/facebook/flipper.git',
                   :tag=> "v"+flipperkit_version }
   spec.module_name = 'FlipperKit'
   spec.platforms = { :ios => "9.0" }

--- a/iOS/Podfile
+++ b/iOS/Podfile
@@ -1,5 +1,5 @@
 # Uncomment the next line to define a global platform for your project
-source 'https://github.com/facebook/Sonar.git'
+source 'https://github.com/facebook/flipper.git'
 source 'https://github.com/CocoaPods/Specs'
 platform :ios, '10.0'
 swift_version = "4.1"

--- a/iOS/Sample/Podfile
+++ b/iOS/Sample/Podfile
@@ -1,5 +1,5 @@
 project 'Sample.xcodeproj'
-source 'https://github.com/facebook/Sonar.git'
+source 'https://github.com/facebook/flipper.git'
 source 'https://github.com/CocoaPods/Specs'
 
 target 'Sample' do

--- a/iOS/SampleSwift/Podfile
+++ b/iOS/SampleSwift/Podfile
@@ -1,5 +1,5 @@
 project 'SampleSwift.xcodeproj'
-source 'https://github.com/facebook/Sonar.git'
+source 'https://github.com/facebook/flipper.git'
 source 'https://github.com/CocoaPods/Specs'
 
 target 'SampleSwift' do


### PR DESCRIPTION
A few people reported issues due to the previous repo name (`Sonar`) being referenced in the Podfile.

- https://github.com/facebook/react-native/issues/27565
- https://github.com/facebook/react-native/issues/29251
- https://github.com/facebook/flipper/issues/1321

This PR updates it to the current name (`flipper`). Please let me know if these updates are also needed for the files under `Specs/Flipper/**/Flipper.podspec` (not sure what the purpose is).
