### PR TITLE
Fix async filtering

### DIFF
--- a/desktop/plugin-lib/src/pluginPaths.ts
+++ b/desktop/plugin-lib/src/pluginPaths.ts
@@ -10,6 +10,7 @@
 import path from 'path';
 import {homedir} from 'os';
 import fs from 'fs-extra';
+import pFilter from 'p-filter';
 import expandTilde from 'expand-tilde';
 
 const flipperDataDir = path.join(homedir(), '.flipper');
@@ -43,7 +44,7 @@ export async function getPluginSourceFolders(): Promise<string[]> {
   }
   pluginFolders.push(path.resolve(__dirname, '..', '..', 'plugins', 'public'));
   pluginFolders.push(path.resolve(__dirname, '..', '..', 'plugins', 'fb'));
-  return pluginFolders.map(expandTilde).filter(async (f) => fs.pathExists(f));
+  return pFilter(pluginFolders.map(expandTilde), (p) => fs.pathExists(p));
 }
 
 export function getPluginInstallationDir(name: string) {

--- a/desktop/scripts/get-app-watch-folders.ts
+++ b/desktop/scripts/get-app-watch-folders.ts
@@ -8,6 +8,7 @@
  */
 
 import fs from 'fs-extra';
+import pFilter from 'p-filter';
 import path from 'path';
 import {getWatchFolders} from 'flipper-pkg-lib';
 import {appDir, publicPluginsDir, fbPluginsDir} from './paths';
@@ -29,7 +30,8 @@ export default async function getAppWatchFolders() {
     ),
   );
   const watchFolders = ([] as string[]).concat(...getWatchFoldersResults);
-  return watchFolders
-    .filter((value, index, self) => self.indexOf(value) === index)
-    .filter(async (f) => fs.pathExists(f));
+  return pFilter(
+    watchFolders.filter((value, index, self) => self.indexOf(value) === index),
+    (f) => fs.pathExists(f),
+  );
 }


### PR DESCRIPTION
Summary:
I relied too much on the types which in this case don't help at all.
Filtering on a promise will just automatically get all values to pass.

Test Plan:
`yarn build --mac` works again on the GH checkout.