### PR TITLE
[actions] Hopefully fix flipper-release npm publish step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -217,7 +217,7 @@ jobs:
       run: echo "//registry.yarnpkg.com/:_authToken=${{ secrets.FLIPPER_NPM_TOKEN }}" >> ~/.npmrc
     - name: Publish flipper-server on NPM
       run: |
-        tar zxvf flipper-server.tgz
+        tar zxvf flipper-server.tgz/flipper-server.tgz
         cd package
         yarn publish
     - name: Open issue on failure


### PR DESCRIPTION
Summary:

This is really stupid but the download creates a directory with the same name before putting the file in it. I think `@v2` no longer does but hey, this is the devil we know.

You can look at the actions further down to see that we reference all the other downloads by `filename/filename` as well, so this should do it.

Test Plan:
Another release, I'm afraid. This is a step you cannot dry-run.

