### PR TITLE
[pkg] Revert globby upgrade

### DIFF
--- a/desktop/pkg/package.json
+++ b/desktop/pkg/package.json
@@ -34,7 +34,7 @@
     "@types/jest": "^26.0.24",
     "@types/node": "^15.12.5",
     "flipper-test-utils": "0.0.0",
-    "globby": "^12.0.2",
+    "globby": "^11.0.0",
     "jest": "^26.6.3",
     "prettier": "^2.3.2",
     "rimraf": "^3.0.2",

--- a/desktop/yarn.lock
+++ b/desktop/yarn.lock
@@ -7062,6 +7062,18 @@ globby@^10.0.1:
     merge2 "^1.2.3"
     slash "^3.0.0"
 
+globby@^11.0.0:
+  version "11.0.4"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.4.tgz#2cbaff77c2f2a62e71e9b2813a67b97a3a3001a5"
+  integrity sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==
+  dependencies:
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.1.1"
+    ignore "^5.1.4"
+    merge2 "^1.3.0"
+    slash "^3.0.0"
+
 globby@^11.0.1, globby@^11.0.3:
   version "11.0.3"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.3.tgz#9b1f0cb523e171dd1ad8c7b2a9fb4b644b9593cb"


### PR DESCRIPTION
Summary:
Fixes https://github.com/facebook/flipper/issues/2710

Test Plan
cd pkg; yarn && yarn run run help

No longer shows ESM error.