### PR TITLE
Fix the regex to allow xcode from non standard location

### DIFF
--- a/desktop/app/src/dispatcher/__tests__/iOSDevice.node.tsx
+++ b/desktop/app/src/dispatcher/__tests__/iOSDevice.node.tsx
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+import {parseXcodeFromCoreSimPath} from '../iOSDevice';
+
+const standardCoresimulatorLog =
+  'username            1264   0.0  0.1  5989740  41648   ??  Ss    2:23PM   0:12.92 /Applications/Xcode_12.4.0_fb.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/libexec/mobileassetd';
+
+const nonStandardCoresimulatorLog =
+  'username            1264   0.0  0.1  5989740  41648   ??  Ss    2:23PM   0:12.92 /Some/Random/Path/Xcode_12.4.0_fb.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/libexec/mobileassetd';
+
+const nonStandardSpecialCharacterAphanumericCoresimulatorLog =
+  'username            1264   0.0  0.1  5989740  41648   ??  Ss    2:23PM   0:12.92 /Some_R@d0m/Path-3455355/path(2)+connection/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/libexec/mobileassetd';
+
+test('test parseXcodeFromCoreSimPath from non standard locations', () => {
+  const match = parseXcodeFromCoreSimPath(nonStandardCoresimulatorLog);
+  expect(match && match.length > 0).toBeTruthy();
+  expect(
+    // @ts-ignore the null and non zero lenght check for match is already done above
+    match[0],
+  ).toEqual('/Some/Random/Path/Xcode_12.4.0_fb.app/Contents/Developer');
+});
+
+test('test parseXcodeFromCoreSimPath from non standard alphanumeric special character locations', () => {
+  const match = parseXcodeFromCoreSimPath(
+    nonStandardSpecialCharacterAphanumericCoresimulatorLog,
+  );
+  expect(match && match.length > 0).toBeTruthy();
+  expect(
+    // @ts-ignore the null and non zero lenght check for match is already done above
+    match[0],
+  ).toEqual(
+    '/Some_R@d0m/Path-3455355/path(2)+connection/Xcode.app/Contents/Developer',
+  );
+});
+
+test('test parseXcodeFromCoreSimPath from standard locations', () => {
+  const match = parseXcodeFromCoreSimPath(standardCoresimulatorLog);
+  expect(match && match.length > 0).toBeTruthy();
+  expect(
+    // @ts-ignore the null and non zero lenght check for match is already done above
+    match[0],
+  ).toEqual('/Applications/Xcode_12.4.0_fb.app/Contents/Developer');
+});

--- a/desktop/app/src/dispatcher/iOSDevice.tsx
+++ b/desktop/app/src/dispatcher/iOSDevice.tsx
@@ -231,7 +231,14 @@ function queryDevicesForever(store: Store, logger: Logger) {
     });
 }
 
+export function parseXcodeFromCoreSimPath(
+  line: string,
+): RegExpMatchArray | null {
+  return line.match(/\/[\/\w@)(\-\+]*\/Xcode[^/]*\.app\/Contents\/Developer/);
+}
+
 let xcodeVersionMismatchFound = false;
+
 async function checkXcodeVersionMismatch(store: Store) {
   if (xcodeVersionMismatchFound) {
     return;
@@ -241,9 +248,7 @@ async function checkXcodeVersionMismatch(store: Store) {
     xcodeCLIVersion = xcodeCLIVersion.trim();
     const {stdout} = await exec('ps aux | grep CoreSimulator');
     for (const line of stdout.split('\n')) {
-      const match = line.match(
-        /\/Applications\/Xcode[^/]*\.app\/Contents\/Developer/,
-      );
+      const match = parseXcodeFromCoreSimPath(line);
       const runningVersion = match && match.length > 0 ? match[0].trim() : null;
       if (runningVersion && runningVersion !== xcodeCLIVersion) {
         const errorMessage = `Xcode version mismatch: Simulator is running from "${runningVersion}" while Xcode CLI is "${xcodeCLIVersion}". Running "xcode-select --switch ${runningVersion}" can fix this. For example: "sudo xcode-select -s /Applications/Xcode.app/Contents/Developer"`;


### PR DESCRIPTION
Summary: This diff fixes T84865014. We used to assume in our xcode cli check that xcode will be run from standard /Applications folder. But as mentioned in the above tasks, its not always true.

Differential Revision: D26484287

