### PR TITLE
Fix windows build (for real this time?)

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -33,7 +33,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-yarn-
     - name: yarn install (with retry)
-      uses: nick-invision/retry@v2.4.0
+      uses: nick-invision/retry@v2.6.0
       with:
         command: cd ${{env.desktop-directory}}; yarn
         timeout_minutes: 30
@@ -61,12 +61,8 @@ jobs:
       working-directory: ${{env.desktop-directory}}
     - name: build windows
       if: matrix.os == 'windows-latest'
-      uses: nick-invision/retry@v2.6.0
-      with:
-        timeout_minutes: 30
-        max_attempts: 3
-        command: cd ${{env.desktop-directory}} && yarn build --win
-        shell: pwsh
+      run: yarn build --win
+      working-directory: ${{env.desktop-directory}}
     - name: upload linux artifact
       uses: actions/upload-artifact@v1
       if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -61,8 +61,12 @@ jobs:
       working-directory: ${{env.desktop-directory}}
     - name: build windows
       if: matrix.os == 'windows-latest'
-      run: yarn build --win
-      working-directory: ${{env.desktop-directory}}
+      uses: nick-invision/retry@v2.6.0
+      with:
+        timeout_minutes: 30
+        max_attempts: 3
+        command: cd ${{env.desktop-directory}} && yarn build --win
+        shell: pwsh
     - name: upload linux artifact
       uses: actions/upload-artifact@v1
       if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,14 +127,14 @@ jobs:
         timeout_minutes: 10
         max_attempts: 3
         shell: pwsh
-        command: cd ${{env.desktop-directory}} && yarn
+        command: cd ${{env.desktop-directory}}; yarn
     - name: Build
       uses: nick-invision/retry@v2.6.0
       with:
         timeout_minutes: 30
         max_attempts: 3
         shell: pwsh
-        command: cd ${{env.desktop-directory}} && yarn build --win
+        command: cd ${{env.desktop-directory}}; yarn build --win
     - name: Upload Windows
       uses: actions/upload-artifact@v1
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,28 +126,20 @@ jobs:
       with:
         timeout_minutes: 10
         max_attempts: 3
-        command: (cd ${{env.desktop-directory}}) -and (yarn)
+        shell: pwsh
+        command: cd ${{env.desktop-directory}} && yarn
     - name: Build
       uses: nick-invision/retry@v2.6.0
       with:
         timeout_minutes: 30
         max_attempts: 3
-        command: (cd ${{env.desktop-directory}}) -and (yarn build --win)
+        shell: pwsh
+        command: cd ${{env.desktop-directory}} && yarn build --win
     - name: Upload Windows
       uses: actions/upload-artifact@v1
       with:
         name: 'Flipper-win.zip'
         path: 'dist/Flipper-win.zip'
-    - name: Open issue on failure
-      if: failure()
-      uses: JasonEtco/create-an-issue@v2.4.0
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        REPOSITORY: ${{ github.repository }}
-        RUN_ID: ${{ github.run_id }}
-        WORKFLOW_NAME: "Release"
-      with:
-        filename: .github/action-failure-template.md
 
   build-flipper-server:
     needs:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -33,6 +33,5 @@
   "jest.runAllTestsFirst": false,
   "jest.pathToConfig": "desktop/jest.config.js",
   "jest.pathToJest": "desktop/node_modules/.bin/jest",
-  "typescript.tsdk": "desktop/node_modules/typescript/lib",
-  "cmake.configureOnOpen": false
+  "typescript.tsdk": "desktop/node_modules/typescript/lib"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -33,5 +33,6 @@
   "jest.runAllTestsFirst": false,
   "jest.pathToConfig": "desktop/jest.config.js",
   "jest.pathToJest": "desktop/node_modules/.bin/jest",
-  "typescript.tsdk": "desktop/node_modules/typescript/lib"
+  "typescript.tsdk": "desktop/node_modules/typescript/lib",
+  "cmake.configureOnOpen": false
 }


### PR DESCRIPTION
Summary:

This previous attempt didn't work. Not even sure what happens now, it seems to just return the result of a boolean evaluation? Cool.

Still haven't verified that this works in the release build but noticed that we do effectively the same in the build step. By upgrading to the same revision of the action we use and then switching from `&&` to simply `;`, we can be reasonably sure that this will work now.

The alternative would be to switch to `pwsh` which appears to be the new name. `powershell` is the default shell and seems to be an older version without support for `&&`. I honestly never want to touch this or read about it again, so let's go with the simpler option.

