### PR TITLE
Disable flaky PluginContainer test

### DIFF
--- a/desktop/flipper-ui-core/src/__tests__/PluginContainer.node.tsx
+++ b/desktop/flipper-ui-core/src/__tests__/PluginContainer.node.tsx
@@ -111,7 +111,8 @@ test('Plugin container can render plugin and receive updates', async () => {
   expect((await renderer.findByTestId('counter')).textContent).toBe('2');
 });
 
-test('PluginContainer can render Sandy plugins', async () => {
+// TODO(T119353406): Disabled due to flakiness.
+test.skip('PluginContainer can render Sandy plugins', async () => {
   let renders = 0;
 
   function MySandyPlugin() {


### PR DESCRIPTION
Keeps flaking out: https://github.com/facebook/flipper/runs/6308722109?check_suite_focus=true
