### PR TITLE
Upgrade to FBJNI 0.2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -63,7 +63,7 @@ android {
 
     dependencies {
         compileOnly deps.proguardAnnotations
-        implementation 'com.facebook.fbjni:fbjni:0.1.0'
+        implementation deps.fbjni
         implementation deps.soloader
         implementation deps.jsr305
         implementation deps.supportAppCompat

--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,7 @@ ext.deps = [
         archPaging         : 'android.arch.paging:runtime:1.0.0',
         // First-party
         soloader           : 'com.facebook.soloader:soloader:0.10.1',
+        fbjni              : 'com.facebook.fbjni:fbjni:0.2.0',
         screenshot         : 'com.facebook.testing.screenshot:core:0.5.0',
         boltsTasks         : 'com.parse.bolts:bolts-tasks:1.4.0',
         boltsApplinks      : 'com.parse.bolts:bolts-applinks:1.4.0',


### PR DESCRIPTION
Summary:
This should fix https://github.com/facebook/flipper/issues/1968

Test Plan:
Built our sample app; built the sample app provided in the repo as part
of the issue; locally released the Flipper artifacts and built the RN
app against it.