### PR TITLE
[Flipper-JS] fix: clear reconnect timeout on stop()

### DIFF
--- a/js/js-flipper/src/client.ts
+++ b/js/js-flipper/src/client.ts
@@ -190,13 +190,13 @@ export class FlipperClient {
   }
 
   stop() {
-    if (!this.ws) {
-      return;
-    }
-
     if (this.reconnectionTimer) {
       clearTimeout(this.reconnectionTimer);
       this.reconnectionTimer = undefined;
+    }
+
+    if (!this.ws) {
+      return;
     }
 
     // TODO: Why is it not 1000 by default?

--- a/js/js-flipper/src/client.ts
+++ b/js/js-flipper/src/client.ts
@@ -194,6 +194,11 @@ export class FlipperClient {
       return;
     }
 
+    if (this.reconnectionTimer) {
+      clearTimeout(this.reconnectionTimer);
+      this.reconnectionTimer = undefined;
+    }
+
     // TODO: Why is it not 1000 by default?
     this.ws.close(WSCloseCode.NormalClosure);
     this.ws = undefined;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

When using `flipperClient.stop()`, after `flipperClient.start()`, it's impossible to `start` new connection, since the previous instance would keep active `reconnect`, so would override the previous connection.

## Changelog

- clean reconnect timer when calling `flipperClient.stop()`

## Test Plan

1. `flipperClient.start('Demo app', { urlBase: 'null:8333' });` - this will fail connection, but keep retrying
2. `flipperClient.stop()` - should disconnect from WS and clear all reconnect timers
3. `flipperClient.start('Demo app', { urlBase: 'localhost:8333' });` - should connect succefully

