### PR TITLE
Fix idb test

### DIFF
--- a/desktop/app/src/utils/IOSBridge.tsx
+++ b/desktop/app/src/utils/IOSBridge.tsx
@@ -65,8 +65,11 @@ function xcrunStartLogListener(udid: string) {
   );
 }
 
-export async function makeIOSBridge(idbPath: string): Promise<IOSBridge> {
-  if (await isAvailable(idbPath)) {
+export async function makeIOSBridge(
+  idbPath: string,
+  isAvailableFn: (idbPath: string) => Promise<boolean> = isAvailable,
+): Promise<IOSBridge> {
+  if (await isAvailableFn(idbPath)) {
     return {
       startLogListener: idbStartLogListener.bind(null, idbPath),
     };

--- a/desktop/app/src/utils/__tests__/IOSBridge.node.tsx
+++ b/desktop/app/src/utils/__tests__/IOSBridge.node.tsx
@@ -38,7 +38,7 @@ test('uses xcrun with no idb', async () => {
 });
 
 test('uses idb when present', async () => {
-  const ib = await makeIOSBridge('/usr/local/bin/idb');
+  const ib = await makeIOSBridge('/usr/local/bin/idb', async (_) => true);
   ib.startLogListener('deadbeef');
 
   expect(spawn).toHaveBeenCalledWith(

--- a/website/package.json
+++ b/website/package.json
@@ -24,9 +24,6 @@
     "react-docgen": "^5.2.1",
     "react-dom": "^16.13.1"
   },
-  "dependencies": {
-    "prismjs": "1.23.0"
-  },
   "resolutions": {
     "axios": "0.21.1",
     "minimist": "1.2.3",
@@ -34,6 +31,7 @@
     "serialize-javascript": "^3.1.0",
     "node-forge": "^0.10.0",
     "node-fetch": "^2.6.1",
-    "immer": "^8.0.1"
+    "immer": "^8.0.1",
+    "prismjs": "1.23.0"
   }
 }

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -9618,17 +9618,10 @@ prism-react-renderer@^1.1.1:
   resolved "https://registry.yarnpkg.com/prism-react-renderer/-/prism-react-renderer-1.1.1.tgz#1c1be61b1eb9446a146ca7a50b7bcf36f2a70a44"
   integrity sha512-MgMhSdHuHymNRqD6KM3eGS0PNqgK9q4QF5P0yoQQvpB6jNjeSAi3jcSAz0Sua/t9fa4xDOMar9HJbLa08gl9ug==
 
-prismjs@1.23.0:
+prismjs@1.23.0, prismjs@^1.22.0:
   version "1.23.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.23.0.tgz#d3b3967f7d72440690497652a9d40ff046067f33"
   integrity sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==
-  optionalDependencies:
-    clipboard "^2.0.0"
-
-prismjs@^1.22.0:
-  version "1.22.0"
-  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.22.0.tgz#73c3400afc58a823dd7eed023f8e1ce9fd8977fa"
-  integrity sha512-lLJ/Wt9yy0AiSYBf212kK3mM5L8ycwlyTlSxHBAneXLR0nzFMlZ5y7riFPF3E33zXOF2IH95xdY5jIyZbM9z/w==
   optionalDependencies:
     clipboard "^2.0.0"
 


### PR DESCRIPTION
Summary:
Erm, I'm a bit of a dummy. I didn't mock the access check, so it would actually
rely on idb being installed to run the tests correctly. Without, we'd fail like here
on GitHub: https://github.com/facebook/flipper/runs/2021551466

I couldn't quite figure out how to mock `fs.promises.access`, so I made the constructor
configurable, which doesn't seem that bad, actually.

Reviewed By: mweststrate

Differential Revision: D26778428

