### PR TITLE
Network Plugin - fix highlighting issues in routes list

### DIFF
--- a/desktop/plugins/network/ManageMockResponsePanel.tsx
+++ b/desktop/plugins/network/ManageMockResponsePanel.tsx
@@ -24,13 +24,8 @@ import {MockResponseDetails} from './MockResponseDetails';
 import {NetworkRouteContext} from './index';
 import {RequestId} from './types';
 
-import {message} from 'antd';
+import {message, Modal} from 'antd';
 import {NUX, Layout} from 'flipper-plugin';
-
-import {Modal} from 'antd';
-import {ExclamationCircleOutlined} from '@ant-design/icons';
-
-//const { confirm } = Modal;
 
 type Props = {
   routes: {[id: string]: Route};

--- a/desktop/plugins/network/index.tsx
+++ b/desktop/plugins/network/index.tsx
@@ -124,7 +124,7 @@ const TextEllipsis = styled(Text)({
 
 // State management
 export interface NetworkRouteManager {
-  addRoute(): void;
+  addRoute(): string | null;
   modifyRoute(id: string, routeChange: Partial<Route>): void;
   removeRoute(id: string): void;
   copyHighlightedCalls(
@@ -137,7 +137,9 @@ export interface NetworkRouteManager {
   clearRoutes(): void;
 }
 const nullNetworkRouteManager: NetworkRouteManager = {
-  addRoute() {},
+  addRoute(): string | null {
+    return '';
+  },
   modifyRoute(_id: string, _routeChange: Partial<Route>) {},
   removeRoute(_id: string) {},
   copyHighlightedCalls(
@@ -330,14 +332,14 @@ export function plugin(client: PluginClient<Events, Methods>) {
       routes.set(newRoutes);
       isMockResponseSupported.set(result);
       showMockResponseDialog.set(false);
-      nextRouteId.set(Object.keys(routes).length);
+      nextRouteId.set(Object.keys(routes.get()).length);
 
       informClientMockChange(routes.get());
     });
 
     // declare new variable to be called inside the interface
     networkRouteManager.set({
-      addRoute() {
+      addRoute(): string | null {
         const newNextRouteId = nextRouteId.get();
         routes.update((draft) => {
           draft[newNextRouteId.toString()] = {
@@ -349,6 +351,7 @@ export function plugin(client: PluginClient<Events, Methods>) {
           };
         });
         nextRouteId.set(newNextRouteId + 1);
+        return String(newNextRouteId);
       },
       modifyRoute(id: string, routeChange: Partial<Route>) {
         if (!routes.get().hasOwnProperty(id)) {


### PR DESCRIPTION
## Summary

Fix problems with row highlighting on mocks route list.  When selecting a row, the highlight would sometimes be on the wrong row.  Also, when adding routes, the routes would sometimes get added in the middle of the list instead of at the end.

These problems were caused by incorrectly referencing route rows in code.  Sometimes index was used and other times the key was used.  Fixed by consistently using key.

This fixes the problem described in issue https://github.com/facebook/flipper/issues/1733

## Changelog

Network Plugin - fix problems with row highlighting on mocks route list

## Test Plan

Manually test multiple scenarios of adding/deleting/selecting route rows.

Test Plan:

Start with no mocks | No rows should be shown | TRUE
Add a single mock | First (and only row should be highlighted) | TRUE
Delete mock | No rows should be shown | TRUE
Add single mockAdd another mock | 2nd row should be highlighted | TRUE
Add another mock | 3rd row should be highlighted | TRUE
Add 2 more mocks and assign number to each row (5 total) | Last row should be highlighted | TRUE
Select 1st row | 1st row should be highlighted | TRUE
Delete 1st row | 1st row should be highlighed | TRUE
Select last row | last row should be highlighted | TRUE
Delete last row | last row should be deleted and new last row should be highlighted | TRUE
Highlight a middle row (row 3) | middle row should be highlighted | TRUE
Delete middle row | middle row should be deleted and last row should be in its place and should be highlighted | TRUE


