### PR TITLE
[WIP][iOS] Update Boost iOSX dep and make it work for arm and i386 for sims

### DIFF
--- a/.github/workflows/iOS-Sample.yml
+++ b/.github/workflows/iOS-Sample.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Build Sample app
         run: |
           IPHONESIMULATOR=$(xcodebuild -showsdks | grep -o "iphonesimulator[0-9]\\+\\.[0-9]\\+$") && echo $IPHONESIMULATOR
-          xcodebuild build -workspace Sample.xcworkspace -scheme Sample -sdk $IPHONESIMULATOR EXCLUDED_ARCHS="arm64 i386"
+          xcodebuild build -workspace Sample.xcworkspace -scheme Sample -sdk $IPHONESIMULATOR EXCLUDED_ARCHS="arm64"
 
   build-sample-swift:
     runs-on: macos-latest
@@ -42,7 +42,7 @@ jobs:
       - name: Build SampleSwift app
         run: |
           IPHONESIMULATOR=$(xcodebuild -showsdks | grep -o "iphonesimulator[0-9]\\+\\.[0-9]\\+$") && echo $IPHONESIMULATOR
-          xcodebuild build -workspace SampleSwift.xcworkspace -scheme SampleSwift -sdk $IPHONESIMULATOR EXCLUDED_ARCHS="arm64 i386"
+          xcodebuild build -workspace SampleSwift.xcworkspace -scheme SampleSwift -sdk $IPHONESIMULATOR
 
   build-tutorial:
     runs-on: macos-latest
@@ -57,4 +57,4 @@ jobs:
       - name: Build Tutorial app
         run: |
           IPHONESIMULATOR=$(xcodebuild -showsdks | grep -o "iphonesimulator[0-9]\\+\\.[0-9]\\+$") && echo $IPHONESIMULATOR
-          xcodebuild build -workspace Tutorial.xcworkspace -scheme Tutorial -sdk $IPHONESIMULATOR EXCLUDED_ARCHS="arm64 i386"
+          xcodebuild build -workspace Tutorial.xcworkspace -scheme Tutorial -sdk $IPHONESIMULATOR

--- a/docs/getting-started/ios-native.mdx
+++ b/docs/getting-started/ios-native.mdx
@@ -3,18 +3,15 @@ id: ios-native
 title: Adding Flipper to iOS apps
 sidebar_label: Generic iOS apps
 ---
-import useBaseUrl from '@docusaurus/useBaseUrl';
-import Link from '@docusaurus/Link';
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
+
+import useBaseUrl from "@docusaurus/useBaseUrl";
+import Link from "@docusaurus/Link";
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
 
 We support both Swift and Objective-C for Flipper with CocoaPods as build and distribution mechanism.
 
 ## CocoaPods
-
-<div class="warning">
-Use Flipper/FlipperKit Version 0.87.0 and Flipper-Folly 2.5.3, if you depend on arm64 and i386 artifacts for the simulator. Versions greater than 0.87 and 2.5.3 of Flipper and Flipper-Folly, respectively, do not have these artifacts. This issue is tracked <Link to="https://github.com/facebook/flipper/issues/2268">here</Link>.
-</div>
 
 The following configuration assumed CocoaPods 1.9+.
 

--- a/iOS/Podspecs/Flipper-Boost-iOSX.podspec
+++ b/iOS/Podspecs/Flipper-Boost-iOSX.podspec
@@ -1,0 +1,25 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+Pod::Spec.new do |s|
+    s.name         = "Flipper-Boost-iOSX"
+    s.version      = "1.76.0.1.11"
+    s.summary      = "Boost C++ libraries"
+    s.homepage     = "https://github.com/priteshrnandgaonkar/boost-iosx"
+    s.license      = "Boost Software License"
+    s.author       = { "Pritesh Nandgaonkar" => "prit91@fb.com" }
+    s.ios.deployment_target = "10.0"
+    s.osx.pod_target_xcconfig = { 'ONLY_ACTIVE_ARCH' => 'YES' }
+    s.ios.pod_target_xcconfig = { 'ONLY_ACTIVE_ARCH' => 'YES' }
+    s.static_framework = true
+    s.source       = { :git => "https://github.com/priteshrnandgaonkar/Flipper-Boost-iOSX.git", :tag => "1.76.0.1.11" }
+    s.module_name = 'boost'
+    s.header_dir = 'boost'
+    s.preserve_path = 'boost', 'asm'
+    s.source_files = 'asm/ontop_combined_all_macho_gas.S', 'asm/make_combined_all_macho_gas.S', 'asm/jump_combined_all_macho_gas.S'
+    s.pod_target_xcconfig = {  "USE_HEADERMAP" => "NO",
+    "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/Flipper-Boost-iOSX/asm\""
+  }
+end

--- a/iOS/Sample/Podfile.lock
+++ b/iOS/Sample/Podfile.lock
@@ -6,7 +6,7 @@ PODS:
   - Flipper (0.88.0):
     - Flipper-Folly (~> 2.6)
     - Flipper-RSocket (~> 1.4)
