### PR TITLE
Link react-flipper-example to local js-flipper

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -34,11 +34,22 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: '14.x'
+    - name: js-flipper - yarn install (with retry)
+      uses: nick-invision/retry@v2.6.0
+      with:
+        command: cd js/js-flipper && yarn
+        timeout_minutes: 30
+        max_attempts: 3
+    - name: js-flipper build
+      run: yarn build
+      working-directory: js/js-flipper
     - name: yarn install (with retry)
       uses: nick-invision/retry@v2.6.0
       with:
         command: cd js/react-flipper-example && yarn
         timeout_minutes: 30
         max_attempts: 3
+    - name: link local js-flipper
+      run: yarn relative-deps
     - name: build
       run: yarn build

--- a/js/react-flipper-example/README.md
+++ b/js/react-flipper-example/README.md
@@ -1,6 +1,6 @@
 # React Flipper Example
 
-Examplary integration of any browser app with Flipper.
+Integration example of any browser app with Flipper.
 
 ## How to start
 


### PR DESCRIPTION
Summary: Before this change, it was impossible to make changes to js-flipper and react-flipper-example at the same time because react-flipper-example used a published version of js-flipper

Differential Revision: D33623034

