### PR TITLE
Add support for "Application Support" folders. Fixes #3391

### DIFF
--- a/desktop/flipper-server-core/src/utils/CertificateProvider.tsx
+++ b/desktop/flipper-server-core/src/utils/CertificateProvider.tsx
@@ -255,9 +255,9 @@ export default class CertificateProvider {
   }
 
   private getRelativePathInAppContainer(absolutePath: string) {
-    const matches = /Application\/[^/]+\/(.*)/.exec(absolutePath);
-    if (matches && matches.length === 2) {
-      return matches[1];
+    const matches = /Application( Support)?\/[^/]+\/(.*)/.exec(absolutePath);
+    if (matches && matches.length === 3) {
+      return matches[2];
     }
     throw new Error("Path didn't match expected pattern: " + absolutePath);
   }


### PR DESCRIPTION
This is the case when running a mobile app directly on an M1 machine. Fixes #3391


## Summary

You can't currently connect to an app that runs directly on the M1 (not a simulator)

## Changelog

Support for apps running directly on an M1 machine (not via a simulator)

## Test Plan

In Xcode, in the simulator dropdown, select the M1 Mac and run the app

