### PR TITLE
"Fix" "typo" that's blocking Android releases

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,12 +11,12 @@ POM_URL=https://github.com/facebook/flipper
 POM_SCM_URL=https://github.com/facebook/flipper.git
 POM_SCM_CONNECTION=scm:git:https://github.com/facebook/flipper.git
 POM_SCM_DEV_CONNECTION=scm:git:git@github.com:facebook/flipper.git
-POM_LICENSE_NAME=MIT
-POM_LICENSE_URL=https://github.com/facebook/flipper/blob/master/LICENSE
-POM_LICENSE_DIST=repo
+POM_LICENCE_NAME=MIT
+POM_LICENCE_URL=https://github.com/facebook/flipper/blob/master/LICENSE
+POM_LICENCE_DIST=repo
 POM_DEVELOPER_ID=facebook
 POM_DEVELOPER_NAME=facebook
-POM_ISSUES_URL = 'https://github.com/facebook/flipper/issues/'
+POM_ISSUES_URL=https://github.com/facebook/flipper/issues/
 
 # Shared version numbers
 LITHO_VERSION=0.39.0


### PR DESCRIPTION
Summary:
Bit of an odd one. Our publishing plugin changed what fields
it expect to define the license of the project. That has caused
Maven Central to reject our uploads:

https://github.com/vanniktech/gradle-maven-publish-plugin/blob/af0de22a5a7ee2efcbaa77756769392e13dd6b38/src/main/kotlin/com/vanniktech/maven/publish/legacy/BaseSetup.kt#L70

I hope this is a temporary "fix".

Test Plan:
Uploaded to my local maven m2 and now the fields are back.
