### PR TITLE
[desktop] fix Settings modal UI glitch with overlow in dark mode

### DIFF
--- a/desktop/flipper-ui-core/src/chrome/SettingsSheet.tsx
+++ b/desktop/flipper-ui-core/src/chrome/SettingsSheet.tsx
@@ -98,7 +98,7 @@ class SettingsSheet extends Component<Props, State> {
         title="Settings"
         footer={footer}
         bodyStyle={{
-          overflow: 'scroll',
+          overflow: 'auto',
           maxHeight: 'calc(100vh - 250px)',
         }}>
         {contents}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This small tweak fixes the Setting modal UI glitch (white rectangle in the bottom right) related to the modal content overflow setting.

## Changelog

* fix Settings modal UI glitch with content overflow setting in dark mode
 
## Test Plan

The change has been testes by running the desktop Flipper app locally from source.

## Preview (before & after)

#### No scrollbar

<img width="390" alt="Screenshot 2022-01-23 at 15 45 47" align="left" src="https://user-images.githubusercontent.com/719641/150684278-b09031bd-9b8c-4c9c-9ac2-2dba3c1af63d.png">
<img width="390" alt="Screenshot 2022-01-23 at 15 45 39" src="https://user-images.githubusercontent.com/719641/150684279-151b83d6-c819-45e0-a662-3d294f4f6a77.png">

#### With scrollbar
<img width="390" alt="Screenshot 2022-01-23 at 15 51 40" align="left" src="https://user-images.githubusercontent.com/719641/150684331-a8f27623-9a2b-4ffe-b4c1-3fb06a6362a2.png">
<img width="390" alt="Screenshot 2022-01-23 at 15 51 47" src="https://user-images.githubusercontent.com/719641/150684330-57434f21-0d4d-4ef6-be41-fdd88d082d1b.png">

