### PR TITLE
Fix Typo In Setup Doctor

### DIFF
--- a/desktop/app/src/sandy-chrome/SetupDoctorScreen.tsx
+++ b/desktop/app/src/sandy-chrome/SetupDoctorScreen.tsx
@@ -52,7 +52,7 @@ const statusTypeAndMessage: {
   },
   WARNING: {
     type: 'warning',
-    message: 'Doctor has discoverd warnings. Please expand items for details.',
+    message: 'Doctor has discovered warnings. Please expand items for details.',
   },
   SUCCESS: {
     type: 'success',


### PR DESCRIPTION
## Summary
Simple fix for a minor typo

## Changelog
SetupDoctorScreen.tsx:55: discoverd -> discovered


## Test Plan
### Visual diff: 
|Before: |
|---|
| <img width="566" alt="Screen Shot 2021-06-24 at 10 59 14 AM" src="https://user-images.githubusercontent.com/68758506/123316824-24cc5380-d4e2-11eb-8337-1e7fa0dbf838.png"> |
|After:|
| <img width="562" alt="Screen Shot 2021-06-24 at 11 54 32 AM" src="https://user-images.githubusercontent.com/68758506/123317505-f3a05300-d4e2-11eb-89a5-e9903279836f.png"> |