### PR TITLE
Upgrade to Gradle 6.8.1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -7,4 +7,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.1-all.zip


### PR DESCRIPTION
Summary:
Playing around with alternative upload options and having
an up-to-date Gradle installation makes that easier.

Test Plan:
./gradlew :sample:assembleDebug + CI