### PR TITLE
fix: react-native Xcode 12 compatibility

### DIFF
--- a/react-native/react-native-flipper/react-native-flipper.podspec
+++ b/react-native/react-native-flipper/react-native-flipper.podspec
@@ -26,5 +26,5 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = { "HEADER_SEARCH_PATHS" => "\"${PODS_ROOT}/Headers/Public/FlipperKit\"" }
   s.requires_arc = true
   s.compiler_flags = compiler_flags
-  s.dependency "React"
+  s.dependency "React-Core"
 end


### PR DESCRIPTION
## Summary

Latest Xcode 12 fails to build while without a module to depend on React-Core directly hence this change is necessary for all native modules on iOS. For more details please check: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116

## Changelog

React Native Xcode 12 compatibility

## Test Plan

Use this branch to install with an app running on Xcode 12.

