### PR TITLE
Fix React Native build

### DIFF
--- a/.github/workflows/react-native-example.yml
+++ b/.github/workflows/react-native-example.yml
@@ -17,7 +17,7 @@ jobs:
         # n.b. doesn't seem to respect cwd:
         podfile-path: react-native/ReactNativeFlipperExample/ios/Podfile.lock
     - name: Install yarn dependencies
-      run: yarn install --frozen-lockfile --ignore-scripts
+      run: yarn install --ignore-scripts
     - name: Install react-native-flipper
       run: yarn relative-deps
     - name: Install pod dependencies
@@ -54,7 +54,7 @@ jobs:
           ~/.gradle/caches/build-cache-*
         key: gradle-${{ hashFiles('checksum-android.txt') }}
     - name: Install yarn dependencies
-      run: yarn install --frozen-lockfile --ignore-scripts
+      run: yarn install --ignore-scripts
     - name: Install react-native-flipper
       run: yarn relative-deps
     - name: Build React Native Android Example debug app

--- a/react-native/ReactNativeFlipperExample/android/gradle.properties
+++ b/react-native/ReactNativeFlipperExample/android/gradle.properties
@@ -30,4 +30,4 @@ android.useAndroidX=true
 android.enableJetifier=true
 
 # Version of flipper SDK to use with React Native
-FLIPPER_VERSION=0.88.0
+FLIPPER_VERSION=0.87.0

--- a/react-native/ReactNativeFlipperExample/ios/Podfile
+++ b/react-native/ReactNativeFlipperExample/ios/Podfile
@@ -19,7 +19,7 @@ target 'ReactNativeFlipperExample' do
   #
   # Note that if you have use_frameworks! enabled, Flipper will not work and
   # you should disable these next few lines.
-  use_flipper!({ 'Flipper' => '0.88.0' })
+  use_flipper!({ 'Flipper' => '0.87.0' })
   post_install do |installer|
     flipper_post_install(installer)
     # based on https://stackoverflow.com/a/37289688/1983583

--- a/react-native/ReactNativeFlipperExample/ios/Podfile.lock
+++ b/react-native/ReactNativeFlipperExample/ios/Podfile.lock
@@ -10,7 +10,7 @@ PODS:
     - React-Core (= 0.64.0)
     - React-jsi (= 0.64.0)
     - ReactCommon/turbomodule/core (= 0.64.0)
-  - Flipper (0.85.0):
+  - Flipper (0.87.0):
     - Flipper-Folly (~> 2.5)
     - Flipper-RSocket (~> 1.3)
   - Flipper-DoubleConversion (1.1.7)
@@ -24,47 +24,47 @@ PODS:
   - Flipper-PeerTalk (0.0.4)
   - Flipper-RSocket (1.3.0):
     - Flipper-Folly (~> 2.5)
-  - FlipperKit (0.85.0):
-    - FlipperKit/Core (= 0.85.0)
-  - FlipperKit/Core (0.85.0):
-    - Flipper (~> 0.85.0)
+  - FlipperKit (0.87.0):
+    - FlipperKit/Core (= 0.87.0)
+  - FlipperKit/Core (0.87.0):
+    - Flipper (~> 0.87.0)
     - FlipperKit/CppBridge
     - FlipperKit/FBCxxFollyDynamicConvert
     - FlipperKit/FBDefines
     - FlipperKit/FKPortForwarding
-  - FlipperKit/CppBridge (0.85.0):
-    - Flipper (~> 0.85.0)
-  - FlipperKit/FBCxxFollyDynamicConvert (0.85.0):
+  - FlipperKit/CppBridge (0.87.0):
+    - Flipper (~> 0.87.0)
+  - FlipperKit/FBCxxFollyDynamicConvert (0.87.0):
     - Flipper-Folly (~> 2.5)
-  - FlipperKit/FBDefines (0.85.0)
-  - FlipperKit/FKPortForwarding (0.85.0):
+  - FlipperKit/FBDefines (0.87.0)
+  - FlipperKit/FKPortForwarding (0.87.0):
     - CocoaAsyncSocket (~> 7.6)
     - Flipper-PeerTalk (~> 0.0.4)