-  - Flipper-Boost-iOSX (1.76.0.1.10)
+  - Flipper-Boost-iOSX (1.76.0.1.11)
   - Flipper-DoubleConversion (3.1.7)
   - Flipper-Fmt (7.1.7)
   - Flipper-Folly (2.6.7):
@@ -99,7 +99,7 @@ DEPENDENCIES:
   - OpenSSL-Universal
 
 SPEC REPOS:
-  https://github.com/CocoaPods/Specs:
+  https://github.com/CocoaPods/Specs.git:
     - CocoaAsyncSocket
     - ComponentKit
     - Flipper-Boost-iOSX
@@ -125,7 +125,7 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   ComponentKit: 7bf7048b9814afc6b6641645a14177f95fd9b9ae
   Flipper: bbba2bf26e3377be472c5afd4113a4c77c4af07a
-  Flipper-Boost-iOSX: df3765e7e26b44bc3e68a250ef1fa0afa15963bc
+  Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
   Flipper-DoubleConversion: 57ffbe81ef95306cc9e69c4aa3aeeeeb58a6a28c
   Flipper-Fmt: 60cbdd92fc254826e61d669a5d87ef7015396a9b
   Flipper-Folly: 83af37379faa69497529e414bd43fbfc7cae259a

--- a/iOS/SampleSwift/Podfile.lock
+++ b/iOS/SampleSwift/Podfile.lock
@@ -7,7 +7,7 @@ PODS:
   - Flipper (0.88.0):
     - Flipper-Folly (~> 2.6)
     - Flipper-RSocket (~> 1.4)
-  - Flipper-Boost-iOSX (1.76.0.1.10)
+  - Flipper-Boost-iOSX (1.76.0.1.11)
   - Flipper-DoubleConversion (3.1.7)
   - Flipper-Fmt (7.1.7)
   - Flipper-Folly (2.6.7):
@@ -97,7 +97,7 @@ DEPENDENCIES:
   - OpenSSL-Universal
 
 SPEC REPOS:
-  https://github.com/CocoaPods/Specs:
+  https://github.com/CocoaPods/Specs.git:
     - boost-for-react-native
     - CocoaAsyncSocket
     - ComponentKit
@@ -125,7 +125,7 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   ComponentKit: 7bf7048b9814afc6b6641645a14177f95fd9b9ae
   Flipper: bbba2bf26e3377be472c5afd4113a4c77c4af07a
-  Flipper-Boost-iOSX: df3765e7e26b44bc3e68a250ef1fa0afa15963bc
+  Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
   Flipper-DoubleConversion: 57ffbe81ef95306cc9e69c4aa3aeeeeb58a6a28c
   Flipper-Fmt: 60cbdd92fc254826e61d669a5d87ef7015396a9b
   Flipper-Folly: 83af37379faa69497529e414bd43fbfc7cae259a

--- a/iOS/Tutorial/Podfile.lock
+++ b/iOS/Tutorial/Podfile.lock
@@ -6,7 +6,7 @@ PODS:
   - Flipper (0.88.0):
     - Flipper-Folly (~> 2.6)
     - Flipper-RSocket (~> 1.4)
-  - Flipper-Boost-iOSX (1.76.0.1.10)
+  - Flipper-Boost-iOSX (1.76.0.1.11)
   - Flipper-DoubleConversion (3.1.7)
   - Flipper-Fmt (7.1.7)
   - Flipper-Folly (2.6.7):
@@ -105,7 +105,7 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   ComponentKit: 7bf7048b9814afc6b6641645a14177f95fd9b9ae
   Flipper: bbba2bf26e3377be472c5afd4113a4c77c4af07a
-  Flipper-Boost-iOSX: df3765e7e26b44bc3e68a250ef1fa0afa15963bc
+  Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
   Flipper-DoubleConversion: 57ffbe81ef95306cc9e69c4aa3aeeeeb58a6a28c
   Flipper-Fmt: 60cbdd92fc254826e61d669a5d87ef7015396a9b
   Flipper-Folly: 83af37379faa69497529e414bd43fbfc7cae259a
@@ -119,6 +119,6 @@ SPEC CHECKSUMS:
   Yoga: cff67a400f6b74dc38eb0bad4f156673d9aa980c
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: 9b143bbf8177a57ba722b816f1f55abe65f9bfe8
+PODFILE CHECKSUM: 6f5624ced7ccda6b31b85d1fa2b0b05b1e2c74a3
 
 COCOAPODS: 1.10.1


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This diff updates and adds the boost ios podspec in flipper repo. This new boost dep works for Arm and i386 archs for simulator too.

This diff also updates our GH Action to remove i386 from excluded archs. Still arm64 is kept as non M1 mac machines do not have arm swift symbols for arm simulator. And since all our CI is on non M1, it is required.

It also takes care of #2268
## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. This should just be a brief oneline we can mention in our release notes: https://github.com/facebook/flipper/releases -->

- Update the boost dep
- Update the GH action

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI / output of the test runner and how you invoked it. -->

CI