### PR TITLE
[circleci] Remove checkout step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,6 @@ jobs:
   snapshot:
     executor: default-executor
     steps:
-      - checkout
       - run:
           name: install retry
           command: scripts/install-retry.sh


### PR DESCRIPTION
According to [this](https://circleci.com/docs/2.0/configuration-reference/#checkout), using the checkout step uses SSH but we're fine with HTTPS.
