### PR TITLE
[android] Fix GitHub Actions for sample build

### DIFF
--- a/.github/workflows/android-sample.yml
+++ b/.github/workflows/android-sample.yml
@@ -13,8 +13,8 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
-    - name: Install NDK 20
-      run: echo "y" | sudo /usr/local/lib/android/sdk/tools/bin/sdkmanager --install "ndk;20.0.5594570" --sdk_root=${ANDROID_SDK_ROOT}
+    - name: Install NDK 21
+      run: echo "y" | sudo /usr/local/lib/android/sdk/tools/bin/sdkmanager --install "ndk;21.0.6113669" --sdk_root=${ANDROID_SDK_ROOT}
     - name: Build with Gradle
       run: ./gradlew :sample:assembleDebug :tutorial:assembleDebug
     - name: upload artifact

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -15,8 +15,8 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
-    - name: Install NDK 20
-      run: echo "y" | sudo /usr/local/lib/android/sdk/tools/bin/sdkmanager --install "ndk;20.0.5594570" --sdk_root=${ANDROID_SDK_ROOT}
+    - name: Install NDK 21
+      run: echo "y" | sudo /usr/local/lib/android/sdk/tools/bin/sdkmanager --install "ndk;21.0.6113669" --sdk_root=${ANDROID_SDK_ROOT}
     - name: Build with Gradle
       run: ./gradlew :sample:assembleDebug :sample:assembleRelease
     - name: Rename apk

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ ext {
     targetSdkVersion = 29
     compileSdkVersion = 29
     buildToolsVersion = '29.0.2'
-    ndkVersion = '20.0.5594570'
+    ndkVersion = '21.0.6113669'
     sourceCompatibilityVersion = JavaVersion.VERSION_1_7
     targetCompatibilityVersion = JavaVersion.VERSION_1_7
 }


### PR DESCRIPTION
Summary:
Honestly not sure what's causing the new NDK to be pulled in
but at least locally installing it fixes the failure we see here:

https://github.com/facebook/flipper/runs/1424681947

Test Plan:
Wait for the Actions on the PR