### PR TITLE
Update docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,9 +20,9 @@ jobs:
         working-directory: website/
 
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@3.7.1
+        uses: JamesIves/github-pages-deploy-action@4.1.3
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: website/build
-          CLEAN: true
+          branch: gh-pages
+          folder: website/build
+          clean: true
+          commit-message: "[ci skip] Deploying documentation update"


### PR DESCRIPTION
Summary:

Updated to the latest version which apparently doesn't need a privileged token anymore, which would be good news.
Also updated the message to include a `[ci skip]` which instructs CircleCI not to run because we're having a chicken-and-egg-problem here with CircleCI otherwise needing a config to tell it not to run, otherwise it will run and fail because there's no config.

Test Plan:
hopeitwork

Task: T91157540
