### PR TITLE
Add option for automatic dark theme

### DIFF
--- a/desktop/app/src/chrome/SettingsSheet.tsx
+++ b/desktop/app/src/chrome/SettingsSheet.tsx
@@ -260,7 +260,7 @@ class SettingsSheet extends Component<Props, State> {
             }}>
             <Radio.Button value="dark">Dark</Radio.Button>
             <Radio.Button value="light">Light</Radio.Button>
-            <Radio.Button value="auto">Use System Seeting</Radio.Button>
+            <Radio.Button value="system">Use System Setting</Radio.Button>
           </Radio.Group>
         </FlexColumn>
         <ToggledSection

--- a/desktop/app/src/chrome/SettingsSheet.tsx
+++ b/desktop/app/src/chrome/SettingsSheet.tsx
@@ -246,19 +246,18 @@ class SettingsSheet extends Component<Props, State> {
             }));
           }}
         />
-        <FlexColumn style={{paddingLeft: 15,
-            paddingBottom: 10,}}>
-            Theme Selection
-          <Radio.Group 
+        <FlexColumn style={{paddingLeft: 15, paddingBottom: 10}}>
+          Theme Selection
+          <Radio.Group
             value={darkMode}
             onChange={(event) => {
-            this.setState((prevState) => ({
-              updatedSettings: {
-                ...prevState.updatedSettings,
-                darkMode: event.target.value,
-              },
-            }));
-          }}>
+              this.setState((prevState) => ({
+                updatedSettings: {
+                  ...prevState.updatedSettings,
+                  darkMode: event.target.value,
+                },
+              }));
+            }}>
             <Radio.Button value="dark">Dark</Radio.Button>
             <Radio.Button value="light">Light</Radio.Button>
             <Radio.Button value="auto">Use System Default</Radio.Button>

--- a/desktop/app/src/chrome/SettingsSheet.tsx
+++ b/desktop/app/src/chrome/SettingsSheet.tsx
@@ -260,7 +260,7 @@ class SettingsSheet extends Component<Props, State> {
             }}>
             <Radio.Button value="dark">Dark</Radio.Button>
             <Radio.Button value="light">Light</Radio.Button>
-            <Radio.Button value="auto">Use System Default</Radio.Button>
+            <Radio.Button value="auto">Use System Seeting</Radio.Button>
           </Radio.Group>
         </FlexColumn>
         <ToggledSection

--- a/desktop/app/src/chrome/SettingsSheet.tsx
+++ b/desktop/app/src/chrome/SettingsSheet.tsx
@@ -9,6 +9,7 @@
 
 import {FlexColumn, Button} from '../ui';
 import React, {Component, useContext} from 'react';
+import {Radio} from 'antd';
 import {updateSettings, Action} from '../reducers/settings';
 import {
   Action as LauncherAction,
@@ -245,18 +246,24 @@ class SettingsSheet extends Component<Props, State> {
             }));
           }}
         />
-        <ToggledSection
-          label="Enable dark theme"
-          toggled={darkMode}
-          onChange={(enabled) => {
+        <FlexColumn style={{paddingLeft: 15,
+            paddingBottom: 10,}}>
+            Theme Selection
+          <Radio.Group 
+            value={darkMode}
+            onChange={(event) => {
             this.setState((prevState) => ({
               updatedSettings: {
                 ...prevState.updatedSettings,
-                darkMode: enabled,
+                darkMode: event.target.value,
               },
             }));
-          }}
-        />
+          }}>
+            <Radio.Button value="dark">Dark</Radio.Button>
+            <Radio.Button value="light">Light</Radio.Button>
+            <Radio.Button value="auto">Use System Default</Radio.Button>
+          </Radio.Group>
+        </FlexColumn>
         <ToggledSection
           label="React Native keyboard shortcuts"
           toggled={reactNative.shortcuts.enabled}

