### PR TITLE
Add app troubleshooting step (android)

### DIFF
--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -165,6 +165,7 @@ When using Flipper with React Native, two devices should show up:
 1. If you upgraded, make sure you made a clean build: `cd android && ./gradlew clean`, `cd iOS && pod install --repo-update`
 1. For iOS, make sure it works on a simulator first
 1. (Unconfirmed) check the deployment info target in the XCode project settings. Target should be `iOS 9.0`.
+1. For Android, make sure the device has the correct time and timezone
 
 #### Q: I see my app, but I don't see the external plugins I've installed
 


### PR DESCRIPTION
## Summary

This PR adds a suggestion to `Q: I see my device / emulator, but I can't see the app` specific to Android.

On a new android virtual device, the date/time may be automatically set incorrectly.

The following error can be observed in the device logs

````
flipper: AsyncSocketException: error:1416F086:SSL routines:tls_process_server_certificate:certificate verify failed, type = SSL error
Make sure the date and time of your device is up to date.
````

Correcting the device time and disabling "Set time automatically" resolves this issue.

Settings -> System -> Date & Time
- Disable "Set time automatically"
- Correct time manually

SSL does not appear in logs again, and the application connects properly.

---
- React native 0.63.2
- Apple Silicon
- Pixel 3a, API 32, arm64

## Changelog

Docs: Correct date/time on Android devices when troubleshooting app connection issues

## Test Plan

**With a fresh install of flipper (No `~./.flipper`) connect a new Android virtual device that has time set incorrectly.**

1. Start up a react native app on the device
2. Open flipper
3. Observe the following in the device logs:

````
flipper: AsyncSocketException: error:1416F086:SSL routines:tls_process_server_certificate:certificate verify failed, type = SSL error
Make sure the date and time of your device is up to date.
````
4. Observe the device is connected to Flipper, but no application is connected
5. Correct the date/time on the Android device
5. Restart the application, if needed, and observe the application properly connects and the SSL error does not appear again