### PR TITLE
[dependabot] Add more gradle sub projects

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,7 +25,61 @@ updates:
     time: '13:00'
   open-pull-requests-limit: 10
 - package-ecosystem: gradle
+  directory: "/"
+  schedule:
+    interval: weekly
+    time: '13:00'
+  open-pull-requests-limit: 10
+- package-ecosystem: gradle
   directory: "/android"
+  schedule:
+    interval: weekly
+    time: '13:00'
+  open-pull-requests-limit: 10
+- package-ecosystem: gradle
+  directory: "/android/tutorial"
+  schedule:
+    interval: weekly
+    time: '13:00'
+  open-pull-requests-limit: 10
+- package-ecosystem: gradle
+  directory: "/android/sample"
+  schedule:
+    interval: weekly
+    time: '13:00'
+  open-pull-requests-limit: 10
+- package-ecosystem: gradle
+  directory: "/android/no-op"
+  schedule:
+    interval: weekly
+    time: '13:00'
+  open-pull-requests-limit: 10
+- package-ecosystem: gradle
+  directory: "/android/plugins/fresco"
+  schedule:
+    interval: weekly
+    time: '13:00'
+  open-pull-requests-limit: 10
+- package-ecosystem: gradle
+  directory: "/android/plugins/network"
+  schedule:
+    interval: weekly
+    time: '13:00'
+  open-pull-requests-limit: 10
+- package-ecosystem: gradle
+  directory: "/android/plugins/litho"
+  schedule:
+    interval: weekly
+    time: '13:00'
+  open-pull-requests-limit: 10
+- package-ecosystem: gradle
+  directory: "/android/plugins/leakcanary"
+  schedule:
+    interval: weekly
+    time: '13:00'
+  open-pull-requests-limit: 10
+- package-ecosystem: gradle
+  directory: "/android/plugins/leakcanary2"
   schedule:
     interval: weekly
     time: '13:00'


### PR DESCRIPTION
Summary:

I don't fully understand how dependabot works with Android but it seems to only look at the literal fbjni version number based on the logs and we're actually outdated on a bunch of dependencies which Gradle doesn't handle very well.

Test Plan:
Tested on my fork and I've got a ton of PRs because of this. Brace yourselves.