### PR TITLE
[android][ci] Build all artifacts as part of GH workflow

### DIFF
--- a/.github/workflows/android-sample.yml
+++ b/.github/workflows/android-sample.yml
@@ -24,7 +24,9 @@ jobs:
           ~/.gradle/caches/jars-*
           ~/.gradle/caches/build-cache-*
         key: gradle-${{ hashFiles('checksum-android.txt') }}
-    - name: Build with Gradle
+    - name: Build artifacts with Gradle
+      run: ./gradlew assembleDebug
+    - name: Build sample apps with Gradle
       run: ./gradlew :sample:assembleDebug :tutorial:assembleDebug
     - name: upload artifact
       uses: actions/upload-artifact@v1


### PR DESCRIPTION
Summary:
We missed that D28795384 broke the Kotlin plugin until we got to
our Snapshot job. This makes sure we build all artifacts and get
signal on PRs.

Test Plan:
CI

`./gradlew assembleDebug` failed correctly when applying the change.

