### PR TITLE
Fix mock export file format

### DIFF
--- a/desktop/plugins/network/index.tsx
+++ b/desktop/plugins/network/index.tsx
@@ -445,7 +445,7 @@ export function plugin(client: PluginClient<Events, Methods>) {
             }
             fs.writeFile(
               file,
-              JSON.stringify(routes.get(), null, 2),
+              JSON.stringify(Object.values(routes.get()), null, 2),
               'utf8',
               (err) => {
                 if (err) {


### PR DESCRIPTION
## Summary

Provide a more robust technique for exporting the mocks to a file.

The current technique for exporting mocks to a file seems to fail under some scenarios.  The correct format is an array of objects:

```
[
  {
    "requestUrl": "https://api.github.com/repos/facebook/yoga",
    "requestMethod": "GET",
```
However, the following format is sometimes exported instead:

```
{
  "10": {
    "requestUrl": "https://demo9512366.mockable.io/SonarPost",
```

Using `Object.values` provides a more robust technique that has been successful during subsequent testing.


## Changelog

Network Plugin - new technique for exporting mocks

## Test Plan

Create mocks in the network plugin
Export mocks
Manually examine file for correct format
Import mocks and verify that the file has been imported correctly



