### PR TITLE
Fix failing build by not propagating deployment target to deps

### DIFF
--- a/desktop/app/package.json
+++ b/desktop/app/package.json
@@ -28,7 +28,9 @@
     "archiver": "^5.0.2",
     "async-mutex": "^0.3.1",
     "axios": "^0.21.1",
+    "cbuffer": "^2.2.0",
     "console-feed": "^3.2.1",
+    "crc32": "^0.2.2",
     "deep-equal": "^2.0.1",
     "expand-tilde": "^2.0.2",
     "flipper-client-sdk": "^0.0.3",
@@ -75,8 +77,7 @@
     "uuid": "^8.3.2",
     "which": "^2.0.1",
     "ws": "^7.4.2",
-    "xdg-basedir": "^4.0.0",
-    "cbuffer": "^2.2.0"
+    "xdg-basedir": "^4.0.0"
   },
   "optionalDependencies": {
     "7zip-bin-mac": "^1.0.1"

--- a/desktop/app/src/dispatcher/plugins.tsx
+++ b/desktop/app/src/dispatcher/plugins.tsx
@@ -43,6 +43,8 @@ import * as Immer from 'immer';
 import * as antd from 'antd';
 import * as emotion_styled from '@emotion/styled';
 import * as antdesign_icons from '@ant-design/icons';
+// @ts-ignore
+import * as crc32 from 'crc32';
 
 // eslint-disable-next-line import/no-unresolved
 import getDefaultPluginsIndex from '../utils/getDefaultPluginsIndex';
@@ -64,6 +66,7 @@ export default async (store: Store, logger: Logger) => {
   globalObject.antd = antd;
   globalObject.emotion_styled = emotion_styled;
   globalObject.antdesign_icons = antdesign_icons;
+  globalObject.crc32_hack_fix_me = crc32;
 
   const gatekeepedPlugins: Array<ActivatablePluginDetails> = [];
   const disabledPlugins: Array<ActivatablePluginDetails> = [];

--- a/desktop/babel-transformer/src/replace-flipper-requires.ts
+++ b/desktop/babel-transformer/src/replace-flipper-requires.ts
@@ -26,6 +26,7 @@ const requireReplacements: any = {
   immer: 'global.Immer',
   '@emotion/styled': 'global.emotion_styled',
   '@ant-design/icons': 'global.antdesign_icons',
+  crc32: 'global.crc32_hack_fix_me',
 };
 
 export function tryReplaceFlipperRequire(path: NodePath<CallExpression>) {

--- a/desktop/yarn.lock
+++ b/desktop/yarn.lock
@@ -4696,6 +4696,11 @@ crc32-stream@^4.0.1:
     crc-32 "^1.2.0"
     readable-stream "^3.4.0"
 
+crc32@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/crc32/-/crc32-0.2.2.tgz#7ad220d6ffdcd119f9fc127a7772cacea390a4ba"
+  integrity sha1-etIg1v/c0Rn5/BJ6d3LKzqOQpLo=
+
 crc@^3.4.4, crc@^3.8.0:
   version "3.8.0"
   resolved "https://registry.yarnpkg.com/crc/-/crc-3.8.0.tgz#ad60269c2c856f8c299e2c4cc0de4556914056c6"

--- a/react-native/ReactNativeFlipperExample/ios/Podfile
+++ b/react-native/ReactNativeFlipperExample/ios/Podfile
@@ -22,5 +22,11 @@ target 'ReactNativeFlipperExample' do
   use_flipper!({ 'Flipper' => '0.79.0' })
   post_install do |installer|
     flipper_post_install(installer)
+    # based on https://stackoverflow.com/a/37289688/1983583
+    installer.pods_project.targets.each do |target|
+      target.build_configurations.each do |config|
+        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '10.0'
+      end
+    end
   end
 end

--- a/react-native/ReactNativeFlipperExample/ios/Podfile.lock
+++ b/react-native/ReactNativeFlipperExample/ios/Podfile.lock
@@ -472,7 +472,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  DoubleConversion: cde416483dac037923206447da6e1454df403714
+  DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 49cbe4b43e445b06bf29199b6ad2057649e4c8f5
   FBReactNativeSpec: 9e9f783f0e063dba3464ba0f9a826ac6c7f2908f
   Flipper: b6ab74c50d17c375c0ed3f729489cd1030f7c511
@@ -482,7 +482,7 @@ SPEC CHECKSUMS:
   Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
   Flipper-RSocket: 602921fee03edacf18f5d6f3d3594ba477f456e5
   FlipperKit: 6a68648b412158059f9021b5e61c36bb3086ebc3
-  glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
+  glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
   hermes-engine: 7d97ba46a1e29bacf3e3c61ecb2804a5ddd02d4f
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b
@@ -513,6 +513,6 @@ SPEC CHECKSUMS:
   Yoga: 8c8436d4171c87504c648ae23b1d81242bdf3bbf
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: e18a5a9e62a6a77042fc43d0d959332ffc5f68ae
+PODFILE CHECKSUM: e0e627b0d2a4b1e3329fac7c2c46a79fa1e7aac8
 
 COCOAPODS: 1.10.1


### PR DESCRIPTION
Summary: Local builds break if the deploy target of deps isn't new enough. It seems that the project podfile is not respected in this regard, as reported here: https://stackoverflow.com/a/37289688/1983583. Will see if there is a better way to fix this.

Differential Revision: D27328025

