### PR TITLE
Remove dcendents.android-maven plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,6 @@ buildscript {
 
 plugins {
     id 'de.undercouch.download' version '4.1.1'
-    id 'com.github.dcendents.android-maven' version '2.1'
     id 'com.github.ben-manes.versions' version '0.38.0'
 }
 


### PR DESCRIPTION
Summary:
This should no longer be needed as our Maven Publishing now happens
through another plugin.

This is blocking the upgrade to Gradle 7 mentioned in https://github.com/facebook/flipper/issues/2221.

It's also deprecated: https://github.com/dcendents/android-maven-gradle-plugin

Test Plan:
Manually built things, ran `uploadArchives -PdryRun=true`. No issues.
