### PR TITLE
Fix build error on windows

### DIFF
--- a/desktop/scripts/build-utils.ts
+++ b/desktop/scripts/build-utils.ts
@@ -10,6 +10,7 @@
 // @ts-ignore
 import Metro from 'metro';
 // provided by Metro
+// @ts-ignore
 // eslint-disable-next-line
 import MetroResolver from 'metro-resolver';
 import tmp from 'tmp';


### PR DESCRIPTION
Summary: Fix a build error caused by missing types for metro-resolver. For some reason it triggers only on windows, but we don't have typings for those indeed.

Differential Revision: D33308474

