### PR TITLE
[android] Enable prefab for fbjni integration

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -55,6 +55,7 @@ file(GLOB libfbjni_include_DIRS "${build_DIR}/fbjni-*-headers.jar/")
 # Without NO_CMAKE_FIND_ROOT_PATH, this will for some bizarre reason only look
 # in the NDK folder.
 find_library(FBJNI_LIBRARY fbjni PATHS ${libfbjni_link_DIRS} NO_CMAKE_FIND_ROOT_PATH)
+find_package(fbjni REQUIRED CONFIG)
 
 add_subdirectory(${libflipper_DIR} ${libflipper_build_DIR})
 
@@ -73,4 +74,4 @@ target_include_directories(${PACKAGE_NAME} PRIVATE
     ${LIBEVENT_DIR}/include/event2
     )
 
-target_link_libraries(${PACKAGE_NAME} ${FBJNI_LIBRARY} flippercpp)
+target_link_libraries(${PACKAGE_NAME} fbjni::fbjni flippercpp)

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -49,19 +49,12 @@ set(libflipper_build_DIR ${build_DIR}/libflipper/${ANDROID_ABI})
 set(libfolly_build_DIR ${build_DIR}/libfolly/${ANDROID_ABI})
 
 file(MAKE_DIRECTORY ${build_DIR})
-file(GLOB libfbjni_link_DIRS "${build_DIR}/fbjni*/jni/${ANDROID_ABI}")
-file(GLOB libfbjni_include_DIRS "${build_DIR}/fbjni-*-headers.jar/")
-
-# Without NO_CMAKE_FIND_ROOT_PATH, this will for some bizarre reason only look
-# in the NDK folder.
-find_library(FBJNI_LIBRARY fbjni PATHS ${libfbjni_link_DIRS} NO_CMAKE_FIND_ROOT_PATH)
 find_package(fbjni REQUIRED CONFIG)
 
 add_subdirectory(${libflipper_DIR} ${libflipper_build_DIR})
 
 target_include_directories(${PACKAGE_NAME} PRIVATE
     ${libjnihack_DIR}
-    ${libfbjni_include_DIRS}
     ${libflipper_DIR}
     ${libfolly_DIR}
     ${glog_DIR}

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,7 +28,7 @@ android {
 
         externalNativeBuild {
             cmake {
-                arguments '-DANDROID_TOOLCHAIN=clang', '-DANDROID_STL=c++_static'
+                arguments '-DANDROID_TOOLCHAIN=clang', '-DANDROID_STL=c++_shared'
                 targets 'flipper', 'event_shared', 'event_extra_shared', 'event_core_shared'
             }
         }
@@ -51,6 +51,9 @@ android {
         }
     }
 
+    buildFeatures {
+        prefab true
+    }
 
     externalNativeBuild {
         cmake {
@@ -60,10 +63,7 @@ android {
 
     dependencies {
         compileOnly deps.proguardAnnotations
-        // Temporary until we upgrade to prefabs: https://developer.android.com/studio/releases/gradle-plugin#native-dependencies
-        implementation 'com.facebook.fbjni:fbjni-java-only:0.0.4'
-        extractHeaders 'com.facebook.fbjni:fbjni:0.0.4:headers'
-        extractJNI 'com.facebook.fbjni:fbjni:0.0.4'
+        implementation 'com.facebook.fbjni:fbjni:0.0.6-SNAPSHOT'
         implementation deps.soloader
         implementation deps.jsr305
         implementation deps.supportAppCompat

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,11 +38,6 @@ android {
         abortOnError false
     }
 
-    configurations {
-        extractHeaders
-        extractJNI
-    }
-
     sourceSets {
         test {
             java {
@@ -86,43 +81,3 @@ android {
 preBuild.dependsOn(tasks.getByPath(':third-party:prepare'))
 
 apply plugin: 'com.vanniktech.maven.publish'
-
-task sourcesJar(type: Jar) {
-    from android.sourceSets.main.java.srcDirs
-    classifier = 'sources'
-}
-
-artifacts.add('archives', sourcesJar)
-
-task extractAARHeaders {
-    doLast {
-        configurations.extractHeaders.files.each {
-            def file = it.absoluteFile
-            copy {
-                from zipTree(file)
-                into "$buildDir/$file.name"
-                include "**/*.h"
-            }
-        }
-    }
-}
-
-task extractJNIFiles {
-    doLast {
-        configurations.extractJNI.files.each {
-            def file = it.absoluteFile
-            copy {
-                from zipTree(file)
-                into "$buildDir/$file.name"
-                include "jni/**/*"
-            }
-        }
-    }
-}
-
-tasks.whenTaskAdded { task ->
-    if (task.name.contains('externalNativeBuild')) {
-        task.dependsOn(extractAARHeaders)
-        task.dependsOn(extractJNIFiles)
-    }
-}

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -63,7 +63,7 @@ android {
 
     dependencies {
         compileOnly deps.proguardAnnotations
-        implementation 'com.facebook.fbjni:fbjni:0.0.6-SNAPSHOT'
+        implementation 'com.facebook.fbjni:fbjni:0.1.0'
         implementation deps.soloader
         implementation deps.jsr305
         implementation deps.supportAppCompat

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -55,6 +55,11 @@ android {
         prefab true
     }
 
+    packagingOptions {
+        exclude("**/libfbjni.so")
+        exclude("**/libc++_shared.so")
+    }
+
     externalNativeBuild {
         cmake {
             path './CMakeLists.txt'


### PR DESCRIPTION
Summary:
I'm in the progress of releasing a prefab-enabled FBJNI release. This dramatically reduces the hackery around integrating with separately released native libraries.

This will fail until the release is actually out.

Test Plan:
`./gradlew :sample:installDebug` works as before.
Once the release is out, we need to check if this creates any problems with RN but because we advice to exclude the dependency, I expect it not to cause any trouble.