### PR TITLE
Network Plugin: Add xhtml and xml to 'Textual' check

### DIFF
--- a/desktop/plugins/public/network/utils.tsx
+++ b/desktop/plugins/public/network/utils.tsx
@@ -39,7 +39,8 @@ export function isTextual(headers?: Array<Header>): boolean {
     contentType.startsWith('application/json') ||
     contentType.startsWith('multipart/') ||
     contentType.startsWith('message/') ||
-    contentType.startsWith('image/svg')
+    contentType.startsWith('image/svg') ||
+    contentType.startsWith('application/xhtml+xml')
   );
 }
 


### PR DESCRIPTION
## Summary

Network requests that return a "Content-Type" of 'application/xhtml+xml' are currently being treated as binary data when they should be treated as text.

## Changelog

Network Plugin - treat "Content-Type" of 'application/xhtml+xml' as text

## Test Plan

Using an API that return "Content-Type" of 'application/xhtml+xml' , verified that the response data in sidebar appears as text rather than '(binary data)'

