### PR TITLE
[iOS] Update all flipper transitive deps to latest versions

### DIFF
--- a/.github/workflows/iOS-Sample.yml
+++ b/.github/workflows/iOS-Sample.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Build Sample app
         run: |
           IPHONESIMULATOR=$(xcodebuild -showsdks | grep -o "iphonesimulator[0-9]\\+\\.[0-9]\\+$") && echo $IPHONESIMULATOR
-          xcodebuild build -workspace Sample.xcworkspace -scheme Sample -sdk $IPHONESIMULATOR EXCLUDED_ARCHS=arm64
+          xcodebuild build -workspace Sample.xcworkspace -scheme Sample -sdk $IPHONESIMULATOR EXCLUDED_ARCHS="arm64 i386"
 
   build-sample-swift:
     runs-on: macos-latest
@@ -42,7 +42,7 @@ jobs:
       - name: Build SampleSwift app
         run: |
           IPHONESIMULATOR=$(xcodebuild -showsdks | grep -o "iphonesimulator[0-9]\\+\\.[0-9]\\+$") && echo $IPHONESIMULATOR
-          xcodebuild build -workspace SampleSwift.xcworkspace -scheme SampleSwift -sdk $IPHONESIMULATOR
+          xcodebuild build -workspace SampleSwift.xcworkspace -scheme SampleSwift -sdk $IPHONESIMULATOR EXCLUDED_ARCHS="arm64 i386"
 
   build-tutorial:
     runs-on: macos-latest
@@ -57,4 +57,4 @@ jobs:
       - name: Build Tutorial app
         run: |
           IPHONESIMULATOR=$(xcodebuild -showsdks | grep -o "iphonesimulator[0-9]\\+\\.[0-9]\\+$") && echo $IPHONESIMULATOR
-          xcodebuild build -workspace Tutorial.xcworkspace -scheme Tutorial -sdk $IPHONESIMULATOR
+          xcodebuild build -workspace Tutorial.xcworkspace -scheme Tutorial -sdk $IPHONESIMULATOR EXCLUDED_ARCHS="arm64 i386"

--- a/Flipper.podspec
+++ b/Flipper.podspec
@@ -17,14 +17,15 @@ Pod::Spec.new do |spec|
   spec.public_header_files = 'xplat/Flipper/*.h','xplat/utils/*.h'
   spec.source_files = 'xplat/Flipper/*.{h,cpp,m,mm}','xplat/Flipper/utils/*.{h,cpp,m,mm}'
   spec.libraries = "stdc++"
-  spec.dependency 'Flipper-Folly', '~> 2.5'
-  spec.dependency 'Flipper-RSocket', '~> 1.3'
-  spec.compiler_flags = '-DFLIPPER_OSS=1 -DFB_SONARKIT_ENABLED=1 -DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_HAVE_LIBGFLAGS=0 -DFOLLY_HAVE_LIBJEMALLOC=0 -DFOLLY_HAVE_PREADV=0 -DFOLLY_HAVE_PWRITEV=0 -DFOLLY_HAVE_TFO=0 -DFOLLY_USE_SYMBOLIZER=0 -Wall
+  spec.dependency 'Flipper-Folly', '~> 2.6
+  '
+  spec.dependency 'Flipper-RSocket', '~> 1.4'
+  spec.compiler_flags = '-DFLIPPER_OSS=1 -DFB_SONARKIT_ENABLED=1 -DFOLLY_HAVE_BACKTRACE=1 -DFOLLY_HAVE_CLOCK_GETTIME=1 -DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_HAVE_LIBGFLAGS=0 -DFOLLY_HAVE_LIBJEMALLOC=0 -DFOLLY_HAVE_PREADV=0 -DFOLLY_HAVE_PWRITEV=0 -DFOLLY_HAVE_TFO=0 -DFOLLY_USE_SYMBOLIZER=0 -Wall
     -std=c++14
     -Wno-global-constructors'
   spec.platforms = { :ios => "10.0" }
   spec.pod_target_xcconfig = { "USE_HEADERMAP" => "NO",
                                "CLANG_CXX_LANGUAGE_STANDARD" => "c++14",
-                               "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)\" \"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/Flipper-RSocket\" \"$(PODS_ROOT)/Flipper-DoubleConversion\" \"$(PODS_ROOT)/libevent/include\""
+                               "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)\" \"$(PODS_ROOT)/Flipper-Boost-iOSX\" \"$(PODS_ROOT)/Flipper-RSocket\" \"$(PODS_ROOT)/Flipper-DoubleConversion\" \"$(PODS_ROOT)/libevent/include\""
                                }
 end

