### PR TITLE
Add "MacOS" to supportedDevices

### DIFF
--- a/desktop/pkg/schemas/plugin-package-v2.json
+++ b/desktop/pkg/schemas/plugin-package-v2.json
@@ -64,7 +64,7 @@
           "os": {
             "description": "Device OS: iOS, Android or Metro. Lack of this property means that all OSes supported.",
             "type": "string",
-            "enum": ["iOS", "Android", "Metro"]
+            "enum": ["iOS", "Android", "Metro", "MacOS"]
           },
           "type": {
             "description": "Device type: physical or emulator or dummy. Lack of this property means it supports physical, emulator and dummy devices.",


### PR DESCRIPTION
This is already supported, when running Flipper on Mac, so just need update schema.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

One use case for `MacOS`, is to have a static plugin available to users before they launch any app/device. So this can be used as Welcome plugin, Documentation or any other "static" plugin not requiring any other device except the one running Flipper Desktop.

## Changelog

- add `MacOS` to supported devices

## Test Plan

- Script `lint` should pass.
