### PR TITLE
Upgrade Litho

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,6 @@ subprojects {
         google()
         mavenLocal()
         mavenCentral()
-        jcenter()
 
         if (isSnapshot()) {
             maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ POM_DEVELOPER_NAME=facebook
 POM_ISSUES_URL=https://github.com/facebook/flipper/issues/
 
 # Shared version numbers
-LITHO_VERSION=0.39.0
+LITHO_VERSION=0.41.1
 ANDROIDX_VERSION=1.3.0
 KOTLIN_VERSION=1.3.72
 


### PR DESCRIPTION
Summary:
This unblocks a bunch of other Kotlin-related updates as Litho 0.39
forced us to use a bunch of old stuff. Also, allows us to finally drop
Jcenter.

Test Plan:
Built and ran the sample app.