### PR TITLE
Fix search by passing query to search request

### DIFF
--- a/desktop/plugin-lib/src/getUpdatablePlugins.ts
+++ b/desktop/plugin-lib/src/getUpdatablePlugins.ts
@@ -35,7 +35,7 @@ export async function getUpdatablePlugins(
 ): Promise<UpdatablePluginDetails[]> {
   const installedPlugins = await getInstalledPlugins();
   const npmHostedPlugins = new Map<string, NpmPackageDescriptor>(
-    (await getNpmHostedPlugins()).map((p) => [p.name, p]),
+    (await getNpmHostedPlugins({query})).map((p) => [p.name, p]),
   );
   const annotatedInstalledPlugins = await pmap(
     installedPlugins,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

When publishing a new flipper plugin, I realized my plugin wasn't showing up in the Plugin Installer search. This was due to a bug where we are only grabbing 50 plugins from NPM and filtering through them locally, instead of passing the search term to the search query. There are 59 plugins that match the keyword filter on npm so 9 plugins never get surfaced.

## Changelog

Fix missing plugins in plugin manager's NPM search

## Test Plan

Test the search feature in Plugin Manager

Search for the previously missing package:
![image](https://user-images.githubusercontent.com/1904616/119906244-b4daa580-bf02-11eb-8545-c8cf0663ae92.png)

Previously working searches continue to work:
![image](https://user-images.githubusercontent.com/1904616/119906274-c02dd100-bf02-11eb-938a-d84b27c6bd81.png)

