### PR TITLE
Add github spec repo as a source in RN Sample app

### DIFF
--- a/.github/workflows/publish-pods.yml
+++ b/.github/workflows/publish-pods.yml
@@ -8,46 +8,46 @@ on:
   workflow_dispatch:
 
 jobs:
-  # publish_flipper_pod:
-  #   runs-on: macos-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
+  publish_flipper_pod:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
 
-  #     - name: Install Dependences
-  #       run: pod repo update
+      - name: Install Dependences
+        run: pod repo update
 
-  #     - name: Pod Version
-  #       run: pod --version
+      - name: Pod Version
+        run: pod --version
 
-  #     - name: Update Flipper version
-  #       run: ./scripts/update-pod-versions.sh ./ ./Flipper.podspec
+      - name: Update Flipper version
+        run: ./scripts/update-pod-versions.sh ./ ./Flipper.podspec
 
-  #     - name: Push Flipper
-  #       run: pod trunk push Flipper.podspec --use-libraries --allow-warnings --verbose --skip-import-validation
-  #       env:
-  #         COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+      - name: Push Flipper
+        run: pod trunk push Flipper.podspec --use-libraries --allow-warnings --verbose --skip-import-validation
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
 
-  # publish_flipperkit_pod:
-  #   needs: publish_flipper_pod
-  #   runs-on: macos-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
+  publish_flipperkit_pod:
+    needs: publish_flipper_pod
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
 
-  #     - name: Install Dependences
-  #       run: pod repo update
+      - name: Install Dependences
+        run: pod repo update
 
-  #     - name: Pod Version
-  #       run: pod --version
+      - name: Pod Version
+        run: pod --version
 
-  #     - name: Update FlipperKit version
-  #       run: ./scripts/update-pod-versions.sh ./ ./FlipperKit.podspec
+      - name: Update FlipperKit version
+        run: ./scripts/update-pod-versions.sh ./ ./FlipperKit.podspec
 
-  #     - name: Push FlipperKit
-  #       run: |
-  #         # Retry publishing FlipperKit 20 times. Putting this hack unless we have cocoapods 1.10. More information related to the bug https://github.com/CocoaPods/CocoaPods/issues/9502#issuecomment-579486258
-  #         for i in {1..20}; do pod trunk push FlipperKit.podspec --use-libraries --allow-warnings --verbose --skip-import-validation --synchronous && break || sleep 30; done
-  #       env:
-  #         COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+      - name: Push FlipperKit
+        run: |
+          # Retry publishing FlipperKit 20 times. Putting this hack unless we have cocoapods 1.10. More information related to the bug https://github.com/CocoaPods/CocoaPods/issues/9502#issuecomment-579486258
+          for i in {1..20}; do pod trunk push FlipperKit.podspec --use-libraries --allow-warnings --verbose --skip-import-validation --synchronous && break || sleep 30; done
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
 
   create_pr:
     runs-on: macos-latest

--- a/.github/workflows/publish-pods.yml
+++ b/.github/workflows/publish-pods.yml
@@ -3,8 +3,6 @@ on:
   push:
     tags:
       - v*
-    branches:
-      - fix-create-pr-rn
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/publish-pods.yml
+++ b/.github/workflows/publish-pods.yml
@@ -48,6 +48,7 @@ jobs:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
 
   create_pr:
+    needs: publish_flipperkit_pod
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/publish-pods.yml
+++ b/.github/workflows/publish-pods.yml
@@ -3,52 +3,53 @@ on:
   push:
     tags:
       - v*
+    branches:
+      - fix-create-pr-rn
   workflow_dispatch:
 
 jobs:
-  publish_flipper_pod:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v2
+  # publish_flipper_pod:
+  #   runs-on: macos-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
 
-      - name: Install Dependences
-        run: pod repo update
+  #     - name: Install Dependences
+  #       run: pod repo update
 
-      - name: Pod Version
-        run: pod --version
+  #     - name: Pod Version
+  #       run: pod --version
 
-      - name: Update Flipper version
-        run: ./scripts/update-pod-versions.sh ./ ./Flipper.podspec
+  #     - name: Update Flipper version
+  #       run: ./scripts/update-pod-versions.sh ./ ./Flipper.podspec
 
-      - name: Push Flipper
-        run: pod trunk push Flipper.podspec --use-libraries --allow-warnings --verbose --skip-import-validation
-        env:
-          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+  #     - name: Push Flipper
+  #       run: pod trunk push Flipper.podspec --use-libraries --allow-warnings --verbose --skip-import-validation
+  #       env:
+  #         COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
 
-  publish_flipperkit_pod:
-    needs: publish_flipper_pod
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v2
+  # publish_flipperkit_pod:
+  #   needs: publish_flipper_pod
+  #   runs-on: macos-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
 
-      - name: Install Dependences
-        run: pod repo update
+  #     - name: Install Dependences
+  #       run: pod repo update
 
-      - name: Pod Version
-        run: pod --version
+  #     - name: Pod Version
+  #       run: pod --version
 
-      - name: Update FlipperKit version
-        run: ./scripts/update-pod-versions.sh ./ ./FlipperKit.podspec
+  #     - name: Update FlipperKit version
+  #       run: ./scripts/update-pod-versions.sh ./ ./FlipperKit.podspec
 
-      - name: Push FlipperKit
-        run: |
-          # Retry publishing FlipperKit 20 times. Putting this hack unless we have cocoapods 1.10. More information related to the bug https://github.com/CocoaPods/CocoaPods/issues/9502#issuecomment-579486258
-          for i in {1..20}; do pod trunk push FlipperKit.podspec --use-libraries --allow-warnings --verbose --skip-import-validation --synchronous && break || sleep 30; done
-        env:
-          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+  #     - name: Push FlipperKit
+  #       run: |
+  #         # Retry publishing FlipperKit 20 times. Putting this hack unless we have cocoapods 1.10. More information related to the bug https://github.com/CocoaPods/CocoaPods/issues/9502#issuecomment-579486258
+  #         for i in {1..20}; do pod trunk push FlipperKit.podspec --use-libraries --allow-warnings --verbose --skip-import-validation --synchronous && break || sleep 30; done
+  #       env:
+  #         COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
 
   create_pr:
-    needs: publish_flipperkit_pod
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2

--- a/react-native/ReactNativeFlipperExample/ios/Podfile
+++ b/react-native/ReactNativeFlipperExample/ios/Podfile
@@ -1,5 +1,6 @@
 require_relative '../node_modules/react-native/scripts/react_native_pods'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
+source 'https://github.com/CocoaPods/Specs'
 
 platform :ios, '10.0'
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This diff adds the cocoapod's github repo as a source otherwise Cocoapod uses the cdn to refer the latest pods. We need this as in create_pr job we update the Podfile.lock of this RN sample project and it fails to find the latest flipper pod because Cocapod takes a while to update its cdn. Reffering the specs directly from github repo solves the issue.
## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. This should just be a brief oneline we can mention in our release notes: https://github.com/facebook/flipper/releases -->

Add github spec repo as a source in the Podfile.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI / output of the test runner and how you invoked it. -->
CI
https://github.com/facebook/flipper/actions/runs/902547740
