### PR TITLE
Solves the sampleswift failing job 

### DIFF
--- a/.github/workflows/iOS-Sample.yml
+++ b/.github/workflows/iOS-Sample.yml
@@ -1,48 +1,47 @@
 name: Build iOS apps
-on: [push, pull_request]    
-jobs:       
+on: [push, pull_request]
+jobs:
   build-sample-objc:
     runs-on: macos-latest
     defaults:
       run:
         working-directory: iOS/Sample
-        
+
     steps:
-    - uses: actions/checkout@v2      
-    - name: Install dependencies
-      run: pod install --repo-update
-    - name: Build Sample app
-      run: |
-        IPHONESIMULATOR=$(xcodebuild -showsdks | grep -o "iphonesimulator[0-9]\\+\\.[0-9]\\+$") && echo $IPHONESIMULATOR
-        xcodebuild build -workspace Sample.xcworkspace -scheme Sample -sdk $IPHONESIMULATOR -arch x86_64
-        
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: pod install --repo-update
+      - name: Build Sample app
+        run: |
+          IPHONESIMULATOR=$(xcodebuild -showsdks | grep -o "iphonesimulator[0-9]\\+\\.[0-9]\\+$") && echo $IPHONESIMULATOR
+          xcodebuild build -workspace Sample.xcworkspace -scheme Sample -sdk $IPHONESIMULATOR EXCLUDED_ARCHS=arm64
+
   build-sample-swift:
     runs-on: macos-latest
     defaults:
       run:
         working-directory: iOS/SampleSwift
-        
+
     steps:
-    - uses: actions/checkout@v2      
-    - name: Install dependencies
-      run: pod install --repo-update
-    - name: Build SampleSwift app
-      run: |
-        IPHONESIMULATOR=$(xcodebuild -showsdks | grep -o "iphonesimulator[0-9]\\+\\.[0-9]\\+$") && echo $IPHONESIMULATOR
-        xcodebuild build -workspace SampleSwift.xcworkspace -scheme SampleSwift -sdk $IPHONESIMULATOR -arch x86_64
-        
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: pod install --repo-update
+      - name: Build SampleSwift app
+        run: |
+          IPHONESIMULATOR=$(xcodebuild -showsdks | grep -o "iphonesimulator[0-9]\\+\\.[0-9]\\+$") && echo $IPHONESIMULATOR
+          xcodebuild build -workspace SampleSwift.xcworkspace -scheme SampleSwift -sdk $IPHONESIMULATOR
+
   build-tutorial:
     runs-on: macos-latest
     defaults:
       run:
         working-directory: iOS/Tutorial
-        
-    steps:
-    - uses: actions/checkout@v2      
-    - name: Install dependencies
-      run: pod install --repo-update
-    - name: Build Tutorial app
-      run: |
-        IPHONESIMULATOR=$(xcodebuild -showsdks | grep -o "iphonesimulator[0-9]\\+\\.[0-9]\\+$") && echo $IPHONESIMULATOR
-        xcodebuild build -workspace Tutorial.xcworkspace -scheme Tutorial -sdk $IPHONESIMULATOR -arch x86_64
 
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: pod install --repo-update
+      - name: Build Tutorial app
+        run: |
+          IPHONESIMULATOR=$(xcodebuild -showsdks | grep -o "iphonesimulator[0-9]\\+\\.[0-9]\\+$") && echo $IPHONESIMULATOR
+          xcodebuild build -workspace Tutorial.xcworkspace -scheme Tutorial -sdk $IPHONESIMULATOR -arch x86_64

--- a/iOS/SampleSwift/SampleSwift.xcodeproj/project.pbxproj
+++ b/iOS/SampleSwift/SampleSwift.xcodeproj/project.pbxproj
@@ -376,10 +376,6 @@
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
-					"-l\"event\"",
-					"-l\"event_core\"",
-					"-l\"event_extra\"",
-					"-l\"event_pthreads\"",
 					"-l\"stdc++\"",
 					"-framework",
 					"\"CFNetwork\"",
@@ -411,10 +407,6 @@
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
-					"-l\"event\"",
-					"-l\"event_core\"",
-					"-l\"event_extra\"",
-					"-l\"event_pthreads\"",
 					"-l\"stdc++\"",
 					"-framework",
 					"\"CFNetwork\"",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Solves the sampleswift failing job, by removing the linker flags which were used when we relied on CocoaLibEvent, but now we do not rely on this. 

I can't build the objc sample for arm64 because of the following error. It looks like for the objc project, xcode is not able to find the arm64 artifacts for swift deps.

