### PR TITLE
Make CertificateProvider side effect free in test

### DIFF
--- a/desktop/app/src/server/comms/ServerController.tsx
+++ b/desktop/app/src/server/comms/ServerController.tsx
@@ -35,6 +35,7 @@ import ServerAdapter, {
 } from './ServerAdapter';
 import {createBrowserServer, createServer} from './ServerFactory';
 import {FlipperServer} from '../FlipperServer';
+import {isTest} from '../../utils/isProduction';
 
 type ClientInfo = {
   connection: ClientConnection | null | undefined;
@@ -109,6 +110,9 @@ class ServerController extends EventEmitter implements ServerEventsListener {
    * which point Flipper is accepting connections.
    */
   init() {
+    if (isTest()) {
+      throw new Error('Spawing new server is not supported in test');
+    }
     const {insecure, secure} = this.store.getState().application.serverPorts;
     this.initialized = this.certificateProvider
       .loadSecureServerConfig()


### PR DESCRIPTION
Summary:
Creating a CertificateProvider in test had the side effect of generating certificate files, which fails in windows CI. This change makes sure the files aren't generated in test. See https://github.com/facebook/flipper/runs/3366318523.

Since it is not possible to start the flipper server 'physically' without writing file (for the secure server), figured to remove the test entirely, since there is high impact but little risk captured by it; if the server doesn't start, *any* manual / exploratory test will fail.

Differential Revision: D30423173