--- a/FlipperKit.podspec
+++ b/FlipperKit.podspec
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-folly_compiler_flags = '-DDEBUG=1 -DFLIPPER_OSS=1 -DFB_SONARKIT_ENABLED=1 -DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_HAVE_LIBGFLAGS=0 -DFOLLY_HAVE_LIBJEMALLOC=0 -DFOLLY_HAVE_PREADV=0 -DFOLLY_HAVE_PWRITEV=0 -DFOLLY_HAVE_TFO=0 -DFOLLY_USE_SYMBOLIZER=0'
+folly_compiler_flags = '-DDEBUG=1 -DFLIPPER_OSS=1 -DFB_SONARKIT_ENABLED=1 -DFOLLY_HAVE_BACKTRACE=1 -DFOLLY_HAVE_CLOCK_GETTIME=1 -DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_HAVE_LIBGFLAGS=0 -DFOLLY_HAVE_LIBJEMALLOC=0 -DFOLLY_HAVE_PREADV=0 -DFOLLY_HAVE_PWRITEV=0 -DFOLLY_HAVE_TFO=0 -DFOLLY_USE_SYMBOLIZER=0'
 yogakit_version = '~> 1.18'
 flipperkit_version = '0.87.0'
 Pod::Spec.new do |spec|
@@ -40,7 +40,7 @@ Pod::Spec.new do |spec|
     # by other FlipperKit source files
     ss.private_header_files = 'iOS/FlipperKit/CppBridge/**/*.h'
     ss.preserve_path = 'iOS/FlipperKit/CppBridge/**/*.h'
