### PR TITLE
Fix Typescript typings in react-native-flipper

### DIFF
--- a/react-native/react-native-flipper/index.d.ts
+++ b/react-native/react-native-flipper/index.d.ts
@@ -41,13 +41,15 @@ declare namespace Flipper {
     runInBackground?(): boolean;
   }
 
+  type Serializable = undefined | Array<any> | object
+
   export interface FlipperResponder {
-    success(response?: any): void;
-    error(response: any): void;
+    success(response?: Serializable): void;
+    error(response: Serializable): void;
   }
 
   export interface FlipperConnection {
-    send(method: string, data: any): void;
+    send(method: string, data: Serializable): void;
     reportErrorWithMetadata(reason: string, stackTrace: string): void;
     reportError(error: Error): void;
     receive(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

The implementation of react-native-flipper [makes runtime assertions](https://github.com/facebook/flipper/blob/main/react-native/react-native-flipper/index.js#L20) about some variables but those type requirements [aren't properly reflected in the Typescript type defs](https://github.com/facebook/flipper/blob/main/react-native/react-native-flipper/index.d.ts#L45).

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

Corrected Typescript type defs in react-native-flipper

<!-- Help reviewers and the release process by writing your own changelog entry. This should just be a brief oneline we can mention in our release notes: https://github.com/facebook/flipper/releases -->

## Test Plan

(No runtime effect)
In vscode, the typings now properly restrict the arguments to `FlipperResponder.success`,  `FlipperResponder.error`, and  `FlipperConnection.send`

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI / output of the test runner and how you invoked it. -->

