### PR TITLE
Removed bolts-applinks dependency not in use

### DIFF
--- a/android/plugins/fresco/build.gradle
+++ b/android/plugins/fresco/build.gradle
@@ -23,7 +23,6 @@ android {
         compileOnly deps.jsr305
 
         api deps.boltsTasks
-        api deps.boltsApplinks
 
         // Exclude the actual stetho dep as we only want some of the fresco APIs here
         implementation(deps.frescoStetho) {

--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,6 @@ ext.deps = [
         fbjni              : 'com.facebook.fbjni:fbjni:0.2.2',
         screenshot         : 'com.facebook.testing.screenshot:core:0.14.0',
         boltsTasks         : 'com.parse.bolts:bolts-tasks:1.4.0',
-        boltsApplinks      : 'com.parse.bolts:bolts-applinks:1.4.0',
         // Annotations
         jsr305             : 'com.google.code.findbugs:jsr305:3.0.2',
         inferAnnotations   : 'com.facebook.infer.annotation:infer-annotation:0.18.0',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

As explained in this [Issue](https://github.com/facebook/flipper/issues/1919) when running checks to see if Jetifier is needed to compile any given app using Flipper, it complain due to the dependency on `com.parse.bolts:bolts-applinks:1.4.0`.

```
Scanning com.parse.bolts:bolts-applinks:1.4.0
 Absoulute path: /....../bolts-applinks-1.4.0.jar
 Graphs to this dependency:
 +---com.facebook.flipper:flipper:0.74.0
     +---com.parse.bolts:bolts-applinks:1.4.0

> Task :canISayByeByeJetifier FAILED
```

Bolts has already fixed the AndroidX migration in version `1.5.0` but it has never been published ([Issue](https://github.com/BoltsFramework/Bolts-Android/issues/157))

After checking the code i realized flipper is only using `bolts-tasks` in `FrescoFlipperPlugin` ([code](https://github.com/facebook/flipper/blob/7bd4f80c2570bebb52af3cf49e45fc6130d6a473/android/plugins/fresco/src/main/java/com/facebook/flipper/plugins/fresco/FrescoFlipperPlugin.java#L14)).

`bolts-applinks` depends on `bolts-tasks` but **not the other way around**, so we can safely remove this dependency.

## Changelog

- Removed dependency on bolts-applinks not in use

## Test Plan

### Tests
- [ ] Run unit tests `./gradlew :android:test` and make sure they pass

### Smoke test `fresco-plugin`
- [ ] Make sure `android/sample` compiles and runs
- In the Flipper desktop app enable `Images` plugin
- In the Android sample app tap on `Load Fresco Image`
- [ ] Verify in desktop app that the image shows correctly and the plugin works

