### PR TITLE
Increase publish verbosity

### DIFF
--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Build artifacts
       run: ./gradlew :sample:assembleDebug :sample:assembleRelease && ./gradlew :android:assembleRelease
     - name: Upload Archives
-      run: ./gradlew publish --no-parallel --no-daemon
+      run: ./gradlew publish -info --no-parallel --no-daemon
     - name: Release and close
       run: ./gradlew closeAndReleaseRepository
     - name: Clean secrets


### PR DESCRIPTION
I can run the same commands locally and everything is fine but in CI, it creates two separate staging repositories.

Maybe this will shed some light.