### PR TITLE
[packer] Pin down Rust toolchain

### DIFF
--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.48.0
       - name: Test
         run: cd packer && cargo test
       - name: Format


### PR DESCRIPTION
Summary:

To make sure we're staying in sync with the internal version. Requires some more manual updating, but even if we do this every couple of months, it should be fine.

Test Plan:
CI

