### PR TITLE
Prototype: Added support for multiple host in mock

### DIFF
--- a/android/plugins/network/src/main/java/com/facebook/flipper/plugins/network/FlipperOkhttpInterceptor.java
+++ b/android/plugins/network/src/main/java/com/facebook/flipper/plugins/network/FlipperOkhttpInterceptor.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import javax.annotation.Nullable;
@@ -192,10 +193,7 @@ public class FlipperOkhttpInterceptor
     final String method = request.method();
     final PartialRequestInfo partialRequest = new PartialRequestInfo(url, method);
 
-    if (!mMockResponseMap.containsKey(partialRequest)) {
-      return null;
-    }
-    ResponseInfo mockResponse = mMockResponseMap.get(partialRequest);
+    ResponseInfo mockResponse = getMockResponse(partialRequest);
     if (mockResponse == null) {
       return null;
     }
@@ -217,6 +215,17 @@ public class FlipperOkhttpInterceptor
       }
     }
     return builder.build();
+  }
+
+  private ResponseInfo getMockResponse(PartialRequestInfo partialRequestInfo) {
+    for (Map.Entry<PartialRequestInfo, ResponseInfo> entry : mMockResponseMap.entrySet()) {
+      PartialRequestInfo mockRequestInfo = entry.getKey();
+      if (partialRequestInfo.first.contains(mockRequestInfo.first) &&
+              Objects.equals(partialRequestInfo.second, mockRequestInfo.second)) {
+        return entry.getValue();
+      }
+    }
+    return null;
   }
 
   @Nullable


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
Apps usually communicate with multiple hosts to support pops and data centres. The problem currently is that for each host we need a different config in the mock tab in flipper. If the host change due to failover then the mocking stops working. Added support to enter the URL without a host in the flipper. We then check if the Url from the actual network request contains the mock URL without a host.

We can change the hint on flipper UI to suggest either entering the complete URL or without the host to allow matching across multiple hosts. 

Resolve:[3751](https://github.com/facebook/flipper/issues/3751)

Let me know if the approach looks good.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. This should just be a brief online we can mention in our release notes: https://github.com/facebook/flipper/releases -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos if the pull request changes UI / output of the test runner and how you invoked it. -->

