### PR TITLE
Update leak-canary-2-plugin.mdx

### DIFF
--- a/docs/setup/leak-canary-2-plugin.mdx
+++ b/docs/setup/leak-canary-2-plugin.mdx
@@ -9,7 +9,7 @@ Ensure that you already have an explicit dependency in your application's
 
 ```groovy
 dependencies {
-  debugImplementation 'com.facebook.flipper:flipper-leakcanary2-plugin:0.76.0'
+  debugImplementation 'com.facebook.flipper:flipper-leakcanary2-plugin:0.81.0'
   debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.6'
 }
 ```


### PR DESCRIPTION
Update the LeakCanary 2 plugin version in LeakCanary 2 plugin doc

## Summary
While adding the version as in the doc, the import statements didn't work. Upon checking the maven repo, I found out that the latest version is `0.81.0`. Updating to the latest version helps

## Changelog
Updated LeakCanary 2  plugin docs to include the latest plugin version

## Test Plan
Not necessary

