### PR TITLE
Network Plugin - New functions to import, export and clear Routes

### DIFF
--- a/desktop/plugins/network/ManageMockResponsePanel.tsx
+++ b/desktop/plugins/network/ManageMockResponsePanel.tsx
@@ -38,18 +38,8 @@ const ColumnSizes = {route: 'flex'};
 
 const Columns = {route: {value: 'Route', resizable: false}};
 
-const AddRouteButton = styled(FlexBox)({
+const Button = styled(FlexBox)({
   color: colors.blackAlpha50,
-  alignItems: 'center',
-  padding: 5,
-  flexShrink: 0,
-  whiteSpace: 'nowrap',
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-});
-
-const CopyHighlightedCallsButton = styled(FlexBox)({
-  color: colors.blueDark,
   alignItems: 'center',
   padding: 5,
   flexShrink: 0,
@@ -199,9 +189,9 @@ export function ManageMockResponsePanel(props: Props) {
     props.routes,
   ]);
   return (
-    <Container style={{height: 580}}>
+    <Container style={{height: 560}}>
       <LeftPanel>
-        <AddRouteButton
+        <Button
           onClick={() => {
             networkRouteManager.addRoute();
           }}>
@@ -212,8 +202,8 @@ export function ManageMockResponsePanel(props: Props) {
             color={colors.blackAlpha30}
           />
           &nbsp;Add Route
-        </AddRouteButton>
-        <CopyHighlightedCallsButton
+        </Button>
+        <Button
           onClick={() => {
             networkRouteManager.copyHighlightedCalls(
               props.highlightedRows as Set<string>,
@@ -228,7 +218,7 @@ export function ManageMockResponsePanel(props: Props) {
             color={colors.blackAlpha30}
           />
           &nbsp;Copy Highlighted Calls
-        </CopyHighlightedCallsButton>
+        </Button>
         <hr
           style={{
             height: 1,

--- a/desktop/plugins/network/MockResponseDetails.tsx
+++ b/desktop/plugins/network/MockResponseDetails.tsx
@@ -11,6 +11,7 @@ import {
   FlexRow,
   FlexColumn,
   FlexBox,
+  Layout,
   Input,
   Text,
   Tabs,
@@ -42,7 +43,7 @@ const StyledSelectContainer = styled(FlexRow)({
 
 const StyledSelect = styled(Select)({
   height: '100%',
-  maxWidth: 200,
+  maxWidth: 400,
 });
 
 const StyledText = styled(Text)({
@@ -53,7 +54,7 @@ const StyledText = styled(Text)({
 const textAreaStyle: React.CSSProperties = {
   width: '100%',
   marginTop: 8,
-  height: 430,
+  height: 400,
   fontSize: 15,
   color: '#333',
   padding: 10,
@@ -114,27 +115,27 @@ const AddHeaderButton = styled(FlexBox)({
 });
 
 const HeadersColumnSizes = {
-  name: '40%',
-  value: '40%',
-  close: '10%',
-  warning: 'flex',
+  close: '4%',
+  warning: '4%',
+  name: '35%',
+  value: 'flex',
 };
 
 const HeadersColumns = {
-  name: {
-    value: 'Name',
-    resizable: false,
-  },
-  value: {
-    value: 'Value',
-    resizable: false,
-  },
   close: {
     value: '',
     resizable: false,
   },
   warning: {
     value: '',
+    resizable: false,
+  },
+  name: {
+    value: 'Name',
+    resizable: false,
+  },
+  value: {
+    value: 'Value',
     resizable: false,
   },
 };
@@ -315,7 +316,7 @@ export function MockResponseDetails({id, route, isDuplicated}: Props) {
           />
         </Tab>
         <Tab key={'headers'} label={'Headers'}>
-          <FlexColumn>
+          <Layout.Container style={{width: '100%'}}>
             <AddHeaderButton
               onClick={() => {
                 const newHeaders = {
@@ -335,25 +336,27 @@ export function MockResponseDetails({id, route, isDuplicated}: Props) {
               />
               &nbsp;Add Header
             </AddHeaderButton>
-            <ManagedTable
-              hideHeader={true}
-              multiline={true}
-              columnSizes={HeadersColumnSizes}
-              columns={HeadersColumns}
-              rows={_buildMockResponseHeaderRows(
-                id,
-                route,
-                selectedHeaderIds.length === 1 ? selectedHeaderIds[0] : null,
-                networkRouteManager,
-              )}
-              stickyBottom={true}
-              autoHeight={true}
-              floating={false}
-              zebra={false}
-              onRowHighlighted={setSelectedHeaderIds}
-              highlightedRows={new Set(selectedHeaderIds)}
-            />
-          </FlexColumn>
+            <Layout.ScrollContainer style={{width: '100%'}}>
+              <ManagedTable
+                hideHeader={true}
+                multiline={true}
+                columnSizes={HeadersColumnSizes}
+                columns={HeadersColumns}
+                rows={_buildMockResponseHeaderRows(
+                  id,
+                  route,
+                  selectedHeaderIds.length === 1 ? selectedHeaderIds[0] : null,
+                  networkRouteManager,
+                )}
+                stickyBottom={true}
+                autoHeight={true}
+                floating={false}
+                zebra={false}
+                onRowHighlighted={setSelectedHeaderIds}
+                highlightedRows={new Set(selectedHeaderIds)}
+              />
+            </Layout.ScrollContainer>
+          </Layout.Container>
         </Tab>
       </Tabs>
     </Container>

--- a/desktop/plugins/network/MockResponseDialog.tsx
+++ b/desktop/plugins/network/MockResponseDialog.tsx
@@ -54,7 +54,7 @@ export function MockResponseDialog(props: Props) {
           responses={props.responses}
         />
       </Layout.Horizontal>
-      <Layout.Horizontal>
+      <Layout.Horizontal gap>
         <Button
           compact
           padded

--- a/desktop/plugins/network/MockResponseDialog.tsx
+++ b/desktop/plugins/network/MockResponseDialog.tsx
@@ -7,11 +7,14 @@
  * @format
  */
 
-import {FlexColumn, Button, styled, Layout} from 'flipper';
+import {FlexColumn, Button, styled, Layout, Spacer} from 'flipper';
 
 import {ManageMockResponsePanel} from './ManageMockResponsePanel';
 import {Route, Request, Response} from './types';
 import React from 'react';
+
+import {NetworkRouteContext} from './index';
+import {useContext} from 'react';
 
 type Props = {
   routes: {[id: string]: Route};
@@ -39,6 +42,7 @@ const Row = styled(FlexColumn)({
 });
 
 export function MockResponseDialog(props: Props) {
+  const networkRouteManager = useContext(NetworkRouteContext);
   return (
     <Layout.Container pad width={1200}>
       <Title>Mock Network Responses</Title>
@@ -51,6 +55,31 @@ export function MockResponseDialog(props: Props) {
         />
       </Layout.Horizontal>
       <Layout.Horizontal>
+        <Button
+          compact
+          padded
+          onClick={() => {
+            networkRouteManager.importRoutes();
+          }}>
+          Import
+        </Button>
+        <Button
+          compact
+          padded
+          onClick={() => {
+            networkRouteManager.exportRoutes();
+          }}>
+          Export
+        </Button>
+        <Button
+          compact
+          padded
+          onClick={() => {
+            networkRouteManager.clearRoutes();
+          }}>
+          Clear
+        </Button>
+        <Spacer />
         <Button compact padded onClick={props.onHide}>
           Close
         </Button>

--- a/desktop/plugins/network/index.tsx
+++ b/desktop/plugins/network/index.tsx
@@ -10,6 +10,7 @@
 import {padStart} from 'lodash';
 import React, {createContext} from 'react';
 import {MenuItemConstructorOptions} from 'electron';
+import {message} from 'antd';
 
 import {
   ContextMenu,
@@ -398,14 +399,13 @@ export function plugin(client: PluginClient<Events, Methods>) {
         const options: OpenDialogOptions = {
           properties: ['openFile'],
           filters: [{extensions: ['json'], name: 'Flipper Route Files'}],
-          title: 'Import Routes',
         };
         remote.dialog.showOpenDialog(options).then((result) => {
           const filePaths = result.filePaths;
           if (filePaths.length > 0) {
             fs.readFile(filePaths[0], 'utf8', (err, data) => {
               if (err) {
-                console.error(err);
+                message.error('Unable to import file');
                 return;
               }
               const importedRoutes = JSON.parse(data);
@@ -449,6 +449,7 @@ export function plugin(client: PluginClient<Events, Methods>) {
               JSON.stringify(routes.get(), null, 2),
               'utf8',
             );
+            message.info('Successfully exported mock routes');
           });
       },
       clearRoutes() {


### PR DESCRIPTION
## Summary

In the network plugin, add features to import and export routes as described in issue https://github.com/facebook/flipper/issues/1651

Primary use case is that external testers (such as QA teams) would be able to create test data, convert it to mocks and save the mocks to make bug fixes easier for devs.

Here is a screenshot showing location of buttons to perform import/export (and clearing) of mock routes:

![image](https://user-images.githubusercontent.com/337874/105658269-cb58ed80-5e8b-11eb-8118-f13efc96bf6d.png)

Here is another screenshot showing export dialog:

![image](https://user-images.githubusercontent.com/337874/105657733-afa11780-5e8a-11eb-9725-120617e1dd71.png)


## Changelog

Network plugin - Add import and export of routes

## Test Plan

Performed manual testing

- create new mocks
- export mocks
- clear mocks
- import mocks
- verify that mocks still work by making GET/POST requests in sample app

Performed various permutations of above manual tests, including restarting Flipper at various points to ensure that test plan still worked.  Also performed visual inspection of exported files to verify correctness.

Would be very interested in learning how to create automated tests for this functionality.

