### PR TITLE
Misc UI fixes

### DIFF
--- a/desktop/plugins/network/ManageMockResponsePanel.tsx
+++ b/desktop/plugins/network/ManageMockResponsePanel.tsx
@@ -176,7 +176,6 @@ export function ManageMockResponsePanel(props: Props) {
               placement="bottom">
               <Button
                 onClick={() => {
-                  console.log(props.highlightedRows);
                   if (
                     !props.highlightedRows ||
                     props.highlightedRows.size == 0

--- a/desktop/plugins/network/ManageMockResponsePanel.tsx
+++ b/desktop/plugins/network/ManageMockResponsePanel.tsx
@@ -8,11 +8,9 @@
  */
 
 import {
-  Layout,
+  Button,
   ManagedTable,
   Text,
-  FlexBox,
-  FlexRow,
   Glyph,
   styled,
   colors,
@@ -26,6 +24,9 @@ import {MockResponseDetails} from './MockResponseDetails';
 import {NetworkRouteContext} from './index';
 import {RequestId} from './types';
 
+import {message} from 'antd';
+import {NUX, Layout} from 'flipper-plugin';
+
 type Props = {
   routes: {[id: string]: Route};
   highlightedRows: Set<string> | null | undefined;
@@ -36,16 +37,6 @@ type Props = {
 const ColumnSizes = {route: 'flex'};
 
 const Columns = {route: {value: 'Route', resizable: false}};
-
-const Button = styled(FlexBox)({
-  color: colors.blackAlpha50,
-  alignItems: 'center',
-  padding: 5,
-  flexShrink: 0,
-  whiteSpace: 'nowrap',
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-});
 
 const TextEllipsis = styled(Text)({
   overflowX: 'hidden',
@@ -110,11 +101,11 @@ function RouteRow(props: {
   handleRemoveId: () => void;
 }) {
   return (
-    <FlexRow grow={true}>
-      <FlexRow onClick={props.handleRemoveId}>
+    <Layout.Horizontal>
+      <Layout.Horizontal onClick={props.handleRemoveId}>
         <Icon name="cross-circle" color={colors.red} />
-      </FlexRow>
-      <FlexRow grow={true}>
+      </Layout.Horizontal>
+      <Layout.Horizontal>
         {props.showWarning && (
           <Icon name="caution-triangle" color={colors.yellow} />
         )}
@@ -125,8 +116,8 @@ function RouteRow(props: {
         ) : (
           <TextEllipsis>{props.text}</TextEllipsis>
         )}
-      </FlexRow>
-    </FlexRow>
+      </Layout.Horizontal>
+    </Layout.Horizontal>
   );
 }
 
@@ -173,35 +164,38 @@ export function ManageMockResponsePanel(props: Props) {
     <Layout.Container style={{height: 550}}>
       <Layout.Left>
         <Layout.Container width={450} pad={10} gap={5}>
-          <Button
-            onClick={() => {
-              networkRouteManager.addRoute();
-            }}>
-            <Glyph
-              name="plus-circle"
-              size={16}
-              variant="outline"
-              color={colors.blackAlpha30}
-            />
-            &nbsp;Add Route
-          </Button>
-          <Button
-            onClick={() => {
-              networkRouteManager.copyHighlightedCalls(
-                props.highlightedRows as Set<string>,
-                props.requests,
-                props.responses,
-              );
-            }}>
-            <Glyph
-              name="plus-circle"
-              size={16}
-              variant="outline"
-              color={colors.blackAlpha30}
-            />
-            &nbsp;Copy Highlighted Calls
-          </Button>
+          <Layout.Horizontal gap>
+            <Button
+              onClick={() => {
+                networkRouteManager.addRoute();
+              }}>
+              Add Route
+            </Button>
+            <NUX
+              title="It is now possible to highlight calls from the network call list and convert them into mock routes."
+              placement="bottom">
+              <Button
+                onClick={() => {
+                  console.log(props.highlightedRows);
+                  if (
+                    !props.highlightedRows ||
+                    props.highlightedRows.size == 0
+                  ) {
+                    message.info('No network calls have been highlighted');
+                    return;
+                  }
+                  networkRouteManager.copyHighlightedCalls(
+                    props.highlightedRows as Set<string>,
+                    props.requests,
+                    props.responses,
+                  );
+                }}>
+                Copy Highlighted Calls
+              </Button>
+            </NUX>
+          </Layout.Horizontal>
           <Panel
+            padded={false}
             grow={true}
             collapsable={false}
             floating={false}

--- a/desktop/plugins/network/MockResponseDetails.tsx
+++ b/desktop/plugins/network/MockResponseDetails.tsx
@@ -10,8 +10,8 @@
 import {
   FlexRow,
   FlexColumn,
-  FlexBox,
   Layout,
+  Button,
   Input,
   Text,
   Tabs,
@@ -101,17 +101,6 @@ const Container = styled(FlexColumn)({
 
 const Warning = styled(FlexRow)({
   marginTop: 8,
-});
-
-const AddHeaderButton = styled(FlexBox)({
-  color: colors.blackAlpha50,
-  marginTop: 8,
-  alignItems: 'center',
-  padding: 10,
-  flexShrink: 0,
-  whiteSpace: 'nowrap',
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
 });
 
 const HeadersColumnSizes = {
@@ -210,8 +199,10 @@ function _buildMockResponseHeaderRows(
         },
         close: {
           value: (
-            <FlexBox
+            <Layout.Container
               onClick={() => {
+                console.log('button pressed - delete header');
+
                 const newHeaders = produce(
                   route.responseHeaders,
                   (draftHeaders) => {
@@ -223,7 +214,7 @@ function _buildMockResponseHeaderRows(
                 });
               }}>
               <HeaderGlyph name="cross-circle" color={colors.red} />
-            </FlexBox>
+            </Layout.Container>
           ),
         },
       },
@@ -317,26 +308,26 @@ export function MockResponseDetails({id, route, isDuplicated}: Props) {
         </Tab>
         <Tab key={'headers'} label={'Headers'}>
           <Layout.Container style={{width: '100%'}}>
-            <AddHeaderButton
-              onClick={() => {
-                const newHeaders = {
-                  ...route.responseHeaders,
-                  [nextHeaderId.toString()]: {key: '', value: ''},
-                };
-                setNextHeaderId(nextHeaderId + 1);
-                networkRouteManager.modifyRoute(id, {
-                  responseHeaders: newHeaders,
-                });
-              }}>
-              <Glyph
-                name="plus-circle"
-                size={16}
-                variant="outline"
-                color={colors.blackAlpha30}
-              />
-              &nbsp;Add Header
-            </AddHeaderButton>
-            <Layout.ScrollContainer style={{width: '100%'}}>
+            <Layout.Horizontal>
+              <Button
+                onClick={() => {
+                  console.log('button pressed - add headers');
+                  const newHeaders = {
+                    ...route.responseHeaders,
+                    [nextHeaderId.toString()]: {key: '', value: ''},
+                  };
+                  setNextHeaderId(nextHeaderId + 1);
+                  networkRouteManager.modifyRoute(id, {
+                    responseHeaders: newHeaders,
+                  });
+                }}
+                compact
+                padded
+                style={{marginBottom: 10}}>
+                Add Header
+              </Button>
+            </Layout.Horizontal>
+            <Layout.ScrollContainer>
               <ManagedTable
                 hideHeader={true}
                 multiline={true}

--- a/desktop/plugins/network/MockResponseDetails.tsx
+++ b/desktop/plugins/network/MockResponseDetails.tsx
@@ -201,8 +201,6 @@ function _buildMockResponseHeaderRows(
           value: (
             <Layout.Container
               onClick={() => {
-                console.log('button pressed - delete header');
-
                 const newHeaders = produce(
                   route.responseHeaders,
                   (draftHeaders) => {
@@ -311,7 +309,6 @@ export function MockResponseDetails({id, route, isDuplicated}: Props) {
             <Layout.Horizontal>
               <Button
                 onClick={() => {
-                  console.log('button pressed - add headers');
                   const newHeaders = {
                     ...route.responseHeaders,
                     [nextHeaderId.toString()]: {key: '', value: ''},


### PR DESCRIPTION
## Summary

Continue with cleanup of Network plugin mock screens.  This mostly consists of replacing FlexColumn, FlexRow and FlexBox with equivalent Sandy components.

Here is the new screen:

- replace text buttons with Button
- add NUX info to "Copy Highlighted Calls" button
- add message when no calls have been highlighted 
- in routes list remove padding on line items

![image](https://user-images.githubusercontent.com/337874/106415468-d58f6480-6414-11eb-93a8-498fd81b54d9.png)

Here is the prior screen:

![image](https://user-images.githubusercontent.com/337874/106415499-e8099e00-6414-11eb-8e0e-48875a945621.png)


## Changelog

Network Plugin - Additional cleanup of UI on mock screen

## Test Plan

Create and modify mocks
Verify that the functionality has not been affected by UI changes

