### PR TITLE
Display AccessibilityNodeInfoCompat.isScreenReaderFocusable() property (fixes #1756)

### DIFF
--- a/android/src/main/java/com/facebook/flipper/plugins/inspector/descriptors/utils/AccessibilityUtil.java
+++ b/android/src/main/java/com/facebook/flipper/plugins/inspector/descriptors/utils/AccessibilityUtil.java
@@ -603,6 +603,7 @@ public final class AccessibilityUtil {
         .put("long-clickable", nodeInfo.isLongClickable())
         .put("multiline", nodeInfo.isMultiLine())
         .put("password", nodeInfo.isPassword())
+        .put("screenreader-focusable", nodeInfo.isScreenReaderFocusable())
         .put("scrollable", nodeInfo.isScrollable())
         .put("selected", nodeInfo.isSelected())
         .put("text", nodeInfo.getText())


### PR DESCRIPTION
Add screenreader-focusable property to AccessibilityUtil#getAccessibilityNodeInfoData

## Summary
The accessibility hierarchy displays various AccessibilityNodeInfo properties. However, it was missing the screenreader-focusable property.

## Changelog
Display screenreader-focusable property in the accessibility hierarchy.

## Test Plan

Test suite passes and code lints.

