### PR TITLE
Fix network plugin for ios14+

### DIFF
--- a/iOS/Plugins/FlipperKitNetworkPlugin/SKIOSNetworkPlugin/FLEXNetworkLib/FLEXNetworkObserver.mm
+++ b/iOS/Plugins/FlipperKitNetworkPlugin/SKIOSNetworkPlugin/FLEXNetworkLib/FLEXNetworkObserver.mm
@@ -318,6 +318,7 @@ typedef void (^NSURLSessionAsyncCompletion)(
     // In iOS 7 resume lives in __NSCFLocalSessionTask
     // In iOS 8 resume lives in NSURLSessionTask
     // In iOS 9 resume lives in __NSCFURLSessionTask
+    // In iOS 14 resume lives in NSURLSessionTask
     Class className = Nil;
     if (![[NSProcessInfo processInfo]
             respondsToSelector:@selector(operatingSystemVersion)]) {
@@ -325,7 +326,8 @@ typedef void (^NSURLSessionAsyncCompletion)(
           NSClassFromString([@[ @"__", @"NSC", @"FLocalS", @"ession", @"Task" ]
               componentsJoinedByString:@""]);
     } else if (
-        [[NSProcessInfo processInfo] operatingSystemVersion].majorVersion < 9) {
+        [[NSProcessInfo processInfo] operatingSystemVersion].majorVersion < 9 ||
+        [[NSProcessInfo processInfo] operatingSystemVersion].majorVersion >= 14) {
       className = [NSURLSessionTask class];
     } else {
       className =


### PR DESCRIPTION
## Summary

Network plugin stopped working for iOS 14 as reported in https://github.com/facebook/flipper/issues/1534. 
The fix is based on the origin Flex network observer, as seen in https://github.com/FLEXTool/FLEX/pull/451

## Changelog

- NetworkPlugin supports iOS 14+

## Test Plan

Using xcode 12 you can run iOS 14 simulator. 

