### PR TITLE
Upgrade upload actions

### DIFF
--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -48,7 +48,7 @@ jobs:
       run: mv android/sample/build/outputs/apk/debug/sample-debug.apk SampleApp-android.apk
     - name: Attach sample APK to release
       if: ${{ github.event.inputs.tag != '' }}
-      uses: passy/github-upload-release-artifacts-action@v2.1.2
+      uses: passy/github-upload-release-artifacts-action@v2.2.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,7 +178,7 @@ jobs:
         path: 'Flipper-win.zip'
     - name: GitHub Upload Release Artifacts
       if: ${{ needs.release.outputs.tag != '' }}
-      uses: passy/github-upload-release-artifacts-action@v2.1.2
+      uses: passy/github-upload-release-artifacts-action@v2.2.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:


### PR DESCRIPTION
We're seeing some spurious failures, unrelated to any changes on our end.

I've upgraded the action to do two things:

- Retry on failure (up to three times): https://github.com/passy/github-upload-release-artifacts-action/commit/b0dfcdf1c7159f9734e6b01a363b363d19afff7f
- Replace the artefact if it's already present (otherwise this might fail subsequent retries): https://github.com/passy/github-upload-release-artifacts-action/commit/92bec0ba48f0629f27748362083298dda123c3ad

