### PR TITLE
Fix the layout of LeakCanary plugin

### DIFF
--- a/desktop/flipper-plugin/src/ui/Layout.tsx
+++ b/desktop/flipper-plugin/src/ui/Layout.tsx
@@ -94,7 +94,6 @@ const Horizontal = styled(Container)({
 });
 
 const ScrollParent = styled.div<{axis?: ScrollAxis}>(({axis}) => ({
-  flex: `1 1 0`,
   boxSizing: 'border-box',
   position: 'relative',
   overflowX: axis === 'y' ? 'hidden' : 'auto',
@@ -102,7 +101,6 @@ const ScrollParent = styled.div<{axis?: ScrollAxis}>(({axis}) => ({
 }));
 
 const ScrollChild = styled(Container)<{axis?: ScrollAxis}>(({axis}) => ({
-  position: 'absolute',
   minHeight: '100%',
   minWidth: '100%',
   maxWidth: axis === 'y' ? '100%' : undefined,


### PR DESCRIPTION
## Summary

Since v0.86, the LeakCanary plugin cannot layout the detail info anymore as describe in this ticket #2373 

## Changelog

- (#2373 Fix the layout issue of LeakCanary plugin

## Test Plan

- Enable LeakCanary
- Reproduce a leak on the app
- Observe that detail info of Leak Canary plugin appear in Flipper client


