### PR TITLE
Close resource as we cannot inline

### DIFF
--- a/android/src/main/java/com/facebook/flipper/android/FlipperSocketImpl.java
+++ b/android/src/main/java/com/facebook/flipper/android/FlipperSocketImpl.java
@@ -87,7 +87,9 @@ class FlipperSocketImpl extends WebSocketClient implements FlipperSocket {
         String cert_client_pass = authenticationObject.getString("certificates_client_pass");
         String cert_ca_path = authenticationObject.getString("certificates_ca_path");
 
-        ks.load(new FileInputStream(cert_client_path), cert_client_pass.toCharArray());
+        try (InputStream clientCertificateStream = new FileInputStream(cert_client_path)) {
+          ks.load(clientCertificateStream, cert_client_pass.toCharArray());
+        }
 
         KeyManagerFactory kmf =
             KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());


### PR DESCRIPTION
Summary:
Better stream creation and disposal.

A report was generated with the following error:
StrictMode policy violation: android.os.strictmode.LeakedClosableViolation: A resource was acquired at attached stack trace but never released. See java.io.Closeable for information on avoiding resource leaks.

Changelog: Close input stream after use which was causing strict mode policy violation crashes and possibly leaking resources.

Differential Revision: D32830690

