### PR TITLE
[website] use splash gradient in footer, switch to GitHub icon

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -52,14 +52,15 @@ const siteConfig = {
           position: 'right',
         },
         {
-          href: repoUrl,
-          label: 'GitHub',
-          position: 'right',
-        },
-        {
           to: 'docs/internals/index',
           label: 'Under the Hood',
           position: 'right',
+        },
+        {
+          href: repoUrl,
+          position: 'right',
+          'aria-label': 'GitHub repository',
+          className: 'navbar-github-link',
         },
       ],
     },

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -386,6 +386,10 @@ footer iframe {
   margin-top: 8px;
 }
 
+.footer--dark {
+  background: linear-gradient(#21233e, #121020);
+}
+
 @media screen and (max-width: 736px) {
   .docsNavContainer,
   .docsSliderActive nav.toc .navBreadcrumb {
@@ -493,4 +497,23 @@ footer iframe {
 .button:hover {
   background-color: rgba(0, 0, 0, 0.1);
   color: inherit;
+}
+
+.navbar__brand:hover {
+  color: var(--ifm-navbar-link-hover-color);
+}
+
+.navbar-github-link:after {
+  transition: opacity 0.2s;
+  content: "";
+  width: 24px;
+  height: 24px;
+  display: flex;
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill='%23fff' d='M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: center;
+}
+
+.navbar-github-link:hover:after {
+  opacity: 0.5;
 }


### PR DESCRIPTION
## Summary

This small PR aims to tweak a bit website appearance and fix small UI issue:
* footer background has been changed to reversed splash gradient
  <img width="1104" alt="Screenshot 2021-03-04 131823" src="https://user-images.githubusercontent.com/719641/109964907-8cba1c80-7cee-11eb-8905-2fa82533cfd7.png">
* GitHub link in the Navbar has been moved to the tight and text was replaced with icon (like on few other Docusaurus sites)
  <img width="557" alt="Screenshot 2021-03-04 133112" src="https://user-images.githubusercontent.com/719641/109965233-f9351b80-7cee-11eb-84d6-30788f662fbf.png">
* Navbar brand title ("Flipper") hover color issues has been fixed, now hover effect is the same as other navbar links

## Changelog

N/A

## Test Plan

Flipper website run on `localhost`.

