### PR TITLE
[desktop] fix Plugins table UI glitch in dark mode, add column name

### DIFF
--- a/desktop/flipper-ui-core/src/chrome/plugin-manager/PluginInstaller.tsx
+++ b/desktop/flipper-ui-core/src/chrome/plugin-manager/PluginInstaller.tsx
@@ -49,7 +49,7 @@ const columns = {
     value: 'Description',
   },
   install: {
-    value: '',
+    value: 'Action',
   },
 };
 

--- a/desktop/flipper-ui-core/src/ui/components/table/ManagedTable.tsx
+++ b/desktop/flipper-ui-core/src/ui/components/table/ManagedTable.tsx
@@ -155,7 +155,7 @@ type ManagedTableState = {
 };
 
 const Container = styled(FlexColumn)<{canOverflow?: boolean}>((props) => ({
-  overflow: props.canOverflow ? 'scroll' : 'visible',
+  overflow: props.canOverflow ? 'auto' : 'visible',
   flexGrow: 1,
   height: '100%',
 }));


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Same as Settings modal, the Plugin Manager table used in Plugins modal includes the UI glitch in dark mode due to overflow setting. This PR fixes that and also adds missing column caption in "Install Plugins" table.

I have chosen `Action` as a title but this can be altered, I have no strong preference in there. The goal was to improve the clarity and also improve the context menu content (where user can show/hide columns).

## Changelog

* fix Plugins table UI glitch in dark mode, add column name

## Test Plan

The change has been testes by running the desktop Flipper app locally from source.

## Preview (before & after)
<img width="396" alt="Screenshot 2022-01-23 at 16 19 02" align="left" src="https://user-images.githubusercontent.com/719641/150685739-e2047e70-de14-4801-ac5a-0fc45a6ea476.png">
<img width="396" alt="Screenshot 2022-01-23 at 16 19 31" src="https://user-images.githubusercontent.com/719641/150685735-3de8b7a2-ea3f-489a-b1f8-7af73f0a5225.png">

