### PR TITLE
Cache Android builds on GitHub Actions

### DIFF
--- a/.github/workflows/android-sample.yml
+++ b/.github/workflows/android-sample.yml
@@ -15,6 +15,15 @@ jobs:
         java-version: 1.8
     - name: Install NDK 21
       run: echo "y" | sudo /usr/local/lib/android/sdk/tools/bin/sdkmanager --install "ndk;21.0.6113669" "ndk;20.0.5594570" --sdk_root=${ANDROID_SDK_ROOT}
+    - name: Compute build cache
+      run: ./scripts/checksum-android.sh checksum-android.txt
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/.gradle/caches/modules-*
+          ~/.gradle/caches/jars-*
+          ~/.gradle/caches/build-cache-*
+        key: gradle-${{ hashFiles('checksum-android.txt') }}
     - name: Build with Gradle
       run: ./gradlew :sample:assembleDebug :tutorial:assembleDebug
     - name: upload artifact

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -28,6 +28,15 @@ jobs:
       run: echo '${{ secrets.GPG_KEY_CONTENTS }}' | base64 -d > /tmp/secring.gpg
     - name: Update gradle.properties
       run: echo -e "signing.secretKeyRingFile=/tmp/secring.gpg\nsigning.keyId=${{ secrets.SIGNING_KEY_ID }}\nsigning.password=${{ secrets.SIGNING_PASSWORD }}" >> gradle.properties
+    - name: Compute build cache
+      run: ./scripts/checksum-android.sh checksum-android.txt
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/.gradle/caches/modules-*
+          ~/.gradle/caches/jars-*
+          ~/.gradle/caches/build-cache-*
+        key: gradle-${{ hashFiles('checksum-android.txt') }}
     - name: Build artifacts
       run: ./gradlew :sample:assembleDebug :sample:assembleRelease && ./gradlew :android:assembleRelease
     - name: Upload Archives

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -40,6 +40,9 @@ jobs:
       env:
         SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
         SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
+    - name: Clean secrets
+      if: always()
+      run: rm /tmp/secring.gpg
     - name: Rename apk
       run: mv android/sample/build/outputs/apk/debug/sample-debug.apk SampleApp-android.apk
     - name: Attach sample APK to release

--- a/scripts/checksum-android.sh
+++ b/scripts/checksum-android.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+RESULT_FILE=$1
+
+if [ -f $RESULT_FILE ]; then
+  rm $RESULT_FILE
+fi
+touch $RESULT_FILE
+
+checksum_file() {
+  echo $(openssl sha256 $1 | awk '{print $2}')
+}
+
+FILES=()
+while read -r -d ''; do
+	FILES+=("$REPLY")
+done < <(find . -type f \( -name "build.gradle*" -o -name "gradle-wrapper.properties" \) -print0)
+
+# Loop through files and append checksum to result file
+for FILE in ${FILES[@]}; do
+	echo $(checksum_file $FILE) >> $RESULT_FILE
+done
+
+sort $RESULT_FILE -o $RESULT_FILE


### PR DESCRIPTION
Summary:
Builds up a file with checksums of all `build.gradle` files. Deliberately excludes the `gradle.properties` which changes all the time. The cache shouldn't require nuking except in some rare circumstances.

Test Plan:
From 41 minutes down to 17: https://github.com/passy/flipper-1/actions/runs/561501374
