### PR TITLE
Add library verification step

### DIFF
--- a/.github/workflows/android-sample.yml
+++ b/.github/workflows/android-sample.yml
@@ -1,33 +1,36 @@
-name: Build Sample App
+name: Build Android Sample App
 
 on: [push, pull_request]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: set up JDK
-      uses: actions/setup-java@v1
-      with:
-        java-version: 11
-    - name: Compute build cache
-      run: ./scripts/checksum-android.sh checksum-android.txt
-    - uses: actions/cache@v2
-      with:
-        path: |
-          ~/.gradle/caches/modules-*
-          ~/.gradle/caches/jars-*
-          ~/.gradle/caches/build-cache-*
-        key: gradle-${{ hashFiles('checksum-android.txt') }}
-    - name: Build sample apps with Gradle
-      run: ./gradlew :sample:assembleDebug :tutorial:assembleDebug
-    - name: Build remaining artifacts with Gradle
-      run: ./gradlew assembleDebug
-    - name: upload artifact
-      uses: actions/upload-artifact@v1
-      with:
-        name: sample-app.apk
-        path: android/sample/build/outputs/apk/debug/sample-debug.apk
+      - uses: actions/checkout@v2
+      - name: set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Compute build cache
+        run: ./scripts/checksum-android.sh checksum-android.txt
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches/modules-*
+            ~/.gradle/caches/jars-*
+            ~/.gradle/caches/build-cache-*
+          key: gradle-${{ hashFiles('checksum-android.txt') }}
+      - name: Build debug artifact
+        run: ./gradlew :android:assembleDebug
+      - name: Verify libraries in artifact
+        run: scripts/verify-android-libraries.sh
+      - name: Build sample apps with Gradle
+        run: ./gradlew :sample:assembleDebug :tutorial:assembleDebug
+      - name: Build remaining artifacts with Gradle
+        run: ./gradlew assembleDebug
+      - name: upload artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: sample-app.apk
+          path: android/sample/build/outputs/apk/debug/sample-debug.apk

--- a/scripts/verify-android-libraries.sh
+++ b/scripts/verify-android-libraries.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+NUM=$(unzip -l "$BASEDIR"/android/build/outputs/aar/android-debug.aar | grep -c libevent_core)
+
+if (( NUM >= 4 )); then
+        echo "Found $NUM instances of libevent_core. Looks good."
+        exit 0
+else
+        echo "Found fewer than 4 libevent_core.so files. Expecting one for each architecture. See #3395 for details."
+        exit 1
+fi


### PR DESCRIPTION
Summary:
This is pretty dumb but hopefully good enough to prevent accidental regressions. We simply check if there are "enough" `libevent_core.so`s in the bundle. This is obviously not future-proof but it's super cheap to run and if it causes problems at some point, we can always remove it.

Test Plan:
CI here.
