### PR TITLE
[android] Move bolts dependencies to Fresco plugin

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -74,9 +74,6 @@ android {
         testImplementation deps.testRules
         testImplementation deps.hamcrest
         testImplementation deps.junit
-
-        api 'com.parse.bolts:bolts-tasks:1.4.0'
-        api 'com.parse.bolts:bolts-applinks:1.4.0'
     }
 }
 

--- a/android/plugins/fresco/build.gradle
+++ b/android/plugins/fresco/build.gradle
@@ -23,6 +23,9 @@ android {
         implementation deps.frescoFlipper
         compileOnly deps.jsr305
 
+        api deps.boltsTasks
+        api deps.boltsApplinks
+
         // Exclude the actual stetho dep as we only want some of the fresco APIs here
         implementation(deps.frescoStetho) {
             exclude group: 'com.facebook.stetho'

--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,8 @@ ext.deps = [
         // First-party
         soloader           : 'com.facebook.soloader:soloader:0.10.1',
         screenshot         : 'com.facebook.testing.screenshot:core:0.5.0',
+        boltsTasks         : 'com.parse.bolts:bolts-tasks:1.4.0',
+        boltsApplinks      : 'com.parse.bolts:bolts-applinks:1.4.0',
         // Annotations
         jsr305             : 'com.google.code.findbugs:jsr305:3.0.2',
         inferAnnotations   : 'com.facebook.infer.annotation:infer-annotation:0.11.2',


### PR DESCRIPTION
Summary:

Fixes https://github.com/facebook/flipper/issues/1919

Somehow the diff author put the dependencies in the root `build.gradle`, which is unnecessary as this is only used by Fresco.

Test Plan:

Built the sample app, checked that the Fresco stuff continues to work.
![Screenshot_1613565381](https://user-images.githubusercontent.com/9906/108205459-0366ef80-711d-11eb-8b3b-f804f02622af.png)


