### PR TITLE
Create issue on publish failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,7 +184,16 @@ jobs:
       with:
         created_tag: ${{ needs.release.outputs.tag }}
         args: Flipper-mac.dmg Flipper-linux.zip Flipper-win.zip
-
+    - name: Open issue on failure
+      if: failure()
+      uses: JasonEtco/create-an-issue@v2.4.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPOSITORY: ${{ github.repository }}
+        RUN_ID: ${{ github.run_id }}
+        WORKFLOW_NAME: "Publish"
+      with:
+        filename: .github/action-failure-template.md
   dispatch:
     needs:
       - release


### PR DESCRIPTION
Summary:
We've done this for the "release" part of the workflow
before but need to handle the "publish" branch separately.

Test Plan:
_eyes
