### PR TITLE
ANDROID_SDK_ROOT support

### DIFF
--- a/desktop/app/src/dispatcher/androidDevice.tsx
+++ b/desktop/app/src/dispatcher/androidDevice.tsx
@@ -138,7 +138,7 @@ export default (store: Store, logger: Logger) => {
   const watchAndroidDevices = () => {
     // get emulators
     promisify(which)('emulator')
-      .catch(() => `${process.env.ANDROID_HOME || ''}/tools/emulator`)
+      .catch(() => `${process.env.ANDROID_HOME || process.env.ANDROID_SDK_ROOT || ''}/tools/emulator`)
       .then((emulatorPath) => {
         child_process.exec(
           `${emulatorPath} -list-avds`,

--- a/desktop/app/src/init.tsx
+++ b/desktop/app/src/init.tsx
@@ -162,7 +162,7 @@ function setProcessState(store: Store) {
   const androidHome = settings.androidHome;
   const idbPath = settings.idbPath;
 
-  if (!process.env.ANDROID_HOME) {
+  if (!process.env.ANDROID_HOME && !process.env.ANDROID_SDK_ROOT) {
     process.env.ANDROID_HOME = androidHome;
   }
 

--- a/desktop/doctor/src/index.ts
+++ b/desktop/doctor/src/index.ts
@@ -46,10 +46,10 @@ export type Healthcheck = {
   run: (
     env: EnvironmentInfo,
     settings?: Settings,
-  ) => Promise<HealthchecRunResult>;
+  ) => Promise<HealthcheckRunResult>;
 };
 
-export type HealthchecRunResult = {
+export type HealthcheckRunResult = {
   hasProblem: boolean;
   message: string;
 };
@@ -117,7 +117,7 @@ export function getHealthchecks(): Healthchecks {
             const androidHome = process.env.ANDROID_HOME
             const androidSdkRoot = process.env.ANDROID_SDK_ROOT
             
-            let androidHomeResult: HealthchecRunResult
+            let androidHomeResult: HealthcheckRunResult
             if (!androidHome) {
               androidHomeResult = {
                 hasProblem: true,
@@ -145,7 +145,7 @@ export function getHealthchecks(): Healthchecks {
               return androidHomeResult
             }
 
-            let androidSdkRootResult: HealthchecRunResult
+            let androidSdkRootResult: HealthcheckRunResult
             if (!androidSdkRoot) {
               androidSdkRootResult = {
                 hasProblem: true,
@@ -335,7 +335,7 @@ export async function runHealthchecks(): Promise<
 
 async function tryExecuteCommand(
   command: string,
-): Promise<HealthchecRunResult> {
+): Promise<HealthcheckRunResult> {
   try {
     const output = await promisify(exec)(command);
     return {


### PR DESCRIPTION
## Summary
According to Google, ANDROID_HOME is deprecated.
This means, that having only ANDROID_SDK_ROOT as environment variable leading to Android SDK is enough.
Flipper supports only ANDROID_HOME, so I would like to add ANDROID_SDK_ROOT support.
However, there is a set of rules of ANDROID_HOME and ANDROID_SDK_ROOT priority.
Everything is mentioned on a this page: https://developer.android.com/studio/command-line/variables

## Changelog
Added ANDROID_SDK_ROOT environment variable support

## Test Plan
Probably I would need a help with this