### PR TITLE
Fix for idb file pull command

### DIFF
--- a/desktop/app/src/utils/CertificateProvider.tsx
+++ b/desktop/app/src/utils/CertificateProvider.tsx
@@ -496,7 +496,7 @@ export default class CertificateProvider {
             deviceId,
             originalFile,
             bundleId,
-            path.join(dir, csrFileName),
+            dir,
             this.store.getState().settingsState.idbPath,
           )
           .then(() => dir);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Fixes following error when using Flipper with iOS device:

Connection to *App* on *Device* failed.
Failed to start client connection
```
Error: EISDIR: illegal operation on a directory, read
errno: -21
code: "EISDIR"
syscall: "read"
```

The problem is that `idb file pull --bundle-id com.foo.bar src.txt dest.txt` does not create `dest.txt` but `dest.txt/src.txt`. The last argument must be a **directory**, not a file name.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

Fixed a bug where Flipper failed to connect the app on iOS device.
<!-- Help reviewers and the release process by writing your own changelog entry. This should just be a brief oneline we can mention in our release notes: https://github.com/facebook/flipper/releases -->

## Test Plan

* build idb from sources
* use Flipper with iOS device

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI / output of the test runner and how you invoked it. -->

