### PR TITLE
Fix Date Label In Crashes Plugin

### DIFF
--- a/desktop/plugins/public/crash_reporter/index.tsx
+++ b/desktop/plugins/public/crash_reporter/index.tsx
@@ -47,7 +47,7 @@ export function devicePlugin(client: DevicePluginClient) {
       callstack: payload.callstack,
       name: payload.name,
       reason: payload.reason,
-      date: payload.date ?? Date.now(),
+      date: payload.date || Date.now(),
     };
 
     crashes.update((draft) => {


### PR DESCRIPTION
## Summary

The date type for crash reports was updated in aff02b2ca12b94e1a63dfcf9b8a516f5554e8c11 from `Date` to `number`. Unset values were previously `null` but became `NaN` in this change. `NaN` is nonnull so the backup value of `Date.now()` was not getting triggered properly and leading to "Invalid Date" to show up in the UI.


## Changelog

Fixed date label for crashes in Crash Reporter Plugin.

## Test Plan

### Before

![Screen Shot 2021-10-15 at 2 20 40 PM](https://user-images.githubusercontent.com/11892859/137557635-3ede030c-99c4-4172-a802-39f8016adf21.png)

### After
![Screen Shot 2021-10-15 at 2 20 18 PM](https://user-images.githubusercontent.com/11892859/137557637-a54019de-4c0a-40d3-8cb1-e2d60b2d2a66.png)

