### PR TITLE
Update Flipper-Folly.podspec

### DIFF
--- a/iOS/Podspecs/Flipper-Folly.podspec
+++ b/iOS/Podspecs/Flipper-Folly.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   spec.dependency 'Flipper-Boost-iOSX'
   spec.dependency 'Flipper-Glog'
   spec.dependency 'Flipper-DoubleConversion'
-  spec.dependency 'OpenSSL-Universal', '1.1.180'
+  spec.dependency 'OpenSSL-Universal', '1.1.1100'
   spec.dependency 'libevent', '~> 2.1.12'
   spec.dependency 'Flipper-Fmt', '7.1.7'
   spec.compiler_flags = '-DFOLLY_HAVE_BACKTRACE=1 -DFOLLY_HAVE_CLOCK_GETTIME=1 -DFOLLY_HAVE_PTHREAD=1 -DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_HAVE_LIBGFLAGS=0 -DFOLLY_HAVE_LIBJEMALLOC=0 -DFOLLY_HAVE_PREADV=0 -DFOLLY_HAVE_PWRITEV=0 -DFOLLY_HAVE_TFO=0


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

OpenSSL-Univeral cause app to crash with `@rpath/OpenSSL.framework/OpenSSL' not found` when [debugger is not attached] (https://github.com/krzyzanowskim/OpenSSL/issues/115). Looks like this was caused by arm64e slice and it's now resolved in version 1.1.1000 

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. This should just be a brief oneline we can mention in our release notes: https://github.com/facebook/flipper/releases -->

Bump OpenSSL-Universal to version 1.1.1000 

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI / output of the test runner and how you invoked it. -->

There are no code changes, this only removes problematic arm64 slice from OpenSSL-Universal xcframework.