--- a/desktop/app/src/init.tsx
+++ b/desktop/app/src/init.tsx
@@ -225,7 +225,7 @@ function init() {
       }
       return {
         shouldUseDarkMode: shouldUseDarkMode,
-        theme: theme
+        theme: theme,
       };
     },
     (result) => {

--- a/desktop/app/src/init.tsx
+++ b/desktop/app/src/init.tsx
@@ -49,7 +49,7 @@ import styled from '@emotion/styled';
 import {CopyOutlined} from '@ant-design/icons';
 import {getVersionString} from './utils/versionString';
 import {PersistGate} from 'redux-persist/integration/react';
-import {ipcRenderer} from 'electron';
+import {ipcRenderer, remote} from 'electron';
 
 if (process.env.NODE_ENV === 'development' && os.platform() === 'darwin') {
   // By default Node.JS has its internal certificate storage and doesn't use
@@ -213,9 +213,20 @@ function init() {
   sideEffect(
     store,
     {name: 'loadTheme', fireImmediately: false, throttleMs: 500},
-    (state) => ({
-      dark: state.settingsState.darkMode,
-    }),
+    (state) => {
+      const darkMode = state.settingsState.darkMode;
+      let shouldUseDarkMode = remote.systemPreferences.isDarkMode();
+      if (darkMode === 'dark') {
+        shouldUseDarkMode = true;
+      } else if (darkMode === 'light') {
+        shouldUseDarkMode =  false;
+      } else if (darkMode === 'auto') {
+        shouldUseDarkMode = remote.systemPreferences.isDarkMode();
+      }
+      return {
+        dark: shouldUseDarkMode
+      }
+    },
     (theme) => {
       (
         document.getElementById('flipper-theme-import') as HTMLLinkElement

--- a/desktop/app/src/init.tsx
+++ b/desktop/app/src/init.tsx
@@ -219,13 +219,13 @@ function init() {
       if (darkMode === 'dark') {
         shouldUseDarkMode = true;
       } else if (darkMode === 'light') {
-        shouldUseDarkMode =  false;
+        shouldUseDarkMode = false;
       } else if (darkMode === 'auto') {
         shouldUseDarkMode = remote.systemPreferences.isDarkMode();
       }
       return {
-        dark: shouldUseDarkMode
-      }
+        dark: shouldUseDarkMode,
+      };
     },
     (theme) => {
       (

--- a/desktop/app/src/init.tsx
+++ b/desktop/app/src/init.tsx
@@ -214,24 +214,25 @@ function init() {
     store,
     {name: 'loadTheme', fireImmediately: false, throttleMs: 500},
     (state) => {
-      const darkMode = state.settingsState.darkMode;
-      let shouldUseDarkMode = remote.systemPreferences.isDarkMode();
-      if (darkMode === 'dark') {
+      const theme = state.settingsState.darkMode;
+      let shouldUseDarkMode = remote.nativeTheme.shouldUseDarkColors;
+      if (theme === 'dark') {
         shouldUseDarkMode = true;
-      } else if (darkMode === 'light') {
+      } else if (theme === 'light') {
         shouldUseDarkMode = false;
-      } else if (darkMode === 'auto') {
-        shouldUseDarkMode = remote.systemPreferences.isDarkMode();
+      } else if (theme === 'system') {
+        shouldUseDarkMode = remote.nativeTheme.shouldUseDarkColors;
       }
       return {
-        dark: shouldUseDarkMode,
+        shouldUseDarkMode: shouldUseDarkMode,
+        theme: theme
       };
     },
-    (theme) => {
+    (result) => {
       (
         document.getElementById('flipper-theme-import') as HTMLLinkElement
-      ).href = `themes/${theme.dark ? 'dark' : 'light'}.css`;
-      ipcRenderer.send('setTheme', theme.dark ? 'dark' : 'light');
+      ).href = `themes/${result.shouldUseDarkMode ? 'dark' : 'light'}.css`;
+      ipcRenderer.send('setTheme', result.theme);
     },
   );
 }

--- a/desktop/app/src/reducers/settings.tsx
+++ b/desktop/app/src/reducers/settings.tsx
@@ -43,7 +43,7 @@ export type Settings = {
       openDevMenu: string;
     };
   };
-  darkMode: boolean;
+  darkMode: string;
   showWelcomeAtStartup: boolean;
   suppressPluginErrors: boolean;
 };
@@ -78,7 +78,7 @@ const initialState: Settings = {
       openDevMenu: 'Alt+Shift+D',
     },
   },
-  darkMode: false,
+  darkMode: 'auto',
   showWelcomeAtStartup: true,
   suppressPluginErrors: false,
 };

--- a/desktop/app/src/utils/useIsDarkMode.tsx
+++ b/desktop/app/src/utils/useIsDarkMode.tsx
@@ -10,6 +10,10 @@
 import {useStore} from './useStore';
 import {remote} from 'electron';
 
+remote.nativeTheme.on('updated', (theme: any) =>{
+  
+});
+
 /**
  * This hook returns whether dark mode is currently being used.
  * Generally should be avoided in favor of using the above theme object,
@@ -22,7 +26,7 @@ export function useIsDarkMode(): boolean {
       return true;
     } else if (darkMode === 'light') {
       return false;
-    } else if (darkMode === 'auto') {
+    } else if (darkMode === 'system') {
       return remote.nativeTheme.shouldUseDarkColors;
     }
     return remote.nativeTheme.shouldUseDarkColors;

--- a/desktop/app/src/utils/useIsDarkMode.tsx
+++ b/desktop/app/src/utils/useIsDarkMode.tsx
@@ -8,6 +8,7 @@
  */
 
 import {useStore} from './useStore';
+import {remote} from 'electron';
 
 /**
  * This hook returns whether dark mode is currently being used.
@@ -15,5 +16,15 @@ import {useStore} from './useStore';
  * which will provide colors that reflect the theme
  */
 export function useIsDarkMode(): boolean {
-  return useStore((state) => state.settingsState.darkMode);
+  return useStore((state) => {
+    const darkMode = state.settingsState.darkMode;
+    if (darkMode === 'dark') {
+      return true;
+    } else if (darkMode === 'light') {
+      return false;
+    } else if (darkMode === 'auto') {
+      return remote.systemPreferences.isDarkMode();
+    }
+    return remote.systemPreferences.isDarkMode();
+  });
 }

--- a/desktop/app/src/utils/useIsDarkMode.tsx
+++ b/desktop/app/src/utils/useIsDarkMode.tsx
@@ -10,10 +10,6 @@
 import {useStore} from './useStore';
 import {remote} from 'electron';
 
-remote.nativeTheme.on('updated', (theme: any) =>{
-  
-});
-
 /**
  * This hook returns whether dark mode is currently being used.
  * Generally should be avoided in favor of using the above theme object,
@@ -29,6 +25,6 @@ export function useIsDarkMode(): boolean {
     } else if (darkMode === 'system') {
       return remote.nativeTheme.shouldUseDarkColors;
     }
-    return remote.nativeTheme.shouldUseDarkColors;
+    return false;
   });
 }

--- a/desktop/app/src/utils/useIsDarkMode.tsx
+++ b/desktop/app/src/utils/useIsDarkMode.tsx
@@ -23,8 +23,8 @@ export function useIsDarkMode(): boolean {
     } else if (darkMode === 'light') {
       return false;
     } else if (darkMode === 'auto') {
-      return remote.systemPreferences.isDarkMode();
+      return remote.nativeTheme.shouldUseDarkColors;
     }
-    return remote.systemPreferences.isDarkMode();
+    return remote.nativeTheme.shouldUseDarkColors;
   });
 }

--- a/desktop/static/main.ts
+++ b/desktop/static/main.ts
@@ -109,9 +109,7 @@ if (argv['disable-gpu'] || process.env.FLIPPER_DISABLE_GPU === '1') {
 }
 
 process.env.CONFIG = JSON.stringify(config);
-if (config.darkMode) {
-  nativeTheme.themeSource = 'dark';
-}
+nativeTheme.themeSource = config.darkMode || 'light';
 
 // possible reference to main app window
 let win: BrowserWindow;
@@ -290,7 +288,7 @@ ipcMain.on('getLaunchTime', (event) => {
   }
 });
 
-ipcMain.on('setTheme', (_e, mode: 'light' | 'dark') => {
+ipcMain.on('setTheme', (_e, mode: 'light' | 'dark' | 'system') => {
   nativeTheme.themeSource = mode;
 });
 
@@ -382,7 +380,7 @@ function createWindow() {
       configPath,
       JSON.stringify({
         ...config,
-        darkMode: nativeTheme.themeSource === 'dark',
+        darkMode: nativeTheme.themeSource,
         lastWindowPosition: {
           x,
           y,

--- a/desktop/static/setup.ts
+++ b/desktop/static/setup.ts
@@ -24,7 +24,7 @@ export type Config = {
   launcherMsg?: string | undefined;
   updaterEnabled?: boolean;
   launcherEnabled?: boolean;
-  darkMode: ('system' | 'light' | 'dark');
+  darkMode: 'system' | 'light' | 'dark';
 };
 
 export default function setup(argv: any) {
@@ -38,7 +38,7 @@ export default function setup(argv: any) {
   let config: Config = {
     pluginPaths: [],
     disabledPlugins: [],
-    darkMode: 'light'
+    darkMode: 'light',
   };
 
   try {

--- a/desktop/static/setup.ts
+++ b/desktop/static/setup.ts
@@ -24,7 +24,7 @@ export type Config = {
   launcherMsg?: string | undefined;
   updaterEnabled?: boolean;
   launcherEnabled?: boolean;
-  darkMode?: boolean;
+  darkMode: ('system' | 'light' | 'dark');
 };
 
 export default function setup(argv: any) {
@@ -38,6 +38,7 @@ export default function setup(argv: any) {
   let config: Config = {
     pluginPaths: [],
     disabledPlugins: [],
+    darkMode: 'light'
   };
 
   try {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Add an setting option to allow automatic dark theme

A feature requested by @swrobel https://github.com/facebook/flipper/issues/2708

## Changelog

### UI change
Replace the `Enable Dark Theme` Toggle button with a Radio group containing three Radio buttons. 

The available options are `Dark`, `Light` and `Use System Default`, of which `Use System Default` is the default value

<img width="548" alt="Screenshot 2021-08-31 at 3 32 44 PM" src="https://user-images.githubusercontent.com/410850/131462798-4e74f757-41fc-4a3f-ba28-53d00fc1cf03.png">

### Data structure change

The `darkMode` property of [Settings](https://github.com/facebook/flipper/blob/c0cd32564ad4b07a42365af886045095877a6a6b/desktop/app/src/reducers/settings.tsx#L20) is changed from `boolean` to `string`, the available values are `dark`, `light` and `auto`

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI / output of the test runner and how you invoked it. -->

### Test 1
- Step: Choose `Dark` in the Settings page and click on `Apply and Restart` button
- Expect: The application is displayed in Dark mode
### Test 2
- Step: Choose `Light` in the Settings page and click on `Apply and Restart` button
- Expect: The application is displayed in Light mode
### Test 3
- Step: Choose `Use System Default` in the Settings page and click on `Apply and Restart` button
- Expect: The application is displayed in System Default mode
