### PR TITLE
Bump OpenSSL-Universal pod dependency to 1.1.171

### DIFF
--- a/iOS/Podspecs/Flipper-Folly.podspec
+++ b/iOS/Podspecs/Flipper-Folly.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   spec.dependency 'boost-for-react-native'
   spec.dependency 'Flipper-Glog'
   spec.dependency 'Flipper-DoubleConversion'
-  spec.dependency 'OpenSSL-Universal', '1.0.2.20'
+  spec.dependency 'OpenSSL-Universal', '1.1.171'
   spec.dependency 'CocoaLibEvent', '~> 1.0'
   spec.compiler_flags = '-DFOLLY_HAVE_PTHREAD=1 -DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_HAVE_LIBGFLAGS=0 -DFOLLY_HAVE_LIBJEMALLOC=0 -DFOLLY_HAVE_PREADV=0 -DFOLLY_HAVE_PWRITEV=0 -DFOLLY_HAVE_TFO=0 -DFOLLY_USE_SYMBOLIZER=0
     -frtti


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This should fix the react-native issue with building on Xcode 12: https://github.com/facebook/react-native/issues/29984

## Changelog

Upgrade OpenSSL-Universal dependency on the one that includes arm for iPhone Simulator: https://github.com/krzyzanowskim/OpenSSL/releases

## Test Plan

This PR is not intended to be merged directly, as more version bumping and propagation through the other pods will be needed.

