### PR TITLE
Corrected Unreachable Plugins Dir Path

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ This repository includes all parts of Flipper. This includes:
 * native Flipper SDKs for iOS (`/iOS`)
 * native Flipper SDKs for Android (`/android`)
 * Plugins:
-  * Logs (`/desktop/src/device-plugins/logs`)
-  * Layout inspector (`/desktop/plugins/layout`)
-  * Network inspector (`/desktop/plugins/network`)
-  * Shared Preferences/NSUserDefaults inspector (`/desktop/plugins/shared_preferences`)
+  * Logs (`/desktop/plugins/public/logs`)
+  * Layout inspector (`/desktop/plugins/public/layout`)
+  * Network inspector (`/desktop/plugins/public/network`)
+  * Shared Preferences/NSUserDefaults inspector (`/desktop/plugins/public/shared_preferences`)
 * website and documentation (`/website` / `/docs`)
 
 # Getting started


### PR DESCRIPTION
## Summary
**All the 4 plugins paths are unreachable/changed in [in-this-repo](https://github.com/facebook/flipper#in-this-repo) section in README file. I have updated them with the correct paths.**

- **Before Changes**

![1](https://user-images.githubusercontent.com/51878265/136379185-8325343b-29f4-444e-8a1a-f13bc6900312.png)

- **After Changes**
 
![2](https://user-images.githubusercontent.com/51878265/136379474-db506b65-7505-42cb-bdad-1d7e545c53e9.png)