-    header_search_paths = "\"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/Flipper-DoubleConversion\" \"$(PODS_ROOT)/FlipperKit/iOS/**/\" \"$(PODS_ROOT)/libevent/include\""
+    header_search_paths = "\"$(PODS_ROOT)/Flipper-Boost-iOSX\" \"$(PODS_ROOT)/Flipper-DoubleConversion\" \"$(PODS_ROOT)/FlipperKit/iOS/**/\" \"$(PODS_ROOT)/libevent/include\""
     ss.pod_target_xcconfig = { "USE_HEADERMAP" => "NO",
                                 "ONLY_ACTIVE_ARCH": "YES",
                              "DEFINES_MODULE" => "YES",
@@ -50,12 +50,12 @@ Pod::Spec.new do |spec|
   spec.subspec 'FBCxxFollyDynamicConvert' do |ss|
     ss.header_dir = 'FBCxxFollyDynamicConvert'
     ss.compiler_flags = folly_compiler_flags
-    ss.dependency 'Flipper-Folly', '~> 2.5'
+    ss.dependency 'Flipper-Folly', '~> 2.6'
     ss.source_files = 'iOS/FlipperKit/FBCxxFollyDynamicConvert/**/*.{h,mm}'
     # We set these files as private headers since they only need to be accessed
     # by other FlipperKit source files
     ss.private_header_files = 'iOS/FlipperKit/FBCxxFollyDynamicConvert/**/*.h'
-    header_search_paths = "\"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/Flipper-DoubleConversion\" \"$(PODS_ROOT)/libevent/include\""
+    header_search_paths = "\"$(PODS_ROOT)/Flipper-Boost-iOSX\" \"$(PODS_ROOT)/Flipper-DoubleConversion\" \"$(PODS_ROOT)/libevent/include\""
     ss.pod_target_xcconfig = { "USE_HEADERMAP" => "NO",
                                "ONLY_ACTIVE_ARCH": "YES",
                                "DEFINES_MODULE" => "YES",
@@ -80,7 +80,7 @@ Pod::Spec.new do |spec|
     ss.compiler_flags = folly_compiler_flags
     ss.source_files = 'iOS/FlipperKit/*.{h,m,mm}', 'iOS/FlipperKit/CppBridge/*.{h,mm}'
     ss.public_header_files = 'iOS/FlipperKit/**/{FlipperDiagnosticsViewController,FlipperStateUpdateListener,FlipperClient,FlipperPlugin,FlipperConnection,FlipperResponder,SKMacros,FlipperKitCertificateProvider}.h'
-    header_search_paths = "\"$(PODS_ROOT)/FlipperKit/iOS/FlipperKit/\" \"$(PODS_ROOT)/Headers/Private/FlipperKit/\" \"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/libevent/include\""
+    header_search_paths = "\"$(PODS_ROOT)/FlipperKit/iOS/FlipperKit/\" \"$(PODS_ROOT)/Headers/Private/FlipperKit/\" \"$(PODS_ROOT)/Flipper-Boost-iOSX\" \"$(PODS_ROOT)/libevent/include\""
     ss.pod_target_xcconfig = { "USE_HEADERMAP" => "NO",
                                "ONLY_ACTIVE_ARCH": "YES",
                                "DEFINES_MODULE" => "YES",
@@ -151,8 +151,8 @@ Pod::Spec.new do |spec|
   spec.subspec "FlipperKitLayoutComponentKitSupport" do |ss|
     ss.header_dir = "FlipperKitLayoutComponentKitSupport"
     ss.dependency             'FlipperKit/Core'
-    ss.dependency             'ComponentKit', '0.30'
-    ss.dependency             'RenderCore', '0.30' # Pinning it to 0.30, as there won't be any new releases from CK team.
+    ss.dependency             'ComponentKit', '0.31'
+    ss.dependency             'RenderCore', '0.31' # Pinning it to 0.30, as there won't be any new releases from CK team.
     ss.dependency             'FlipperKit/FlipperKitLayoutPlugin'
     ss.dependency             'FlipperKit/FlipperKitLayoutTextSearchable'
     ss.dependency             'FlipperKit/FlipperKitHighlightOverlay'

--- a/iOS/Podspecs/Flipper-Fmt.podspec
+++ b/iOS/Podspecs/Flipper-Fmt.podspec
@@ -1,0 +1,26 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+Pod::Spec.new do |spec|
+    spec.name     = 'Flipper-Fmt'
+    spec.version  = '7.1.7'
+    spec.license  = { :type => 'MIT' }
+    spec.homepage = 'https://github.com/fmtlib/fmt'
+    spec.authors  = { 'Pritesh Nandgaonkar' => 'prit91@fb.com' }
+    spec.summary  = '{fmt} is an open-source formatting library providing a fast and safe alternative to C stdio and C++ iostreams.    '
+
+    spec.source   = { :git => "https://github.com/priteshrnandgaonkar/fmt.git",
+                      :tag => "7.1.7" }
+    spec.source_files = "src/format.cc", "include/**/*.h",
+    spec.public_header_files = "include/**/*.h"
+    spec.requires_arc = true
+    spec.ios.deployment_target = '10.0'
+    spec.header_dir = 'fmt'
+    spec.libraries = "stdc++" 
+    spec.exclude_files = "src/fmt.cc", "src/fmt.cc"
+    spec.pod_target_xcconfig = {  "USE_HEADERMAP" => "NO",
+    "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/include/\""
+  }
+end

--- a/iOS/Podspecs/Flipper-Folly.podspec
+++ b/iOS/Podspecs/Flipper-Folly.podspec
@@ -5,20 +5,21 @@
 
 Pod::Spec.new do |spec|
   spec.name = 'Flipper-Folly'
-  spec.version = '2.5.1'
+  spec.version = '2.6.7'
   spec.license = { :type => 'Apache License, Version 2.0' }
   spec.homepage = 'https://github.com/facebook/folly'
   spec.summary = 'An open-source C++ library developed and used at Facebook.'
   spec.authors = 'Facebook'
   spec.source = { :git => 'https://github.com/facebook/folly.git',
-                  :tag => "v2020.04.06.00"}
+                  :tag => "v2021.04.26.00"}
   spec.module_name = 'folly'
-  spec.dependency 'boost-for-react-native'
+  spec.dependency 'Flipper-Boost-iOSX'
   spec.dependency 'Flipper-Glog'
   spec.dependency 'Flipper-DoubleConversion'
   spec.dependency 'OpenSSL-Universal', '1.1.180'
   spec.dependency 'libevent', '~> 2.1.12'
-  spec.compiler_flags = '-DFOLLY_HAVE_PTHREAD=1 -DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_HAVE_LIBGFLAGS=0 -DFOLLY_HAVE_LIBJEMALLOC=0 -DFOLLY_HAVE_PREADV=0 -DFOLLY_HAVE_PWRITEV=0 -DFOLLY_HAVE_TFO=0 -DFOLLY_USE_SYMBOLIZER=0
+  spec.dependency 'Flipper-Fmt', '7.1.7'
+  spec.compiler_flags = '-DFOLLY_HAVE_BACKTRACE=1 -DFOLLY_HAVE_CLOCK_GETTIME=1 -DFOLLY_HAVE_PTHREAD=1 -DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_HAVE_LIBGFLAGS=0 -DFOLLY_HAVE_LIBJEMALLOC=0 -DFOLLY_HAVE_PREADV=0 -DFOLLY_HAVE_PWRITEV=0 -DFOLLY_HAVE_TFO=0
     -frtti
     -fexceptions
     -std=c++14
@@ -28,11 +29,13 @@ Pod::Spec.new do |spec|
     -Wno-sign-compare
     -Wno-comment
     -Wno-return-type
-    -Wno-global-constructors'
+    -Wno-global-constructors
+    -Wno-comma'
 
   spec.source_files = "folly/*.h",
                       "folly/concurrency/*.h",
                       "folly/container/*.h",
+                      "folly/container/*.cpp",
                       "folly/container/detail/*.h",
                       "folly/detail/*.h",
                       "folly/executors/**/*.h",
@@ -52,14 +55,16 @@ Pod::Spec.new do |spec|
                       "folly/memory/detail/*.h",
                       "folly/net/*.h",
                       "folly/net/detail/*.h",
-                      "folly/portability/*.h",
                       "folly/ssl/*.h",
                       "folly/ssl/detail/*.h",
                       "folly/synchronization/*.h",
                       "folly/synchronization/detail/*.h",
+                      "folly/synchronization/detail/*.cpp",
                       "folly/system/*.h",
                       "folly/tracing/*.h",
+                      "folly/tracing/*.cpp",
                       "folly/chrono/*.h",
+                      "folly/chrono/*.cpp",
                       "folly/*.cpp",
                       "folly/concurrency/*.cpp",
                       "folly/container/detail/*.cpp",
@@ -76,12 +81,75 @@ Pod::Spec.new do |spec|
                       "folly/memory/*.cpp",
                       "folly/memory/detail/*.cpp",
                       "folly/net/*.cpp",
-                      "folly/portability/*.cpp",
                       "folly/ssl/*.cpp",
                       "folly/ssl/detail/*.cpp",
                       "folly/String.cpp",
                       "folly/synchronization/*.cpp",
-                      "folly/system/*.cpp"
+                      "folly/system/*.cpp",
+                      "folly/experimental/coro/*.h",
+                      "folly/experimental/symbolizer/*.h",
+                      "folly/experimental/symbolizer/*.cpp",
+                      "folly/fibers/*.h",
+                      "folly/fibers/*.cpp",
+                      "folly/experimental/symbolizer/detail/*.h",
+                      "folly/experimental/symbolizer/detail/*.cpp",
+                      "folly/logging/*.h",
+                      "folly/logging/*.cpp",
+                      "folly/experimental/coro/detail/*.h",
+                      "folly/experimental/coro/detail/*.cpp",
+                      "folly/portability/Unistd.h",
+                      "folly/portability/Unistd.cpp",
+                      "folly/portability/Config.h",
+                      "folly/portability/Constexpr.h",
+                      "folly/portability/Builtins.h",
+                      "folly/portability/Builtins.cpp",
+                      "folly/portability/Malloc.h",
+                      "folly/portability/Malloc.cpp",
+                      "folly/portability/Math.h",
+                      "folly/portability/Asm.h",
+                      "folly/portability/OpenSSL.h",
+                      "folly/portability/OpenSSL.cpp",
+                      "folly/portability/PThread.cpp",
+                      "folly/portability/PThread.h",
+                      "folly/portability/Windows.h",
+                      "folly/portability/SysResource.h",
+                      "folly/portability/SysResource.cpp",
+                      "folly/portability/Event.h",
+                      "folly/experimental/observer/*.h",
+                      "folly/experimental/observer/*.cpp",
+                      "folly/portability/Time.h",
+                      "folly/portability/Time.cpp",
+                      "folly/portability/IOVec.h",
+                      "folly/portability/SysTypes.h",
+                      "folly/portability/GFlags.h",
+                      "folly/portability/SysSyscall.h",
+                      "folly/portability/SysUio.h",
+                      "folly/portability/SysUio.cpp",
+                      "folly/portability/SysTime.h",
+                      "folly/portability/SysTime.cpp",
+                      "folly/portability/SysStat.h",
+                      "folly/portability/SysStat.cpp",
+                      "folly/portability/SysMman.h",
+                      "folly/portability/SysMman.cpp",
+                      "folly/portability/Sockets.h",
+                      "folly/portability/Sockets.cpp",
+                      "folly/portability/SysMembarrier.h",
+                      "folly/portability/SysMembarrier.cpp",
+                      "folly/portability/SysFile.h",
+                      "folly/portability/SysFile.cpp",
+                      "folly/portability/String.h",
+                      "folly/portability/String.cpp",
+                      "folly/portability/Fcntl.h",
+                      "folly/portability/Fcntl.cpp",
+                      "folly/portability/Stdlib.h",
+                      "folly/portability/Stdlib.cpp",
+                      "folly/portability/Stdio.h",
+                      "folly/portability/Stdio.cpp",
+                      "folly/portability/FmtCompile.h",
+                      "folly/portability/Sched.h",
+                      "folly/portability/Sched.cpp",
+                      "folly/experimental/observer/detail/*.h",
+                      "folly/experimental/observer/detail/*.cpp",
 
   spec.exclude_files = "folly/synchronization/Rcu.cpp", "folly/synchronization/Rcu.h"
   spec.header_mappings_dir = 'folly'
@@ -91,8 +159,8 @@ Pod::Spec.new do |spec|
   spec.public_header_files =  "folly/**/*.h"
 
   spec.pod_target_xcconfig = {  "USE_HEADERMAP" => "NO",
-                                "CLANG_CXX_LANGUAGE_STANDARD" => "c++11",
-                                "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)\" \"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/Flipper-DoubleConversion\" \"$(PODS_ROOT)/libevent/include\""
+                                "CLANG_CXX_LANGUAGE_STANDARD" => "c++14",
+                                "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/Flipper-Boost-iOSX\" \"$(PODS_ROOT)/Flipper-DoubleConversion\" \"$(PODS_ROOT)/libevent/include\""
                               }
   spec.platforms = { :ios => "10.0"}
 end

--- a/iOS/Podspecs/Flipper-RSocket.podspec
+++ b/iOS/Podspecs/Flipper-RSocket.podspec
@@ -5,12 +5,12 @@
 
 Pod::Spec.new do |spec|
   spec.name = 'Flipper-RSocket'
-  spec.version = '1.3.1'
+  spec.version = '1.4.3'
   spec.license = { :type => 'MIT' }
   spec.homepage = 'https://github.com/rsocket/rsocket-cpp'
   spec.summary = 'C++ implementation of RSocket'
   spec.authors = 'Facebook'
-  spec.source = { :git => 'https://github.com/priteshrnandgaonkar/rsocket-cpp.git', :tag => "0.11.0"}
+  spec.source = { :git => 'https://github.com/rsocket/rsocket-cpp.git', :tag => "v2021.04.26.00"}
   spec.module_name = 'RSocket'
   spec.static_framework = true
   spec.source_files = 'rsocket/benchmarks/*.{h,cpp,m,mm}',
@@ -25,17 +25,20 @@ Pod::Spec.new do |spec|
 
   spec.libraries = "stdc++"
   spec.compiler_flags = '-std=c++1y'
-  spec.dependency 'Flipper-Folly', '~> 2.5'
-  spec.compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_HAVE_LIBGFLAGS=0 -DFOLLY_HAVE_LIBJEMALLOC=0 -DFOLLY_HAVE_PREADV=0 -DFOLLY_HAVE_PWRITEV=0 -DFOLLY_HAVE_TFO=0 -DFOLLY_USE_SYMBOLIZER=0  -frtti
-    -fexceptions
-    -std=c++14
-    -Wno-error
-    -Wno-unused-local-typedefs
-    -Wno-unused-variable
-    -Wno-sign-compare
-    -Wno-comment
-    -Wno-return-type
-    -Wno-global-constructors'
+  spec.dependency 'Flipper-Folly', '~> 2.6'
+  spec.compiler_flags = '-DFOLLY_HAVE_BACKTRACE=1 -DFOLLY_HAVE_CLOCK_GETTIME=1 -DFOLLY_HAVE_PTHREAD=1 -DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_HAVE_LIBGFLAGS=0 -DFOLLY_HAVE_LIBJEMALLOC=0 -DFOLLY_HAVE_PREADV=0 -DFOLLY_HAVE_PWRITEV=0 -DFOLLY_HAVE_TFO=0
+  -frtti
+  -fexceptions
+  -std=c++14
+  -Wno-error
+  -Wno-unused-local-typedefs
+  -Wno-unused-variable
+  -Wno-sign-compare
+  -Wno-comment
+  -Wno-return-type
+  -Wno-global-constructors
+  -Wno-comma'
+
   spec.preserve_paths = 'rsocket/benchmarks/*.h',
                         'rsocket/framing/*.h',
                         'rsocket/internal/*.h',
@@ -53,7 +56,7 @@ Pod::Spec.new do |spec|
   spec.header_dir = './'
   spec.pod_target_xcconfig = { "USE_HEADERMAP" => "NO",
                                "CLANG_CXX_LANGUAGE_STANDARD" => "c++14",
-                               "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)\"/** \"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/glog\" \"$(PODS_ROOT)/libevent/include\" \"$(PODS_ROOT)/DoubleConversion\"/**" }
+                               "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)\"/**  \"$(PODS_ROOT)/Flipper-Boost-iOSX\" \"$(PODS_ROOT)/glog\" \"$(PODS_ROOT)/libevent/include\" \"$(PODS_ROOT)/DoubleConversion\"/**" }
   spec.platforms = { :ios => "10.0" }
 
 end

--- a/iOS/Sample/Podfile
+++ b/iOS/Sample/Podfile
@@ -18,7 +18,7 @@ target 'Sample' do
   pod 'Flipper-Glog', :configuration => 'Debug'
   pod 'Flipper-PeerTalk', :configuration => 'Debug'
   pod 'libevent', :configuration => 'Debug'
-  pod 'boost-for-react-native', :configuration => 'Debug'
+  pod 'Flipper-Boost-iOSX', :configuration => 'Debug'
   pod 'OpenSSL-Universal', :configuration => 'Debug'
   pod 'CocoaAsyncSocket', :configuration => 'Debug'
   pod 'ComponentKit', '~> 0.30'

--- a/iOS/Sample/Podfile.lock
+++ b/iOS/Sample/Podfile.lock
@@ -1,23 +1,25 @@
 PODS:
-  - boost-for-react-native (1.63.0)
   - CocoaAsyncSocket (7.6.5)
-  - ComponentKit (0.30):
-    - RenderCore (= 0.30)
+  - ComponentKit (0.31):
+    - RenderCore (= 0.31)
     - Yoga (~> 1.14)
   - Flipper (0.87.0):
-    - Flipper-Folly (~> 2.5)
-    - Flipper-RSocket (~> 1.3)
+    - Flipper-Folly (~> 2.6)
+    - Flipper-RSocket (~> 1.4)
+  - Flipper-Boost-iOSX (1.76.0.1.10)
   - Flipper-DoubleConversion (3.1.7)
-  - Flipper-Folly (2.5.1):
-    - boost-for-react-native
+  - Flipper-Fmt (7.1.7)
+  - Flipper-Folly (2.6.7):
+    - Flipper-Boost-iOSX
     - Flipper-DoubleConversion
+    - Flipper-Fmt (= 7.1.7)
     - Flipper-Glog
     - libevent (~> 2.1.12)
     - OpenSSL-Universal (= 1.1.180)
-  - Flipper-Glog (0.3.8)
+  - Flipper-Glog (0.3.9)
   - Flipper-PeerTalk (0.0.4)
-  - Flipper-RSocket (1.3.1):
-    - Flipper-Folly (~> 2.5)
+  - Flipper-RSocket (1.4.3):
+    - Flipper-Folly (~> 2.6)
   - FlipperKit (0.87.0):
     - FlipperKit/Core (= 0.87.0)
   - FlipperKit/Core (0.87.0):
@@ -29,7 +31,7 @@ PODS:
   - FlipperKit/CppBridge (0.87.0):
     - Flipper (~> 0.87.0)
   - FlipperKit/FBCxxFollyDynamicConvert (0.87.0):
-    - Flipper-Folly (~> 2.5)
+    - Flipper-Folly (~> 2.6)
   - FlipperKit/FBDefines (0.87.0)
   - FlipperKit/FKPortForwarding (0.87.0):
     - CocoaAsyncSocket (~> 7.6)
@@ -38,13 +40,13 @@ PODS:
     - FlipperKit/Core
   - FlipperKit/FlipperKitHighlightOverlay (0.87.0)
   - FlipperKit/FlipperKitLayoutComponentKitSupport (0.87.0):
-    - ComponentKit (= 0.30)
+    - ComponentKit (= 0.31)
     - FlipperKit/Core
     - FlipperKit/FlipperKitHighlightOverlay
     - FlipperKit/FlipperKitLayoutHelpers
     - FlipperKit/FlipperKitLayoutPlugin
     - FlipperKit/FlipperKitLayoutTextSearchable
-    - RenderCore (= 0.30)
+    - RenderCore (= 0.31)
   - FlipperKit/FlipperKitLayoutHelpers (0.87.0):
     - FlipperKit/Core
     - FlipperKit/FlipperKitHighlightOverlay
@@ -73,16 +75,16 @@ PODS:
     - FlipperKit/FlipperKitNetworkPlugin
   - libevent (2.1.12)
   - OpenSSL-Universal (1.1.180)
-  - RenderCore (0.30)
+  - RenderCore (0.31)
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
     - Yoga (~> 1.14)
 
 DEPENDENCIES:
-  - boost-for-react-native
   - CocoaAsyncSocket
   - ComponentKit (~> 0.30)
   - Flipper (from `../../Flipper.podspec`)
+  - Flipper-Boost-iOSX
   - Flipper-DoubleConversion
   - Flipper-Folly
   - Flipper-Glog
@@ -97,11 +99,12 @@ DEPENDENCIES:
   - OpenSSL-Universal
 
 SPEC REPOS:
-  https://github.com/CocoaPods/Specs:
-    - boost-for-react-native
+  https://github.com/CocoaPods/Specs.git:
     - CocoaAsyncSocket
     - ComponentKit
+    - Flipper-Boost-iOSX
     - Flipper-DoubleConversion
+    - Flipper-Fmt
     - Flipper-Folly
     - Flipper-Glog
     - Flipper-PeerTalk
@@ -119,22 +122,23 @@ EXTERNAL SOURCES:
     :path: "../../FlipperKit.podspec"
 
 SPEC CHECKSUMS:
-  boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  ComponentKit: c34da1ab3515cf18db68a4ba22c6599568d1de74
-  Flipper: 1bd2db48dcc31e4b167b9a33ec1df01c2ded4893
+  ComponentKit: 7bf7048b9814afc6b6641645a14177f95fd9b9ae
+  Flipper: 2d67b1c61a6f070dfa967ce020a998b1e5c444d9
+  Flipper-Boost-iOSX: df3765e7e26b44bc3e68a250ef1fa0afa15963bc
   Flipper-DoubleConversion: 57ffbe81ef95306cc9e69c4aa3aeeeeb58a6a28c
-  Flipper-Folly: f7a3caafbd74bda4827954fd7a6e000e36355489
-  Flipper-Glog: 565852920d7e9c3417be83353e6973e684ce2f48
+  Flipper-Fmt: 60cbdd92fc254826e61d669a5d87ef7015396a9b
+  Flipper-Folly: 83af37379faa69497529e414bd43fbfc7cae259a
+  Flipper-Glog: 05579840e2750ec907ee2f81544f41ad76a7cae4
   Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
-  Flipper-RSocket: 127954abe8b162fcaf68d2134d34dc2bd7076154
-  FlipperKit: 651f50a42eb95c01b3e89a60996dd6aded529eeb
+  Flipper-RSocket: d9d9ade67cbecf6ac10730304bf5607266dd2541
+  FlipperKit: ac5073dfb652025c0216a132031d694c37b0d703
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b
-  RenderCore: d779c47622b313ce2d51bb36d084517af38b0dc1
+  RenderCore: 090beb17b5bff80b86929a7ceb49df789923d23a
   Yoga: cff67a400f6b74dc38eb0bad4f156673d9aa980c
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: dd8f14ea331e1d68ea6725734d2d4f9b2fc6ecf1
+PODFILE CHECKSUM: 1851d403b80e8171a90a5086cf56f579d45a1f71
 
 COCOAPODS: 1.10.1

--- a/iOS/SampleSwift/Podfile.lock
+++ b/iOS/SampleSwift/Podfile.lock
@@ -1,23 +1,26 @@
 PODS:
   - boost-for-react-native (1.63.0)
   - CocoaAsyncSocket (7.6.5)
-  - ComponentKit (0.30):
-    - RenderCore (= 0.30)
+  - ComponentKit (0.31):
+    - RenderCore (= 0.31)
     - Yoga (~> 1.14)
   - Flipper (0.87.0):
-    - Flipper-Folly (~> 2.5)
-    - Flipper-RSocket (~> 1.3)
+    - Flipper-Folly (~> 2.6)
+    - Flipper-RSocket (~> 1.4)
+  - Flipper-Boost-iOSX (1.76.0.1.10)
   - Flipper-DoubleConversion (3.1.7)
-  - Flipper-Folly (2.5.1):
-    - boost-for-react-native
+  - Flipper-Fmt (7.1.7)
+  - Flipper-Folly (2.6.7):
+    - Flipper-Boost-iOSX
     - Flipper-DoubleConversion
+    - Flipper-Fmt (= 7.1.7)
     - Flipper-Glog
     - libevent (~> 2.1.12)
     - OpenSSL-Universal (= 1.1.180)
-  - Flipper-Glog (0.3.8)
+  - Flipper-Glog (0.3.9)
   - Flipper-PeerTalk (0.0.4)
-  - Flipper-RSocket (1.3.1):
-    - Flipper-Folly (~> 2.5)
+  - Flipper-RSocket (1.4.3):
+    - Flipper-Folly (~> 2.6)
   - FlipperKit (0.87.0):
     - FlipperKit/Core (= 0.87.0)
   - FlipperKit/Core (0.87.0):
@@ -29,7 +32,7 @@ PODS:
   - FlipperKit/CppBridge (0.87.0):
     - Flipper (~> 0.87.0)
   - FlipperKit/FBCxxFollyDynamicConvert (0.87.0):
-    - Flipper-Folly (~> 2.5)
+    - Flipper-Folly (~> 2.6)
   - FlipperKit/FBDefines (0.87.0)
   - FlipperKit/FKPortForwarding (0.87.0):
     - CocoaAsyncSocket (~> 7.6)
@@ -38,13 +41,13 @@ PODS:
     - FlipperKit/Core
   - FlipperKit/FlipperKitHighlightOverlay (0.87.0)
   - FlipperKit/FlipperKitLayoutComponentKitSupport (0.87.0):
-    - ComponentKit (= 0.30)
+    - ComponentKit (= 0.31)
     - FlipperKit/Core
     - FlipperKit/FlipperKitHighlightOverlay
     - FlipperKit/FlipperKitLayoutHelpers
     - FlipperKit/FlipperKitLayoutPlugin
     - FlipperKit/FlipperKitLayoutTextSearchable
-    - RenderCore (= 0.30)
+    - RenderCore (= 0.31)
   - FlipperKit/FlipperKitLayoutHelpers (0.87.0):
     - FlipperKit/Core
     - FlipperKit/FlipperKitHighlightOverlay
@@ -71,7 +74,7 @@ PODS:
     - FlipperKit/FlipperKitNetworkPlugin
   - libevent (2.1.12)
   - OpenSSL-Universal (1.1.180)
-  - RenderCore (0.30)
+  - RenderCore (0.31)
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
     - Yoga (~> 1.14)
@@ -94,11 +97,13 @@ DEPENDENCIES:
   - OpenSSL-Universal
 
 SPEC REPOS:
-  https://github.com/CocoaPods/Specs:
+  https://github.com/CocoaPods/Specs.git:
     - boost-for-react-native
     - CocoaAsyncSocket
     - ComponentKit
+    - Flipper-Boost-iOSX
     - Flipper-DoubleConversion
+    - Flipper-Fmt
     - Flipper-Folly
     - Flipper-Glog
     - Flipper-PeerTalk
@@ -118,17 +123,19 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  ComponentKit: c34da1ab3515cf18db68a4ba22c6599568d1de74
-  Flipper: 1bd2db48dcc31e4b167b9a33ec1df01c2ded4893
+  ComponentKit: 7bf7048b9814afc6b6641645a14177f95fd9b9ae
+  Flipper: 2d67b1c61a6f070dfa967ce020a998b1e5c444d9
+  Flipper-Boost-iOSX: df3765e7e26b44bc3e68a250ef1fa0afa15963bc
   Flipper-DoubleConversion: 57ffbe81ef95306cc9e69c4aa3aeeeeb58a6a28c
-  Flipper-Folly: f7a3caafbd74bda4827954fd7a6e000e36355489
-  Flipper-Glog: 565852920d7e9c3417be83353e6973e684ce2f48
+  Flipper-Fmt: 60cbdd92fc254826e61d669a5d87ef7015396a9b
+  Flipper-Folly: 83af37379faa69497529e414bd43fbfc7cae259a
+  Flipper-Glog: 05579840e2750ec907ee2f81544f41ad76a7cae4
   Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
-  Flipper-RSocket: 127954abe8b162fcaf68d2134d34dc2bd7076154
-  FlipperKit: 651f50a42eb95c01b3e89a60996dd6aded529eeb
+  Flipper-RSocket: d9d9ade67cbecf6ac10730304bf5607266dd2541
+  FlipperKit: ac5073dfb652025c0216a132031d694c37b0d703
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b
-  RenderCore: d779c47622b313ce2d51bb36d084517af38b0dc1
+  RenderCore: 090beb17b5bff80b86929a7ceb49df789923d23a
   Yoga: cff67a400f6b74dc38eb0bad4f156673d9aa980c
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 


### PR DESCRIPTION
Differential Revision: D28058972

This diff does the following:
- Updates Folly to the latest version.
- Updates boost to latest version and the boost is added as pre built artefact
- Updates RSocket to the latest version
- Updates ComponentKit to the latest version which has a fix for XCode 12.5
- Adds Flipper-Glog dependency as non pre-built, I was facing some issues with XCode 12.5 with the pre built artifact of Glog. (We can take a look on this later).
- This PR also ensures that Flipper, FlipperKit builds with Sample and SampleSwift app.
- This PR also ensures that the bug mentioned [here](https://github.com/facebook/flipper/issues/2248) is addressed.


Note: For Tutorial App to work we will have to make a release of Flipper and FlipperKit to CococaPods.