### PR TITLE
Fix desktop template tests

### DIFF
--- a/desktop/pkg/src/__tests__/runInit.node.ts
+++ b/desktop/pkg/src/__tests__/runInit.node.ts
@@ -58,6 +58,11 @@ test('It generates the correct files for client plugin', async () => {
         ],
     };
     ",
+      "/dev/null/jest-setup.ts": "// See https://github.com/facebook/flipper/pull/3327 for why we need this
+    // @ts-ignore
+    global.electronRequire = require;
+    require(\\"@testing-library/react\\");
+    ",
       "/dev/null/package.json": "{
       \\"$schema\\": \\"https://fbflipper.com/schemas/plugin-package/v2.json\\",
       \\"name\\": \\"flipper-plugin-my-weird-package-name-etc\\",
@@ -104,7 +109,10 @@ test('It generates the correct files for client plugin', async () => {
         \\"typescript\\": \\"latest\\"
       },
       \\"jest\\": {
-        \\"testEnvironment\\": \\"jsdom\\"
+        \\"testEnvironment\\": \\"jsdom\\",
+        \\"setupFiles\\": [
+          \\"<rootDir>/jest-setup.ts\\"
+        ]
       }
     }
     ",

--- a/desktop/pkg/templates/plugin/jest-setup.ts.template
+++ b/desktop/pkg/templates/plugin/jest-setup.ts.template
@@ -1,0 +1,4 @@
+// See https://github.com/facebook/flipper/pull/3327 for why we need this
+// @ts-ignore
+global.electronRequire = require;
+require("@testing-library/react");

--- a/desktop/pkg/templates/plugin/package.json.template
+++ b/desktop/pkg/templates/plugin/package.json.template
@@ -44,6 +44,9 @@
     "typescript": "latest"
   },
   "jest": {
-    "testEnvironment": "jsdom"
+    "testEnvironment": "jsdom",
+    "setupFiles": [
+      "<rootDir>/jest-setup.ts"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

When creating a brand new Flipper desktop plugin, the tests don't pass

### To Reproduce

```
npx flipper-pkg init
cd flipper-plugin-new
yarn jest
```

The test are not passing.
It would seem that we have 2 issues since this commit: https://github.com/facebook/flipper/commit/e46fcba0b28717d85df9e28ca400e267a88beb28#diff-26467a831e67f87a2bd99be5b62a71a6e3e4e7f86135c11ccede9a02e58c44feR48

#### 1. `electronRequire` is not defined

![image](https://user-images.githubusercontent.com/4534323/150385278-29527a4d-4783-4902-aeea-986b3c634a29.png)

Adding:
```ts
// @ts-ignore
global.electronRequire = require;
```
fixes the issue of course like [here](https://github.com/facebook/flipper/commit/e46fcba0b28717d85df9e28ca400e267a88beb28#diff-a283d77d8667b28aec5319fe5671a91489485a683898efedf9441b816c84a447R15) but might not be very ideal
When fixing this, we hit a second issue:

#### 2. Hooks cannot be defined inside tests

![image](https://user-images.githubusercontent.com/4534323/150385722-c0604cfc-33ef-4d8e-a8fd-d60042a87699.png)
 
This is because we now require `@testing-library/react` on the fly: https://github.com/facebook/flipper/commit/e46fcba0b28717d85df9e28ca400e267a88beb28#diff-26467a831e67f87a2bd99be5b62a71a6e3e4e7f86135c11ccede9a02e58c44feR198
which will run `afterEach` if defined: https://github.com/testing-library/react-testing-library/blob/071a6fdc1d8378bad0ad2d9f8fa58ec846ed7e2d/src/index.js#L12

A non ideal fix is to require `require("@testing-library/react");` before running the test

## Changelog

Fix: ensure desktop plugin template tests run

## Test Plan
I've cloned the repo and run:

```
cd flipper/desktop/pkg
yarn
cd ../../..
./flipper/desktop/pkg/bin/run init
```
I run the tests on the newly package created and they're now good

![image](https://user-images.githubusercontent.com/4534323/150391527-d834ec5b-57d8-4948-b9f3-17ade4eda79b.png)

## Side note

The fixes are not great, if you guys have better ones to suggest, really addressing the root cause of the issue, I'll happily close the PR

Also it's so easy to test desktop plugins with the awesome work you've done 🤩, it'd be sad if the community could not totally benefit from it.
Since I had this issue before (https://github.com/facebook/flipper/pull/3039), I'd be really happy to help (if given some directions 🙏) set up a test to ensure a plugin generated is always well set up.