### PR TITLE
Fix LeakCanary plugin UI, Upgrade LC dependency and make it compile only

### DIFF
--- a/android/plugins/leakcanary2/build.gradle
+++ b/android/plugins/leakcanary2/build.gradle
@@ -20,9 +20,9 @@ android {
     }
 
     dependencies {
-        implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$KOTLIN_VERSION"
+        compileOnly "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$KOTLIN_VERSION"
         implementation project(':android')
-        implementation deps.leakcanary2
+        compileOnly deps.leakcanary2
         compileOnly deps.jsr305
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ ext.deps = [
         mockito            : 'org.mockito:mockito-core:4.3.0',
         okhttp3            : 'com.squareup.okhttp3:okhttp:4.9.3',
         leakcanary         : 'com.squareup.leakcanary:leakcanary-android:1.6.3',
-        leakcanary2        : 'com.squareup.leakcanary:leakcanary-android:2.6',
+        leakcanary2        : 'com.squareup.leakcanary:leakcanary-android:2.8.1',
         protobuf           : 'com.google.protobuf:protobuf-java:3.19.3',
         testCore           : 'androidx.test:core:1.4.0',
         testRules          : 'androidx.test:rules:1.4.0',

--- a/desktop/plugins/public/leak_canary/docs/setup.mdx
+++ b/desktop/plugins/public/leak_canary/docs/setup.mdx
@@ -4,7 +4,7 @@ Ensure that you already have an explicit dependency in your application's
 ```groovy
 dependencies {
   debugImplementation 'com.facebook.flipper:flipper-leakcanary2-plugin:0.131.1'
-  debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.6'
+  debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.8.1'
 }
 ```
 
@@ -18,7 +18,6 @@ import com.facebook.flipper.plugins.leakcanary2.LeakCanary2FlipperPlugin
 
   override fun onCreate() {
     super.onCreate()
-    setupFlipper()
 
     /*
     set the flipper listener in leak canary config

--- a/desktop/plugins/public/leak_canary/index.tsx
+++ b/desktop/plugins/public/leak_canary/index.tsx
@@ -232,10 +232,10 @@ export default class LeakCanary<PersistedState> extends FlipperPlugin<
               return (
                 <Panel
                   key={idx}
-                  collapsable={false}
+                  collapsable={true}
                   padded={false}
                   heading={leak.title}
-                  floating={false}
+                  floating={true}
                   accessory={leak.retainedSize}>
                   <ElementsInspector
                     onElementSelected={(eid) => {
@@ -249,6 +249,7 @@ export default class LeakCanary<PersistedState> extends FlipperPlugin<
                     searchResults={null}
                     root={leak.root}
                     elements={elements}
+                    scrollable={false}
                   />
                 </Panel>
               );


### PR DESCRIPTION
## Summary

**Currently, the Leak Canary plugins is broken, see this screenshot (unable to expand):**
<img width="1359" alt="Screen Shot 2022-01-29 at 2 06 33 PM" src="https://user-images.githubusercontent.com/745166/151679662-9d8e8eb6-c19c-4008-9821-1c2c1af92351.png">

**This fix repairs and improves the UI:**
<img width="1350" alt="Screen Shot 2022-01-29 at 2 06 03 PM" src="https://user-images.githubusercontent.com/745166/151679677-7965604c-dd04-4ee5-bc8e-d53a82da1bd7.png">


## Changelog

- Fixes UI to enable showing leak trace
- Upgrades LackCanary dependency from 2.6 to 2.8.1
- Makes Kotlin and LC `compileOnly` dependencies in order to prevent conflict for the users
- Updates documentation

## Test Plan

See demo at https://github.com/hbmartin/leakcanary/tree/flipper-demo/leakcanary-android-sample