### PR TITLE
Fix dark diff background colors

### DIFF
--- a/desktop/flipper-plugin/src/ui/theme.tsx
+++ b/desktop/flipper-plugin/src/ui/theme.tsx
@@ -57,8 +57,8 @@ export const theme = {
     colorValue: antColors.cyan[5],
     booleanValue: antColors.magenta[5],
     numberValue: antColors.blue[5],
-    diffAddedBackground: antColors.lime[1],
-    diffRemovedBackground: antColors.volcano[1],
+    diffAddedBackground: 'var(--flipper-diff-added-background)',
+    diffRemovedBackground: 'var(--flipper-diff-removed-background)',
   },
 } as const;
 

--- a/desktop/themes/base.less
+++ b/desktop/themes/base.less
@@ -55,5 +55,7 @@
   --flipper-button-default-background: @button-default-background;
   --flipper-background-transparent-hover: @background-transparent-hover;
   --flipper-divider-color: @divider-color;
+  --flipper-diff-added-background: @diff-added-background;
+  --flipper-diff-removed-background: @diff-removed-background;
   --flipper-border-radius: @border-radius-base;
 }

--- a/desktop/themes/dark.less
+++ b/desktop/themes/dark.less
@@ -47,6 +47,21 @@
 // Divider color
 @divider-color: #181818; // white 10%
 
+// Semantic colors: Diff
+@diff-added-background: @lime-1;
+@diff-removed-background: @volcano-1;
+
+// @l1: #1f2611;
+// @v1: #2b1611;
+
+// 
+// @l2:  #2e3c10;
+// @v2: #441d12;
+
+// still no
+// @l3: #3e4f13;
+// @v3: #592716;
+
 ::-webkit-scrollbar { width: 8px; height: 8px; }
 ::-webkit-scrollbar-track-piece { background-color: transparent; }
 ::-webkit-scrollbar-thumb { background-color: rgba(255, 255, 255, 0.5); border-radius: 3px;}

--- a/desktop/themes/dark.less
+++ b/desktop/themes/dark.less
@@ -48,8 +48,8 @@
 @divider-color: #181818; // white 10%
 
 // Semantic colors: Diff
-@diff-added-background: @lime-1;
-@diff-removed-background: @volcano-1;
+@diff-added-background: @lime-2;
+@diff-removed-background: @volcano-2;
 
 ::-webkit-scrollbar { width: 8px; height: 8px; }
 ::-webkit-scrollbar-track-piece { background-color: transparent; }

--- a/desktop/themes/dark.less
+++ b/desktop/themes/dark.less
@@ -51,17 +51,6 @@
 @diff-added-background: @lime-1;
 @diff-removed-background: @volcano-1;
 
-// @l1: #1f2611;
-// @v1: #2b1611;
-
-// 
-// @l2:  #2e3c10;
-// @v2: #441d12;
-
-// still no
-// @l3: #3e4f13;
-// @v3: #592716;
-
 ::-webkit-scrollbar { width: 8px; height: 8px; }
 ::-webkit-scrollbar-track-piece { background-color: transparent; }
 ::-webkit-scrollbar-thumb { background-color: rgba(255, 255, 255, 0.5); border-radius: 3px;}

--- a/desktop/themes/light.less
+++ b/desktop/themes/light.less
@@ -46,3 +46,7 @@
 
 // Divider color
 @divider-color: #ececec; // black 10%
+
+// Semantic colors: Diff
+@diff-added-background: @lime-1;
+@diff-removed-background: @volcano-1;

--- a/desktop/themes/light.less
+++ b/desktop/themes/light.less
@@ -48,5 +48,5 @@
 @divider-color: #ececec; // black 10%
 
 // Semantic colors: Diff
-@diff-added-background: @lime-1;
-@diff-removed-background: @volcano-1;
+@diff-added-background: @lime-2;
+@diff-removed-background: @volcano-2;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Bug fix. Currenty Flipper provides incorrect red and green diff colors in Dark theme, this PR fixes the issue. Light theme colors are the same.

Closes #3011

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

Color theme fix: make diff background colors be defined in theme LESS files

<!-- Help reviewers and the release process by writing your own changelog entry. This should just be a brief oneline we can mention in our release notes: https://github.com/facebook/flipper/releases -->

## Test Plan

I used [redux-debugger](https://github.com/jk-gan/flipper-plugin-redux-debugger) plugin to test this as this is what I actually use for debugging Redux in React Native projects with Flipper. Here's a [React Native app](https://github.com/3rdp/flipper-redux-debugger-app) that I put together for testing purposes.

Light theme:
![lime2 light](https://user-images.githubusercontent.com/8898635/141799686-8b94655f-2501-46f9-9b28-d9ba8aeee222.png)

Dark theme:
![lime2](https://user-images.githubusercontent.com/8898635/141799710-fbd008a5-28cc-46f3-abf7-6b90fd85facb.png)

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI / output of the test runner and how you invoked it. -->

