### PR TITLE
Detect JSON API content type ('application/vnd.api+json') as textual content

### DIFF
--- a/desktop/plugins/public/network/utils.tsx
+++ b/desktop/plugins/public/network/utils.tsx
@@ -26,6 +26,9 @@ export function getHeaderValue(
   return '';
 }
 
+// Matches `application/json` and `application/vnd.api.v42+json` (see https://jsonapi.org/#mime-types)
+const jsonContentTypeRegex = new RegExp('application/(json|.+\\+json)')
+
 export function isTextual(headers?: Array<Header>): boolean {
   const contentType = getHeaderValue(headers, 'Content-Type');
   if (!contentType) {
@@ -36,7 +39,7 @@ export function isTextual(headers?: Array<Header>): boolean {
   return (
     contentType.startsWith('text/') ||
     contentType.startsWith('application/x-www-form-urlencoded') ||
-    contentType.startsWith('application/json') ||
+    jsonContentTypeRegex.test(contentType) ||
     contentType.startsWith('multipart/') ||
     contentType.startsWith('message/') ||
     contentType.startsWith('image/svg')


### PR DESCRIPTION
## Summary

Network requests and responses using JSON API content type of pattern `application/vnd.api+json` (see https://jsonapi.org/#mime-types) are currently treated as binary data. They should be treated as textual content.

## Changelog

Add regular expression to detect JSON content types.

## Test Plan

Using an API that return `Content-Type` of pattern `application/vnd.api+json`, verify that the response data in sidebar appears as text rather than `(binary data)`.

