### PR TITLE
Bump react-native-android versions

### DIFF
--- a/react-native/ReactNativeFlipperExample/android/app/src/main/AndroidManifest.xml
+++ b/react-native/ReactNativeFlipperExample/android/app/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
         android:label="@string/app_name"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
         android:launchMode="singleTask"
-        android:windowSoftInputMode="adjustResize">
+        android:windowSoftInputMode="adjustResize"
+        android:exported="true">
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />

--- a/react-native/ReactNativeFlipperExample/android/build.gradle
+++ b/react-native/ReactNativeFlipperExample/android/build.gradle
@@ -6,14 +6,13 @@
  */
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-
 buildscript {
     ext {
-        buildToolsVersion = "30.0.2"
+        buildToolsVersion = "30.0.3"
         minSdkVersion = 21
-        compileSdkVersion = 30
-        targetSdkVersion = 30
-        ndkVersion = "21.4.7075529"
+        compileSdkVersion = 31
+        targetSdkVersion = 31
+        ndkVersion = '23.0.7599858'
     }
     repositories {
         google()

--- a/react-native/ReactNativeFlipperExample/android/gradle.properties
+++ b/react-native/ReactNativeFlipperExample/android/gradle.properties
@@ -30,4 +30,4 @@ android.useAndroidX=true
 android.enableJetifier=true
 
 # Version of flipper SDK to use with React Native
-FLIPPER_VERSION=0.110.0
+FLIPPER_VERSION=0.125.0

--- a/react-native/react-native-flipper/android/build.gradle
+++ b/react-native/react-native-flipper/android/build.gradle
@@ -17,7 +17,7 @@ buildscript {
             google()
         }
         dependencies {
-            classpath 'com.android.tools.build:gradle:4.2.1'
+            classpath 'com.android.tools.build:gradle:7.0.4'
         }
     }
 }
@@ -37,7 +37,7 @@ plugins {
 //   - https://github.com/facebook/react-native/blob/0.58-stable/local-cli/templates/HelloWorld/android/app/build.gradle
 
 def DEFAULT_COMPILE_SDK_VERSION = 28
-def DEFAULT_BUILD_TOOLS_VERSION = '28.0.3'
+def DEFAULT_BUILD_TOOLS_VERSION = '30.0.3'
 def DEFAULT_MIN_SDK_VERSION = 16
 def DEFAULT_TARGET_SDK_VERSION = 28
 


### PR DESCRIPTION
Summary:
^
Updates a few versions of different things used in react-native-android and the provided sample as to have more parity with the ones used in vanilla Android.

Changelog: React-native Android. Bump tools versions.

Differential Revision: D34751493

