### PR TITLE
Fix React Native build

### DIFF
--- a/.github/workflows/react-native-example.yml
+++ b/.github/workflows/react-native-example.yml
@@ -8,7 +8,9 @@ jobs:
         working-directory: react-native/ReactNativeFlipperExample
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-node@v2.1.5
+      with:
+        node-version: 12.x
     - uses: maxim-lobanov/setup-cocoapods@v1
       with:
         # Path to Podfile.lock file to determine Cocoapods version

--- a/.github/workflows/react-native-example.yml
+++ b/.github/workflows/react-native-example.yml
@@ -35,7 +35,9 @@ jobs:
         working-directory: react-native/ReactNativeFlipperExample
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-node@v2.1.5
+      with:
+        node-version: 12.x
     - name: set up JDK 1.8
       uses: actions/setup-java@v1
       with:


### PR DESCRIPTION
Summary:
Currently failing because the 0.64.x build requires Node >= 0.12

Test Plan:
CI
