### PR TITLE
Update js client path for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
       update-types: ["version-update:semver-major"]
     - dependency-name: "@types/*"
 - package-ecosystem: npm
-  directory: "/flipper-js-client-sdk"
+  directory: "/js/js-flipper"
   schedule:
     interval: weekly
     time: '13:00'


### PR DESCRIPTION
Summary:
This has been failing since the move in D31688105.

Test Plan:
_eyes_