### PR TITLE
Update emulator path to emulator directory instead of deprecated tool…

### DIFF
--- a/desktop/flipper-server-core/src/devices/android/AndroidDevice.tsx
+++ b/desktop/flipper-server-core/src/devices/android/AndroidDevice.tsx
@@ -283,7 +283,7 @@ export async function launchEmulator(name: string, coldBoot: boolean = false) {
     .catch(() =>
       join(
         process.env.ANDROID_HOME || process.env.ANDROID_SDK_ROOT || '',
-        'tools',
+        'emulator',
         'emulator',
       ),
     )

--- a/desktop/flipper-server-core/src/devices/android/androidDeviceManager.tsx
+++ b/desktop/flipper-server-core/src/devices/android/androidDeviceManager.tsx
@@ -129,7 +129,7 @@ export class AndroidDeviceManager {
     } catch (_e) {
       this.emulatorPath = join(
         process.env.ANDROID_HOME || process.env.ANDROID_SDK_ROOT || '',
-        'tools',
+        'emulator',
         'emulator',
       );
     }


### PR DESCRIPTION
…s directory

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Currently, flipper tries to launch emulators using  `<android sdk path>\tools\emulator.exe`. The use of this emulator path has been deprecated for a while now, and remains in the sdk for those on versions of Android Studio 2.2 and older (see https://issuetracker.google.com/issues/66886035?pli=1). The supported path is `<android sdk path>\emulator\emulator.exe`. Trying to use the deprecated path on Windows results in a failure to launch AVDs.

## Changelog

Point emulator path to emulator directory instead of deprecated tools directory.

## Test Plan

Verified a failure to launch the AVD on windows using the deprecated path. Confirmed that updating the path results in a successful launch and the device showing up in flipper.