### PR TITLE
fix problem with mock request data

### DIFF
--- a/desktop/plugins/public/network/request-mocking/ManageMockResponsePanel.tsx
+++ b/desktop/plugins/public/network/request-mocking/ManageMockResponsePanel.tsx
@@ -148,9 +148,9 @@ export function ManageMockResponsePanel(props: Props) {
             placement="bottom">
             <Button
               onClick={() => {
-                networkRouteManager.copyHighlightedCalls();
+                networkRouteManager.copySelectedCalls();
               }}>
-              Copy Highlighted Calls
+              Copy Selected Calls
             </Button>
           </NUX>
           <Button onClick={networkRouteManager.importRoutes}>Import</Button>

--- a/desktop/plugins/public/network/request-mocking/NetworkRouteManager.tsx
+++ b/desktop/plugins/public/network/request-mocking/NetworkRouteManager.tsx
@@ -39,7 +39,7 @@ export interface NetworkRouteManager {
   modifyRoute(id: string, routeChange: Partial<Route>): void;
   removeRoute(id: string): void;
   enableRoute(id: string): void;
-  copyHighlightedCalls(): void;
+  copySelectedCalls(): void;
   importRoutes(): void;
   exportRoutes(): void;
   clearRoutes(): void;
@@ -52,7 +52,7 @@ export const nullNetworkRouteManager: NetworkRouteManager = {
   modifyRoute(_id: string, _routeChange: Partial<Route>) {},
   removeRoute(_id: string) {},
   enableRoute(_id: string) {},
-  copyHighlightedCalls() {},
+  copySelectedCalls() {},
   importRoutes() {},
   exportRoutes() {},
   clearRoutes() {},
@@ -109,7 +109,7 @@ export function createNetworkManager(
       }
       informClientMockChange(routes.get());
     },
-    copyHighlightedCalls() {
+    copySelectedCalls() {
       tableManagerRef.current?.getSelectedItems().forEach((request) => {
         // convert headers
         const headers: {[id: string]: Header} = {};
@@ -117,14 +117,9 @@ export function createNetworkManager(
           headers[e.key] = e;
         });
 
-        // convert data TODO: we only want this for non-binary data! See D23403095
+        // no need to convert data, already converted when real call was created
         const responseData =
-          request && request.responseData
-            ? decodeBody(
-                request.responseHeaders ?? [],
-                bodyAsString(request.responseData),
-              )
-            : '';
+          request && request.responseData ? request.responseData : '';
 
         const newNextRouteId = nextRouteId.get();
         routes.update((draft) => {


### PR DESCRIPTION
## Summary

Network Plugin - When creating a mock request from a selected request, the request data is not in the proper format.  It is decoded instead of just being copied from the call (which has already been decoded properly).  This PR fixes that problem.

Below is a screenshot showing the problem (which occurs for all text response data):

![image](https://user-images.githubusercontent.com/337874/118744068-423e3b80-b819-11eb-9076-216459517fdb.png)


## Changelog

Network Plugin - Fix problem with decoding request data for mocks copied from selection

## Test Plan

Using the sample Android app, issue a network request

In Flipper, create a mock for the network request by selecting it and using the "Copy Selected Calls" function in the mock

Verify that the request data is readable:

![image](https://user-images.githubusercontent.com/337874/118744220-8af5f480-b819-11eb-9206-0fa40e7d7e46.png)

Note:

Testing was done using the sample app which uses responses with JSON data.  I was not able to provide testing for other types of calls, specifically calls that would return binary data.

