### PR TITLE
Fixes the Flipper-RSocket podspec to exclude .txt and .md files

### DIFF
--- a/iOS/Podspecs/Flipper-RSocket.podspec
+++ b/iOS/Podspecs/Flipper-RSocket.podspec
@@ -13,15 +13,15 @@ Pod::Spec.new do |spec|
   spec.source = { :git => 'https://github.com/priteshrnandgaonkar/rsocket-cpp.git', :tag => "0.11.0"}
   spec.module_name = 'RSocket'
   spec.static_framework = true
-  spec.source_files = 'rsocket/benchmarks/*',
-                      'rsocket/framing/*',
-                      'rsocket/internal/*',
-                      'rsocket/statemachine/*',
-                      'rsocket/transports/*',
-                      'rsocket/transports/**/*',
-                      'yarpl/observable/*',
-                      'yarpl/flowable/*',
-                      'rsocket/*'
+  spec.source_files = 'rsocket/benchmarks/*.{h,cpp,m,mm}',
+                      'rsocket/framing/*.{h,cpp,m,mm}',
+                      'rsocket/internal/*.{h,cpp,m,mm}',
+                      'rsocket/statemachine/*.{h,cpp,m,mm}',
+                      'rsocket/transports/*.{h,cpp,m,mm}',
+                      'rsocket/transports/**/*.{h,cpp,m,mm}',
+                      'yarpl/observable/*.{h,cpp,m,mm}',
+                      'yarpl/flowable/*.{h,cpp,m,mm}',
+                      'rsocket/*.{h,cpp,m,mm}'
 
   spec.libraries = "stdc++"
   spec.compiler_flags = '-std=c++1y'


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Fixes the Flipper-RSocket podspec similar to the [RSocket podpec](https://github.com/facebook/flipper/pull/1438) to exclude the .md and .txt files from the compilation, which is throwing a warning.

Removal of these warnings:

```
warning: no rule to process file '<redacted>/ios/Pods/Flipper-RSocket/rsocket/benchmarks/CMakeLists.txt' of type 'text' for architecture 'arm64' (in target 'Flipper-RSocket' from project 'Pods')
warning: no rule to process file '<redacted>/ios/Pods/Flipper-RSocket/rsocket/benchmarks/README.md' of type 'net.daringfireball.markdown' for architecture 'arm64' (in target 'Flipper-RSocket' from project 'Pods')
warning: no rule to process file '<redacted>/ios/Pods/Flipper-RSocket/rsocket/README.md' of type 'net.daringfireball.markdown' for architecture 'arm64' (in target 'Flipper-RSocket' from project 'Pods')
```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

Fix Flipper-RSocket podspec to exclude .txt and .md files from being included in the compilation

<!-- Help reviewers and the release process by writing your own changelog entry. This should just be a brief oneline we can mention in our release notes: https://github.com/facebook/flipper/releases -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI / output of the test runner and how you invoked it. -->

