### PR TITLE
Updating splitting of avd names to work on Windows and Unix based sys…

### DIFF
--- a/desktop/flipper-server-core/src/devices/android/androidDeviceManager.tsx
+++ b/desktop/flipper-server-core/src/devices/android/androidDeviceManager.tsx
@@ -149,7 +149,7 @@ export class AndroidDeviceManager {
             return;
           }
           const devices = data
-            .split('\n')
+            .split(/\r?\n/)
             .filter(notNull)
             .filter((l) => l !== '');
           resolve(devices);


### PR DESCRIPTION
…tems

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

When trying to start an android emulator in Windows, there is a failure in trying to read `<avd name>.ini`. The reason for this is because when we run `<android sdk path>\tools\emulator.exe -list-avds`, a split is performed with the new line character (`\n`). Unfortunately, this does not work for Windows, which uses `\r\n` as the new line termination. This results in a carriage return remaining on each output string, which results in trying to access `<avd name> .ini`, which is an invalid path.

The fix is to update the split to use a regex that is compatible for both Unix and Windows based systems.

## Changelog

Updating splitting of avd names to work on Windows and Unix based systems

## Test Plan

Verified the avd names didn't have any trailing whitespace, and the emulator is able to launch.

