### PR TITLE
[circleci] Set up automated retry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
           name: build and deploy
           command: |
             yes | sdkmanager "platforms;android-27" || true
-            /tmp/retry -m 3 ./gradlew :android:assembleRelease 
+            /tmp/retry -m 3 ./gradlew :android:assembleRelease
             /tmp/retry -m 3 scripts/publish-android-snapshot.sh
   release:
     executor: default-executor
@@ -35,7 +35,7 @@ jobs:
           name: build and deploy
           command: |
             yes | sdkmanager "platforms;android-27" || true
-            /tmp/retry -m 3 ./gradlew :android:assembleRelease 
+            /tmp/retry -m 3 ./gradlew :android:assembleRelease
             /tmp/retry -m 3 scripts/publish-android-release.sh
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,19 +15,28 @@ jobs:
     steps:
       - checkout
       - run:
+          name: install retry
+          command: scripts/install-retry.sh
+        command: scripts/install-retry.sh
+      - run:
           name: build and deploy
           command: |
             yes | sdkmanager "platforms;android-27" || true
-            ./gradlew :android:assembleRelease && scripts/publish-android-snapshot.sh
+            /tmp/retry -m 3 ./gradlew :android:assembleRelease 
+            /tmp/retry -m 3 scripts/publish-android-snapshot.sh
   release:
     executor: default-executor
     steps:
       - checkout
       - run:
+          name: install retry
+          command: scripts/install-retry.sh
+      - run:
           name: build and deploy
           command: |
             yes | sdkmanager "platforms;android-27" || true
-            ./gradlew :android:assembleRelease && scripts/publish-android-release.sh
+            /tmp/retry -m 3 ./gradlew :android:assembleRelease 
+            /tmp/retry -m 3 scripts/publish-android-release.sh
 workflows:
   version: 2
   build-and-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,6 @@ jobs:
       - run:
           name: install retry
           command: scripts/install-retry.sh
-        command: scripts/install-retry.sh
       - run:
           name: build and deploy
           command: |

--- a/scripts/install-retry.sh
+++ b/scripts/install-retry.sh
@@ -1,0 +1,12 @@
+#!/bin/sh -xe
+
+# try to install with wget
+command -v wget &>/dev/null && wget -O /tmp/retry "https://github.com/moul/retry/releases/download/v0.5.0/retry_$(uname -s)_$(uname -m)" || true
+
+# try to install with curl
+if [ ! -f /tmp/retry ]; then
+  command -v curl &>/dev/null && curl -L -o /tmp/retry "https://github.com/moul/retry/releases/download/v0.5.0/retry_$(uname -s)_$(uname -m)"
+fi
+
+chmod +x /tmp/retry
+/tmp/retry --version


### PR DESCRIPTION
Summary:

Circle occasionally fails with a network error in one of the Android dependencies. This uses a simple retry to alleviate the need to manually restart the tasks.

Test Plan:
Ran this on my private fork: https://app.circleci.com/pipelines/github/passy/flipper-1/9/workflows/e1b40086-1dce-49eb-a178-81052145ed0f