### PR TITLE
Upgrade to Gradle 7

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,6 @@
  */
 
 apply plugin: 'com.android.library'
-apply plugin: 'maven'
 
 android {
     compileSdkVersion rootProject.compileSdkVersion

--- a/android/no-op/build.gradle
+++ b/android/no-op/build.gradle
@@ -6,7 +6,6 @@
  */
 
 apply plugin: 'com.android.library'
-apply plugin: 'maven'
 
 android {
     compileSdkVersion rootProject.compileSdkVersion

--- a/android/plugins/fresco/build.gradle
+++ b/android/plugins/fresco/build.gradle
@@ -6,7 +6,6 @@
  */
 
 apply plugin: 'com.android.library'
-apply plugin: 'maven'
 
 android {
     compileSdkVersion rootProject.compileSdkVersion

--- a/android/plugins/leakcanary/build.gradle
+++ b/android/plugins/leakcanary/build.gradle
@@ -6,7 +6,6 @@
  */
 
 apply plugin: 'com.android.library'
-apply plugin: 'maven'
 
 android {
     compileSdkVersion rootProject.compileSdkVersion

--- a/android/plugins/leakcanary2/build.gradle
+++ b/android/plugins/leakcanary2/build.gradle
@@ -9,7 +9,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
-apply plugin: 'maven'
 
 android {
     compileSdkVersion rootProject.compileSdkVersion

--- a/android/plugins/litho/build.gradle
+++ b/android/plugins/litho/build.gradle
@@ -6,7 +6,6 @@
  */
 
 apply plugin: 'com.android.library'
-apply plugin: 'maven'
 
 android {
     compileSdkVersion rootProject.compileSdkVersion

--- a/android/plugins/network/build.gradle
+++ b/android/plugins/network/build.gradle
@@ -6,7 +6,6 @@
  */
 
 apply plugin: 'com.android.library'
-apply plugin: 'maven'
 
 android {
     compileSdkVersion rootProject.compileSdkVersion

--- a/android/plugins/retrofit2-protobuf/build.gradle
+++ b/android/plugins/retrofit2-protobuf/build.gradle
@@ -9,7 +9,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
-apply plugin: 'maven'
 
 android {
     compileSdkVersion rootProject.compileSdkVersion

--- a/android/third-party/native.gradle
+++ b/android/third-party/native.gradle
@@ -52,6 +52,7 @@ task downloadGlog(dependsOn: createNativeDepsDirectories, type: Download) {
 task prepareGlog(dependsOn: [downloadGlog], type: Copy) {
     onlyIf { isCacheOutOfDate(CACHE_REVISION) }
     from tarTree(downloadGlog.dest)
+    duplicatesStrategy DuplicatesStrategy.INCLUDE
     from './overrides/glog/'
     include 'glog-0.3.5/src/**/*', 'Android.mk', 'config.h', 'build.gradle', 'CMakeLists.txt', 'ApplicationManifest.xml'
     includeEmptyDirs = false

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ ext {
     minSdkVersion = 15
     targetSdkVersion = 29
     compileSdkVersion = 29
-    buildToolsVersion = '29.0.2'
+    buildToolsVersion = '30.0.2'
     ndkVersion = '21.3.6528147'
     sourceCompatibilityVersion = JavaVersion.VERSION_1_7
     targetCompatibilityVersion = JavaVersion.VERSION_1_7

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -7,4 +7,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -7,4 +7,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-all.zip


### PR DESCRIPTION
Summary:
Depends on #2277. Fixes #2221.

The maven plugin is no longer exposed and implied by https://developer.android.com/studio/build/maven-publish-plugin.

Test Plan:
./gradlew uploadArchives -PdryRun=true

