### PR TITLE
Fix Xcode version check

### DIFF
--- a/desktop/flipper-server-core/src/devices/ios/iOSDeviceManager.tsx
+++ b/desktop/flipper-server-core/src/devices/ios/iOSDeviceManager.tsx
@@ -195,7 +195,7 @@ export class IOSDeviceManager {
       let {stdout: xcodeCLIVersion} = await exec('xcode-select -p');
       xcodeCLIVersion = xcodeCLIVersion!.toString().trim();
       const {stdout} = await exec(
-        "pgrep Simulator | xargs ps | grep Simulator.app | awk '{print $NF}'",
+        "pgrep Simulator | xargs ps -o command | grep -v grep | grep Simulator.app | awk '{print $1}'",
       );
       for (const runningSimulatorApp of stdout!.toString().split('\n')) {
         if (!runningSimulatorApp) {


### PR DESCRIPTION
## Summary

Fixes #3396 - the Xcode version mismatch check has been broken since 0.132.0.

## Changelog

Fixed Xcode version mismatch check

## Test Plan

No existing test, manually tested locally on macOS 11.6.3 via `yarn start` when launching the Simulator directly or via `yarn react-native run-ios` in an RN project
