### PR TITLE
[desktop] do not add `GrayedOutOverlay` if there is no children

### DIFF
--- a/desktop/flipper-ui-core/src/chrome/settings/ToggledSection.tsx
+++ b/desktop/flipper-ui-core/src/chrome/settings/ToggledSection.tsx
@@ -45,7 +45,7 @@ export default function ToggledSection(props: {
       </FlexRow>
       <IndentedSection>
         {props.children}
-        {props.toggled || props.frozen ? null : <GrayedOutOverlay />}
+        {props.toggled || props.frozen ? null : props.children && <GrayedOutOverlay />}
       </IndentedSection>
     </FlexColumn>
   );


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Do not add `GrayedOutOverlay` to the `ToggledSection` component if there is no children.

Current approach was causing UI issue in the Settings Modal in dark mode.

## Changelog

* do not add `GrayedOutOverlay` to the `ToggledSection` if there is no children

## Test Plan

The change has been testes by running the desktop Flipper app locally from source.

## Preview (before & after)

<img width="390" alt="Screenshot 2022-01-23 at 15 32 29" align="left" src="https://user-images.githubusercontent.com/719641/150683689-d70f2af9-d835-4139-a8bb-a638aca9b8d3.png">
<img width="390" alt="Screenshot 2022-01-23 at 15 32 12" src="https://user-images.githubusercontent.com/719641/150683692-86da3fba-5740-426e-96c7-6838632f42f0.png">