-  - FlipperKit/FlipperKitHighlightOverlay (0.85.0)
-  - FlipperKit/FlipperKitLayoutHelpers (0.85.0):
+  - FlipperKit/FlipperKitHighlightOverlay (0.87.0)
+  - FlipperKit/FlipperKitLayoutHelpers (0.87.0):
     - FlipperKit/Core
     - FlipperKit/FlipperKitHighlightOverlay
     - FlipperKit/FlipperKitLayoutTextSearchable
-  - FlipperKit/FlipperKitLayoutIOSDescriptors (0.85.0):
+  - FlipperKit/FlipperKitLayoutIOSDescriptors (0.87.0):
     - FlipperKit/Core
     - FlipperKit/FlipperKitHighlightOverlay
     - FlipperKit/FlipperKitLayoutHelpers
     - YogaKit (~> 1.18)
-  - FlipperKit/FlipperKitLayoutPlugin (0.85.0):
+  - FlipperKit/FlipperKitLayoutPlugin (0.87.0):
     - FlipperKit/Core
     - FlipperKit/FlipperKitHighlightOverlay
     - FlipperKit/FlipperKitLayoutHelpers
     - FlipperKit/FlipperKitLayoutIOSDescriptors
     - FlipperKit/FlipperKitLayoutTextSearchable
     - YogaKit (~> 1.18)
-  - FlipperKit/FlipperKitLayoutTextSearchable (0.85.0)
-  - FlipperKit/FlipperKitNetworkPlugin (0.85.0):
+  - FlipperKit/FlipperKitLayoutTextSearchable (0.87.0)
+  - FlipperKit/FlipperKitNetworkPlugin (0.87.0):
     - FlipperKit/Core
-  - FlipperKit/FlipperKitReactPlugin (0.85.0):
+  - FlipperKit/FlipperKitReactPlugin (0.87.0):
     - FlipperKit/Core
-  - FlipperKit/FlipperKitUserDefaultsPlugin (0.85.0):
+  - FlipperKit/FlipperKitUserDefaultsPlugin (0.87.0):
     - FlipperKit/Core
-  - FlipperKit/SKIOSNetworkPlugin (0.85.0):
+  - FlipperKit/SKIOSNetworkPlugin (0.87.0):
     - FlipperKit/Core
     - FlipperKit/FlipperKitNetworkPlugin
   - glog (0.3.5)
@@ -279,7 +279,7 @@ PODS:
     - React-jsi (= 0.64.0)
     - React-perflogger (= 0.64.0)
   - React-jsinspector (0.64.0)
-  - react-native-flipper (0.86.0):
+  - react-native-flipper (0.87.0):
     - React-Core
   - React-perflogger (0.64.0)
   - React-RCTActionSheet (0.64.0):
@@ -353,25 +353,25 @@ DEPENDENCIES:
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
   - FBReactNativeSpec (from `../node_modules/react-native/React/FBReactNativeSpec`)
-  - Flipper (= 0.85.0)
+  - Flipper (= 0.87.0)
   - Flipper-DoubleConversion (= 1.1.7)
   - Flipper-Folly (~> 2.5)
   - Flipper-Glog (= 0.3.6)
   - Flipper-PeerTalk (~> 0.0.4)
   - Flipper-RSocket (~> 1.3)
