### PR TITLE
Upgrade OpenSSL-Universal to 1.1.180

### DIFF
--- a/iOS/Podspecs/Flipper-Folly.podspec
+++ b/iOS/Podspecs/Flipper-Folly.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   spec.dependency 'boost-for-react-native'
   spec.dependency 'Flipper-Glog'
   spec.dependency 'Flipper-DoubleConversion'
-  spec.dependency 'OpenSSL-Universal', '1.1.171'
+  spec.dependency 'OpenSSL-Universal', '1.1.180'
   spec.dependency 'CocoaLibEvent', '~> 1.0'
   spec.compiler_flags = '-DFOLLY_HAVE_PTHREAD=1 -DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_HAVE_LIBGFLAGS=0 -DFOLLY_HAVE_LIBJEMALLOC=0 -DFOLLY_HAVE_PREADV=0 -DFOLLY_HAVE_PWRITEV=0 -DFOLLY_HAVE_TFO=0 -DFOLLY_USE_SYMBOLIZER=0
     -frtti


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

As it is stated in `OpenSSL-Universal`'s release notes: 1.1.180 has "macOS Catalyst support".

In order to use Flipper for Mac Catalyst apps, we need to remove dependency blockers.

## Changelog

- Upgrade OpenSSL-Universal to 1.1.180

## Test Plan

Build this project using iOS target.

In order to test Mac Catalyst, other blockers `CocoaLibEvent` need to be fixed.