### PR TITLE
Network Plugin - Add remaining HTTP method types to mock routes

### DIFF
--- a/desktop/plugins/network/MockResponseDetails.tsx
+++ b/desktop/plugins/network/MockResponseDetails.tsx
@@ -245,7 +245,17 @@ export function MockResponseDetails({id, route, isDuplicated}: Props) {
           <StyledSelect
             grow={true}
             selected={requestMethod}
-            options={{GET: 'GET', POST: 'POST'}}
+            options={{
+              GET: 'GET',
+              POST: 'POST',
+              PATCH: 'PATCH',
+              HEAD: 'HEAD',
+              PUT: 'PUT',
+              DELETE: 'DELETE',
+              TRACE: 'TRACE',
+              OPTIONS: 'OPTIONS',
+              CONNECT: 'CONNECT',
+            }}
             onChange={(text: string) =>
               networkRouteManager.modifyRoute(id, {requestMethod: text})
             }


### PR DESCRIPTION
## Summary

Currently, mock routes can only be created for GET and POST HTTP method types.  Mocks should support all the valid HTTP method types.

See specification for a list of valid types:

    https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html

This was requested in issue: https://github.com/facebook/flipper/issues/1960

Here is a screen shot showing the new values added to the select list:

![image](https://user-images.githubusercontent.com/337874/108955120-418b7400-7633-11eb-9248-63d9639e0c4f.png)


## Changelog

Network Plugin - support all valid HTTP method types in mock routes

## Test Plan

Define mock routes using additional method types
Using "Flipper Messages" plugin, verify that new types have been sent to device


