### PR TITLE
Added --repo-update to pod install in readme

### DIFF
--- a/docs/getting-started/react-native.mdx
+++ b/docs/getting-started/react-native.mdx
@@ -38,7 +38,7 @@ Android:
 iOS:
 
 1. Call `use_flipper` with a specific version in `ios/Podfile`, for example: `use_flipper!({ 'Flipper' => '0.127.0' })`.
-2. Run `pod install` in the `ios` directory.
+2. Run `pod install --repo-update` in the `ios` directory.
 
 ## Manual Setup
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Took me a while during updating Flipper version to resolve proper iOs install with --repo-update (I am newbie to react native). I think others could benefit from having this in readme directly.

## Changelog

Just Readme.md change. No functional change at all.

