### PR TITLE
[release_infra] Fix upload of sample app apk

### DIFF
--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - v*
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to upload artifacts to"
+        required: false
+
 
 jobs:
   build:
@@ -37,9 +42,11 @@ jobs:
         SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
     - name: Rename apk
       run: mv android/sample/build/outputs/apk/debug/sample-debug.apk SampleApp-android.apk
-    - name: Upload Sample App
-      uses: skx/github-action-publish-binaries@master
+    - name: Attach sample APK to release
+      if: ${{ github.event.inputs.tag != '' }}
+      uses: passy/github-upload-release-artifacts-action@v2.1.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
+        created_tag: ${{ github.event.inputs.tag }}
         args: 'SampleApp-android.apk'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,20 +181,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Publish Workflow Dispatch
-      if: ${{ needs.release.outputs.tag != '' }}
-      uses: benc-uk/workflow-dispatch@v1.1
-      with:
-        workflow: Publish Pods
-        token: ${{ secrets.PERSONAL_TOKEN }}
-        ref: ${{ needs.release.outputs.tag }}
-    - name: Publish NPM
-      if: ${{ needs.release.outputs.tag != '' }}
-      uses: benc-uk/workflow-dispatch@v1.1
-      with:
-        workflow: Publish NPM
-        token: ${{ secrets.PERSONAL_TOKEN }}
-        ref: ${{ needs.release.outputs.tag }}
     - name: Publish Android
       if: ${{ needs.release.outputs.tag != '' }}
       uses: benc-uk/workflow-dispatch@v1.1
@@ -202,3 +188,4 @@ jobs:
         workflow: Publish Android
         token: ${{ secrets.PERSONAL_TOKEN }}
         ref: ${{ needs.release.outputs.tag }}
+        input: '{"tag": "${{ needs.release.outputs.tag }}"}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,6 +181,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Publish Workflow Dispatch
+      if: ${{ needs.release.outputs.tag != '' }}
+      uses: benc-uk/workflow-dispatch@v1.1
+      with:
+        workflow: Publish Pods
+        token: ${{ secrets.PERSONAL_TOKEN }}
+        ref: ${{ needs.release.outputs.tag }}
+    - name: Publish NPM
+      if: ${{ needs.release.outputs.tag != '' }}
+      uses: benc-uk/workflow-dispatch@v1.1
+      with:
+        workflow: Publish NPM
+        token: ${{ secrets.PERSONAL_TOKEN }}
+        ref: ${{ needs.release.outputs.tag }}
     - name: Publish Android
       if: ${{ needs.release.outputs.tag != '' }}
       uses: benc-uk/workflow-dispatch@v1.1
@@ -188,4 +202,4 @@ jobs:
         workflow: Publish Android
         token: ${{ secrets.PERSONAL_TOKEN }}
         ref: ${{ needs.release.outputs.tag }}
-        input: '{"tag": "${{ needs.release.outputs.tag }}"}'
+        inputs: '{"tag": "${{ needs.release.outputs.tag }}"}'


### PR DESCRIPTION
## Summary

This was an expected failure, you can see here how the last step of the "Publish Android" workflow currently fails: https://github.com/facebook/flipper/runs/1873750507?check_suite_focus=true

This is because it no longer runs in a tagging context. We're now providing the tag as an input and my custom action knows how to attach to existing tags by name.

## Test Plan

Test run here finished successfully: https://github.com/passy/flipper-1/actions/runs/560774414
Publish Android job: https://github.com/passy/flipper-1/actions/runs/560775419
Attached release: https://github.com/passy/flipper-1/releases/tag/v0.0.7