-  - FlipperKit (= 0.85.0)
-  - FlipperKit/Core (= 0.85.0)
-  - FlipperKit/CppBridge (= 0.85.0)
-  - FlipperKit/FBCxxFollyDynamicConvert (= 0.85.0)
-  - FlipperKit/FBDefines (= 0.85.0)
-  - FlipperKit/FKPortForwarding (= 0.85.0)
-  - FlipperKit/FlipperKitHighlightOverlay (= 0.85.0)
-  - FlipperKit/FlipperKitLayoutPlugin (= 0.85.0)
-  - FlipperKit/FlipperKitLayoutTextSearchable (= 0.85.0)
-  - FlipperKit/FlipperKitNetworkPlugin (= 0.85.0)
-  - FlipperKit/FlipperKitReactPlugin (= 0.85.0)
-  - FlipperKit/FlipperKitUserDefaultsPlugin (= 0.85.0)
-  - FlipperKit/SKIOSNetworkPlugin (= 0.85.0)
+  - FlipperKit (= 0.87.0)
+  - FlipperKit/Core (= 0.87.0)
+  - FlipperKit/CppBridge (= 0.87.0)
+  - FlipperKit/FBCxxFollyDynamicConvert (= 0.87.0)
+  - FlipperKit/FBDefines (= 0.87.0)
+  - FlipperKit/FKPortForwarding (= 0.87.0)
+  - FlipperKit/FlipperKitHighlightOverlay (= 0.87.0)
+  - FlipperKit/FlipperKitLayoutPlugin (= 0.87.0)
+  - FlipperKit/FlipperKitLayoutTextSearchable (= 0.87.0)
+  - FlipperKit/FlipperKitNetworkPlugin (= 0.87.0)
+  - FlipperKit/FlipperKitReactPlugin (= 0.87.0)
+  - FlipperKit/FlipperKitUserDefaultsPlugin (= 0.87.0)
+  - FlipperKit/SKIOSNetworkPlugin (= 0.87.0)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - hermes-engine (~> 0.7.2)
   - libevent (~> 2.1.12)
@@ -486,13 +486,13 @@ SPEC CHECKSUMS:
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 49cbe4b43e445b06bf29199b6ad2057649e4c8f5
   FBReactNativeSpec: 9e9f783f0e063dba3464ba0f9a826ac6c7f2908f
-  Flipper: 6201b61dc6dce66db0be3cdb9ee4d165825d3453
+  Flipper: 1bd2db48dcc31e4b167b9a33ec1df01c2ded4893
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
   Flipper-Folly: f7a3caafbd74bda4827954fd7a6e000e36355489
   Flipper-Glog: 1dfd6abf1e922806c52ceb8701a3599a79a200a6
   Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
   Flipper-RSocket: 602921fee03edacf18f5d6f3d3594ba477f456e5
-  FlipperKit: 512e73377be7e6462679d95ce274ca0b2d978f9c
+  FlipperKit: 651f50a42eb95c01b3e89a60996dd6aded529eeb
   glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
   hermes-engine: 7d97ba46a1e29bacf3e3c61ecb2804a5ddd02d4f
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
@@ -508,7 +508,7 @@ SPEC CHECKSUMS:
   React-jsi: 74341196d9547cbcbcfa4b3bbbf03af56431d5a1
   React-jsiexecutor: 06a9c77b56902ae7ffcdd7a4905f664adc5d237b
   React-jsinspector: 0ae35a37b20d5e031eb020a69cc5afdbd6406301
-  react-native-flipper: d3d2f95926f5059ec268d59921c218adaa821eb5
+  react-native-flipper: a5770950f79017f17f50b316cb74b66d14192c79
   React-perflogger: 9c547d8f06b9bf00cb447f2b75e8d7f19b7e02af
   React-RCTActionSheet: 3080b6e12e0e1a5b313c8c0050699b5c794a1b11
   React-RCTAnimation: 3f96f21a497ae7dabf4d2f150ee43f906aaf516f
@@ -524,6 +524,6 @@ SPEC CHECKSUMS:
   Yoga: 8c8436d4171c87504c648ae23b1d81242bdf3bbf
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: 79e3114c30470608edf7c57690385921aae6fd67
+PODFILE CHECKSUM: 7428f5c59df17f0e7d381f659982cfd15b99db32
 
 COCOAPODS: 1.10.1

--- a/react-native/ReactNativeFlipperExample/package.json
+++ b/react-native/ReactNativeFlipperExample/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "react": "^17.0.1",
     "react-native": "^0.64.0",
-    "react-native-flipper": "^0.88.0"
+    "react-native-flipper": "^0.87.0"
   },
   "devDependencies": {
     "@babel/core": "^7.14.0",


### PR DESCRIPTION
Summary: Fix react native OSS build. As discussed a couple of weeks ago, we can bump deps, but cannot bump lock files during release, as artifacts are then not yet available.

Differential Revision: D28255272

