### PR TITLE
fix: encode ws url

### DIFF
--- a/js/js-flipper/src/client.ts
+++ b/js/js-flipper/src/client.ts
@@ -215,7 +215,10 @@ export class FlipperClient {
   private connectToFlipper() {
     const url = `ws://${this.urlBase}?device_id=${this.device}${this.devicePseudoId}&device=${this.device}&app=${this.appName}&os=${this.os}`;
 
-    this.ws = this.websocketFactory(url);
+    // Encode url to form proper WS url
+    const encodedURL = encodeURIComponent(url);
+
+    this.ws = this.websocketFactory(encodedURL);
 
     this.ws.onerror = (error) => {
       this.onError(error);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Some clients require encoded ws url. For example on Android (running in Rect Native), plain URL like this:
`ws://10.0.2.2:8333?device_id=ReactNative1646120067758.0.2246373385349361&device=ReactNative&app=React Native App Google - Android SDK&os=ReactNative`
will throw error during connection.

To not require param encoding when starting the `flipperClient.start()`, it is easier to encode entire `url` before starting the ws server.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. This should just be a brief oneline we can mention in our release notes: https://github.com/facebook/flipper/releases -->
- encode url for `js-flipper` ws server

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI / output of the test runner and how you invoked it. -->

