### PR TITLE
[ios] Remove pod bumps without flipperkit_version

### DIFF
--- a/.github/workflows/publish-pods.yml
+++ b/.github/workflows/publish-pods.yml
@@ -62,12 +62,6 @@ jobs:
       - name: Update Tutorial's Podfile
         run: ./scripts/update-pod-versions.sh ./ ./iOS/Tutorial/Podfile
 
-      - name: Update Sample's Podfile
-        run: ./scripts/update-pod-versions.sh ./ ./iOS/Sample/Podfile
-
-      - name: Update SampleSwift's Podfile
-        run: ./scripts/update-pod-versions.sh ./ ./iOS/SampleSwift/Podfile
-
       - name: Update Getting Started
         run: ./scripts/update-pod-versions.sh ./ ./docs/getting-started/ios-native.mdx
 


### PR DESCRIPTION
Summary:

Sample and SampleSwift directly link to the debug version and don't reference `flipperkit_version` which is why the script is failing.

Test Plan:
hopeitwork