### PR TITLE
Changes to local storage for mocks and body format

### DIFF
--- a/desktop/plugins/network/index.tsx
+++ b/desktop/plugins/network/index.tsx
@@ -50,6 +50,8 @@ import fs from 'fs';
 import electron from 'electron';
 
 const LOCALSTORAGE_MOCK_ROUTE_LIST_KEY = '__NETWORK_CACHED_MOCK_ROUTE_LIST';
+const LOCALSTORAGE_RESPONSE_BODY_FORMAT_KEY =
+  '__NETWORK_CACHED_RESPONSE_BODY_FORMAT';
 
 export const BodyOptions = {
   formatted: 'formatted',
@@ -162,7 +164,10 @@ export function plugin(client: PluginClient<Events, Methods>) {
   const nextRouteId = createState<number>(0);
   const isMockResponseSupported = createState<boolean>(false);
   const showMockResponseDialog = createState<boolean>(false);
-  const detailBodyFormat = createState<string>(BodyOptions.parsed);
+  const detailBodyFormat = createState<string>(
+    localStorage.getItem(LOCALSTORAGE_RESPONSE_BODY_FORMAT_KEY) ||
+      BodyOptions.parsed,
+  );
   const highlightedRows = createState<Set<string> | null | undefined>(
     new Set(),
   );
@@ -319,7 +324,8 @@ export function plugin(client: PluginClient<Events, Methods>) {
   function init() {
     client.supportsMethod('mockResponses').then((result) => {
       const newRoutes = JSON.parse(
-        localStorage.getItem(LOCALSTORAGE_MOCK_ROUTE_LIST_KEY) || '{}',
+        localStorage.getItem(LOCALSTORAGE_MOCK_ROUTE_LIST_KEY + client.appId) ||
+          '{}',
       );
       routes.set(newRoutes);
       isMockResponseSupported.set(result);
@@ -526,7 +532,7 @@ export function plugin(client: PluginClient<Events, Methods>) {
     if (isMockResponseSupported.get()) {
       const routesValuesArray = Object.values(filteredRoutes);
       localStorage.setItem(
-        LOCALSTORAGE_MOCK_ROUTE_LIST_KEY,
+        LOCALSTORAGE_MOCK_ROUTE_LIST_KEY + client.appId,
         JSON.stringify(routesValuesArray),
       );
 
@@ -572,6 +578,7 @@ export function plugin(client: PluginClient<Events, Methods>) {
     },
     onSelectFormat(bodyFormat: string) {
       detailBodyFormat.set(bodyFormat);
+      localStorage.setItem(LOCALSTORAGE_RESPONSE_BODY_FORMAT_KEY, bodyFormat);
     },
     copyRequestCurlCommand,
     init,


### PR DESCRIPTION
## Summary

Network calls are normally unique to an application as are the associated mocks.  Currently, the mocks for different applications are combined together and saved to the local store.  It would be better if mocks were saved (and retrieved by application).

This PR adds "appId" to the local store name to save mocks separately for each app.  This is not really the ideal technique since different apps could have the same name.  Android apps use packageId rather than app name (which is what appid is) to uniquely identify an app.  However, package id does not seem to be available to the Flipper client so appid is used instead.

This requirement is described in this issue: https://github.com/facebook/flipper/issues/1487

Also, individual developers often have a preference for how they like to view response data (parsed or formatted).  This PR saved the selected format so that the developer does not have to keep selecting it.  Since this preference is not specific to an app, it is not necessary to save the preference for each app.


## Changelog

Network plugin - save mocks by app
Network plugin - save response body format preference to local storage

## Test Plan

Install two apps (with different names)
Create mocks in each app
Restart Flipper
View the mocks for each app and verify that they are unique to the app



