### PR TITLE
Revert "Improve protobuf support (#2513)"

### DIFF
--- a/android/plugins/retrofit2-protobuf/build.gradle
+++ b/android/plugins/retrofit2-protobuf/build.gradle
@@ -25,7 +25,7 @@ android {
         implementation project(':network-plugin')
         implementation deps.protobuf
         implementation "com.squareup.retrofit2:retrofit:2.9.0"
-        implementation "com.github.hbmartin:protobuf_java_to_protobufjs:0.2.0"
+        implementation "com.github.hbmartin:protobuf_java_to_protobufjs:0.1.0"
         compileOnly deps.jsr305
     }
 }

--- a/desktop/plugins/public/network/ProtobufDefinitionsRepository.tsx
+++ b/desktop/plugins/public/network/ProtobufDefinitionsRepository.tsx
@@ -63,10 +63,6 @@ export class ProtobufDefinitionsRepository {
     }
   }
 
-  public hasDefinition(method: string, path: string): boolean {
-    return this.rawDefinitions.hasOwnProperty(this.key(method, path));
-  }
-
   private generateRoots(key: string) {
     if (key in this.cachedDecodedDefinitions) {
       return;

--- a/desktop/plugins/public/network/RequestDetails.tsx
+++ b/desktop/plugins/public/network/RequestDetails.tsx
@@ -670,11 +670,7 @@ class ProtobufFormatter {
   formatRequest(request: Request) {
     if (
       getHeaderValue(request.requestHeaders, 'content-type') ===
-        'application/x-protobuf' ||
-      this.protobufDefinitionRepository.hasDefinition(
-        request.method,
-        request.url,
-      )
+      'application/x-protobuf'
     ) {
       const protobufDefinition =
         this.protobufDefinitionRepository.getRequestType(
@@ -685,9 +681,7 @@ class ProtobufFormatter {
         return (
           <Text>
             Could not locate protobuf definition for request body of{' '}
-            {request.url} <br />
-            Please send ProtobufJS definitions with the plugin's
-            addProtobufDefinitions method.
+            {request.url}
           </Text>
         );
       }
@@ -710,11 +704,7 @@ class ProtobufFormatter {
     if (
       getHeaderValue(request.responseHeaders, 'content-type') ===
         'application/x-protobuf' ||
-      request.url.endsWith('.proto') ||
-      this.protobufDefinitionRepository.hasDefinition(
-        request.method,
-        request.url,
-      )
+      request.url.endsWith('.proto')
     ) {
       const protobufDefinition =
         this.protobufDefinitionRepository.getResponseType(
@@ -725,9 +715,7 @@ class ProtobufFormatter {
         return (
           <Text>
             Could not locate protobuf definition for response body of{' '}
-            {request.url} <br />
-            Please send ProtobufJS definitions with the plugin's
-            addProtobufDefinitions method.
+            {request.url}
           </Text>
         );
       }


### PR DESCRIPTION
## Summary

This reverts commit efd75ea4357c32eba1376a44d1e3587532445d36.

Sorry @hbmartin! We're running into Kotlin compatibility problems. Your latest library release isn't compatible with Kotlin 1.3 and we can't upgrade just yet because Litho hasn't been able to release in a while. :(

## Test Plan

_eyes
