### PR TITLE
docs: update network-plugin.mdx android

### DIFF
--- a/docs/setup/network-plugin.mdx
+++ b/docs/setup/network-plugin.mdx
@@ -26,6 +26,12 @@ the client:
 import com.facebook.flipper.plugins.network.NetworkFlipperPlugin;
 
 NetworkFlipperPlugin networkFlipperPlugin = new NetworkFlipperPlugin();
+new NetworkingModule.CustomClientBuilder() {
+    @Override
+    public void apply(OkHttpClient.Builder builder) {
+        builder.addNetworkInterceptor(new FlipperOkhttpInterceptor(networkFlipperPlugin));
+    }
+});
 client.addPlugin(networkFlipperPlugin);
 ```
 


### PR DESCRIPTION
Flipper network plugin does not work without the above added lines.

## Summary

Without the added lines, the network plugin simply does not work on Android with Flipper version 0.91.0. I found this solution in your example react-native project. This should be stated in the docs.

## Changelog

This should not be stated in changelog.

## Test Plan

There is no code.

