### PR TITLE
[actions] Create issue on publish failure

### DIFF
--- a/.github/action-failure-template.md
+++ b/.github/action-failure-template.md
@@ -1,9 +1,9 @@
 ---
-title: GitHub Actions Workflow failed - {{ tools.context.workflow }}
+title: GitHub Actions Workflow failed - {{ env.WORKFLOW_NAME }}
 assignees: passy
 labels: bug
 ---
 
-The workflow {{ tools.context.workflow }} failed. You can see it at
+The workflow {{ env.WORKFLOW_NAME }} failed. You can see it at
 
 https://github.com/{{ env.REPOSITORY }}/actions/runs/{{ env.RUN_ID }}

--- a/.github/action-failure-template.md
+++ b/.github/action-failure-template.md
@@ -1,0 +1,9 @@
+---
+title: GitHub Actions Workflow failed - {{ tools.context.workflow }}
+assignees: passy
+labels: bug
+---
+
+The workflow {{ tools.context.workflow }} failed. You can see it at
+
+https://github.com/{{ env.REPOSITORY }}/actions/runs/{{ env.RUN_ID }}

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -24,6 +24,8 @@ jobs:
         java-version: 1.8
     - name: Write GPG Sec Ring
       run: echo '${{ secrets.GPG_KEY_CONTENTS }}' | base64 -d > /tmp/secring.gpg
+    - name: FAIL
+      run: exit 1
     - name: Update gradle.properties
       run: echo -e "signing.secretKeyRingFile=/tmp/secring.gpg\nsigning.keyId=${{ secrets.SIGNING_KEY_ID }}\nsigning.password=${{ secrets.SIGNING_PASSWORD }}\nmavenCentralPassword=${{ secrets.SONATYPE_NEXUS_PASSWORD }}\nmavenCentralUsername=${{ secrets.SONATYPE_NEXUS_USERNAME }}" >> gradle.properties
     - name: Compute build cache
@@ -54,3 +56,12 @@ jobs:
       with:
         created_tag: ${{ github.event.inputs.tag }}
         args: 'SampleApp-android.apk'
+    - name: Open issue on failure
+      if: failure()
+      uses: JasonEtco/create-an-issue@v2.4.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPOSITORY: ${{ github.repository }}
+        RUN_ID: ${{ github.run_id }}
+      with:
+        filename: .github/action-failure-template.md

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -61,5 +61,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         REPOSITORY: ${{ github.repository }}
         RUN_ID: ${{ github.run_id }}
+        WORKFLOW_NAME: "Publish Android"
       with:
         filename: .github/action-failure-template.md

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -24,8 +24,6 @@ jobs:
         java-version: 1.8
     - name: Write GPG Sec Ring
       run: echo '${{ secrets.GPG_KEY_CONTENTS }}' | base64 -d > /tmp/secring.gpg
-    - name: FAIL
-      run: exit 1
     - name: Update gradle.properties
       run: echo -e "signing.secretKeyRingFile=/tmp/secring.gpg\nsigning.keyId=${{ secrets.SIGNING_KEY_ID }}\nsigning.password=${{ secrets.SIGNING_PASSWORD }}\nmavenCentralPassword=${{ secrets.SONATYPE_NEXUS_PASSWORD }}\nmavenCentralUsername=${{ secrets.SONATYPE_NEXUS_USERNAME }}" >> gradle.properties
     - name: Compute build cache

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: set up JDK 1.8
       uses: actions/setup-java@v1
       with:


### PR DESCRIPTION
## Summary

Because the publish runs aren't triggered on the main branch, we have limited visibility. Sending push notifications, webhooks or email integrations are hard, but opening an issue seems like a decent work-around for this.

We can broaden this to more publish actions as needed.

## Test Plan

Ran on my fork which generated this issue: https://github.com/passy/flipper/issues/9
