### PR TITLE
Fix typo `Abritrary`

### DIFF
--- a/docs/extending/layout-inspector.mdx
+++ b/docs/extending/layout-inspector.mdx
@@ -101,7 +101,7 @@ In order to register your descriptor for an object, you use `SKDescriptorMapper`
 
 ```objectivec
 [descriptorMapper registerDescriptor:[SKArbitraryViewDescriptor new]
-                            forClass:[AbritraryView class]];
+                            forClass:[ArbitraryView class]];
 
 ```
 


### PR DESCRIPTION
## Summary

Fixes the typo `Abritrary` in the docs which should be `Arbitrary` instead

## Changelog

Docs: Fixed the typo `AbritraryView` (now `ArbitraryView`)

## Test Plan

--

