### PR TITLE
Network plugin - fix issue with responses with empty body

### DIFF
--- a/android/plugins/network/src/main/java/com/facebook/flipper/plugins/network/NetworkFlipperPlugin.java
+++ b/android/plugins/network/src/main/java/com/facebook/flipper/plugins/network/NetworkFlipperPlugin.java
@@ -69,7 +69,7 @@ public class NetworkFlipperPlugin extends BufferingFlipperPlugin implements Netw
             int numChunks =
                 responseInfo.body == null
                     ? 1
-                    : (int) Math.ceil((double) responseInfo.body.length / MAX_BODY_SIZE_IN_BYTES);
+                    : Math.max((int) Math.ceil((double) responseInfo.body.length / MAX_BODY_SIZE_IN_BYTES),1);
 
             for (int i = 0; i < numChunks; i++) {
               byte[] chunk =

--- a/desktop/plugins/network/index.tsx
+++ b/desktop/plugins/network/index.tsx
@@ -368,7 +368,7 @@ export function plugin(client: PluginClient<Events, Methods>) {
 
           // convert data TODO: we only want this for non-binary data! See D23403095
           const responseData =
-            response && response.data ? decodeBody(response) : null;
+            response && response.data ? decodeBody(response) : "";
 
           const newNextRouteId = nextRouteId.get();
           routes.update((draft) => {

--- a/desktop/plugins/network/index.tsx
+++ b/desktop/plugins/network/index.tsx
@@ -368,7 +368,7 @@ export function plugin(client: PluginClient<Events, Methods>) {
 
           // convert data TODO: we only want this for non-binary data! See D23403095
           const responseData =
-            response && response.data ? decodeBody(response) : "";
+            response && response.data ? decodeBody(response) : '';
 
           const newNextRouteId = nextRouteId.get();
           routes.update((draft) => {


### PR DESCRIPTION
## Summary

The Network Plugin does not properly handle network requests that return an empty body (because of the body actually being empty or because the network call returns something like a 404 status).

Also, the creation of mocks using the "Copy Highlighted" command when the original response returns an empty body is not handled properly.

## Fix

The Android plugin now returns a response when the body length is 0.

The client plugin creates a body containing an empty string instead of null when the body is empty.

## Changelog

Fix problem in Network Plugin when original call or mock has an empty body in the response.


## Test Plan

The following screen output for the Network Plugin shows that the call is now being handled correctly.  The fields for "status", "size" and "duration" are now populated.

Also, the mock calls are properly defined and shown in yellow.

![image](https://user-images.githubusercontent.com/337874/102738969-5edd5280-4311-11eb-9b46-33a57a50e334.png)