I tried all the alternatives for solving this issue, but it didn't work for objc. Tried adding empty swift file with brisging header, also tried `LD_VERIFY_BITCODE=NO`, it didn't work. I will wait for new xcode and will try with that, hopefully, the newer xcode might have  the fix.

```
ld: warning: Could not find or use auto-linked library 'swiftFoundation'
ld: warning: Could not find or use auto-linked library 'swiftMetal'
ld: warning: Could not find or use auto-linked library 'swiftUIKit'
ld: warning: Could not find or use auto-linked library 'swiftDarwin'
ld: warning: Could not find or use auto-linked library 'swiftObjectiveC'
ld: warning: Could not find or use auto-linked library 'swiftCoreFoundation'
ld: warning: Could not find or use auto-linked library 'swiftDispatch'
ld: warning: Could not find or use auto-linked library 'swiftCoreImage'
ld: warning: Could not find or use auto-linked library 'swiftCore'
ld: warning: Could not find or use auto-linked library 'swiftQuartzCore'
ld: warning: Could not find or use auto-linked library 'swiftCoreGraphics'
ld: warning: Could not find or use auto-linked library 'swiftSwiftOnoneSupport'
Undefined symbols for architecture arm64:
  "protocol descriptor for Swift.ExpressibleByFloatLiteral", referenced from:
      l_got.$ss25ExpressibleByFloatLiteralMp in libYogaKit.a(YGLayoutExtensions.o)
  "associated type descriptor for Swift.ExpressibleByIntegerLiteral.IntegerLiteralType", referenced from:
      l_got.$s18IntegerLiteralTypes013ExpressibleByaB0PTl in libYogaKit.a(YGLayoutExtensions.o)
  "associated conformance descriptor for Swift.ExpressibleByIntegerLiteral.Swift.ExpressibleByIntegerLiteral.IntegerLiteralType: Swift._ExpressibleByBuiltinIntegerLiteral", referenced from:
      l_got.$ss27ExpressibleByIntegerLiteralP0cD4TypeAB_s01_ab7BuiltincD0Tn in libYogaKit.a(YGLayoutExtensions.o)
  "method descriptor for Swift.ExpressibleByFloatLiteral.init(floatLiteral: A.FloatLiteralType) -> A", referenced from:
      l_got.$ss25ExpressibleByFloatLiteralP05floatD0x0cD4TypeQz_tcfCTq in libYogaKit.a(YGLayoutExtensions.o)
  "protocol descriptor for Swift.ExpressibleByIntegerLiteral", referenced from:
      l_got.$ss27ExpressibleByIntegerLiteralMp in libYogaKit.a(YGLayoutExtensions.o)
  "value witness table for Builtin.Int32", referenced from:
      full type metadata for __C.YGUnit in libYogaKit.a(YGLayoutExtensions.o)
  "__swift_FORCE_LOAD_$_swiftCoreImage", referenced from:
      __swift_FORCE_LOAD_$_swiftCoreImage_$_YogaKit in libYogaKit.a(YGLayoutExtensions.o)
     (maybe you meant: __swift_FORCE_LOAD_$_swiftCoreImage_$_YogaKit)
  "associated type descriptor for Swift.ExpressibleByFloatLiteral.FloatLiteralType", referenced from:
      l_got.$s16FloatLiteralTypes013ExpressibleByaB0PTl in libYogaKit.a(YGLayoutExtensions.o)
  "__swift_FORCE_LOAD_$_swiftQuartzCore", referenced from:
      __swift_FORCE_LOAD_$_swiftQuartzCore_$_YogaKit in libYogaKit.a(YGLayoutExtensions.o)
     (maybe you meant: __swift_FORCE_LOAD_$_swiftQuartzCore_$_YogaKit)
  "__swift_FORCE_LOAD_$_swiftDispatch", referenced from:
      __swift_FORCE_LOAD_$_swiftDispatch_$_YogaKit in libYogaKit.a(YGLayoutExtensions.o)
     (maybe you meant: __swift_FORCE_LOAD_$_swiftDispatch_$_YogaKit)
  "method descriptor for Swift.ExpressibleByIntegerLiteral.init(integerLiteral: A.IntegerLiteralType) -> A", referenced from:
      l_got.$ss27ExpressibleByIntegerLiteralP07integerD0x0cD4TypeQz_tcfCTq in libYogaKit.a(YGLayoutExtensions.o)
  "__swift_FORCE_LOAD_$_swiftCoreFoundation", referenced from:
      __swift_FORCE_LOAD_$_swiftCoreFoundation_$_YogaKit in libYogaKit.a(YGLayoutExtensions.o)
     (maybe you meant: __swift_FORCE_LOAD_$_swiftCoreFoundation_$_YogaKit)
  "protocol witness table for Swift.Int : Swift._ExpressibleByBuiltinIntegerLiteral in Swift", referenced from:
      associated type witness table accessor for Swift.ExpressibleByIntegerLiteral.IntegerLiteralType : Swift._ExpressibleByBuiltinIntegerLiteral in __C.YGValue : Swift.ExpressibleByIntegerLiteral in YogaKit in libYogaKit.a(YGLayoutExtensions.o)
  "__swift_FORCE_LOAD_$_swiftObjectiveC", referenced from:
      __swift_FORCE_LOAD_$_swiftObjectiveC_$_YogaKit in libYogaKit.a(YGLayoutExtensions.o)
     (maybe you meant: __swift_FORCE_LOAD_$_swiftObjectiveC_$_YogaKit)
  "__swift_FORCE_LOAD_$_swiftCoreGraphics", referenced from:
      __swift_FORCE_LOAD_$_swiftCoreGraphics_$_YogaKit in libYogaKit.a(YGLayoutExtensions.o)
     (maybe you meant: __swift_FORCE_LOAD_$_swiftCoreGraphics_$_YogaKit)
  "_swift_getForeignTypeMetadata", referenced from:
      type metadata accessor for __C.YGValue in libYogaKit.a(YGLayoutExtensions.o)
      type metadata accessor for __C.YGUnit in libYogaKit.a(YGLayoutExtensions.o)
  "__swift_FORCE_LOAD_$_swiftFoundation", referenced from:
      __swift_FORCE_LOAD_$_swiftFoundation_$_YogaKit in libYogaKit.a(YGLayoutExtensions.o)
     (maybe you meant: __swift_FORCE_LOAD_$_swiftFoundation_$_YogaKit)
  "associated conformance descriptor for Swift.ExpressibleByFloatLiteral.Swift.ExpressibleByFloatLiteral.FloatLiteralType: Swift._ExpressibleByBuiltinFloatLiteral", referenced from:
      l_got.$ss25ExpressibleByFloatLiteralP0cD4TypeAB_s01_ab7BuiltincD0Tn in libYogaKit.a(YGLayoutExtensions.o)
  "__swift_FORCE_LOAD_$_swiftUIKit", referenced from:
      __swift_FORCE_LOAD_$_swiftUIKit_$_YogaKit in libYogaKit.a(YGLayoutExtensions.o)
     (maybe you meant: __swift_FORCE_LOAD_$_swiftUIKit_$_YogaKit)
  "__swift_FORCE_LOAD_$_swiftMetal", referenced from:
      __swift_FORCE_LOAD_$_swiftMetal_$_YogaKit in libYogaKit.a(YGLayoutExtensions.o)
     (maybe you meant: __swift_FORCE_LOAD_$_swiftMetal_$_YogaKit)
  "Swift.Float.init(Swift.Double) -> Swift.Float", referenced from:
      static (extension in YogaKit):CoreGraphics.CGFloat.% postfix(CoreGraphics.CGFloat) -> __C.YGValue in libYogaKit.a(YGLayoutExtensions.o)
      (extension in YogaKit):__C.YGValue.init(CoreGraphics.CGFloat) -> __C.YGValue in libYogaKit.a(YGLayoutExtensions.o)
  "__swift_FORCE_LOAD_$_swiftDarwin", referenced from:
      __swift_FORCE_LOAD_$_swiftDarwin_$_YogaKit in libYogaKit.a(YGLayoutExtensions.o)
     (maybe you meant: __swift_FORCE_LOAD_$_swiftDarwin_$_YogaKit)
  "protocol witness table for Swift.Float : Swift._ExpressibleByBuiltinFloatLiteral in Swift", referenced from:
      associated type witness table accessor for Swift.ExpressibleByFloatLiteral.FloatLiteralType : Swift._ExpressibleByBuiltinFloatLiteral in __C.YGValue : Swift.ExpressibleByFloatLiteral in YogaKit in libYogaKit.a(YGLayoutExtensions.o)
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. This should just be a brief oneline we can mention in our release notes: https://github.com/facebook/flipper/releases -->
- Removed flag
- Removed arch requirement from the workflow for swift sample

## Test Plan
 CI
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI / output of the test runner and how you invoked it. -->

