### PR TITLE
Upgrade Gradle Runner(?)

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -7,4 +7,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip


### PR DESCRIPTION
Summary: In [D33892189 V3 Android OSS job](https://www.internalfb.com/intern/sandcastle/job/36028797581234803/artifact/runsandcastle), it failed saying that it needs version 7.2 or later. Hence, upgrading this

Differential Revision: D33917841

