### PR TITLE
Docs: fix typo

### DIFF
--- a/docs/getting-started/react-native-android.mdx
+++ b/docs/getting-started/react-native-android.mdx
@@ -37,7 +37,7 @@ These exclusions are currently necessary to avoid some clashes with FBJNI shared
 
 ## Application Setup
 
-For maximum flexibility, it's recommwended you move the Flipper initialization to a separate class that lives in a `debug/` folder, so that Flipper code never gets referenced in a release build.
+For maximum flexibility, it's recommended you move the Flipper initialization to a separate class that lives in a `debug/` folder, so that Flipper code never gets referenced in a release build.
 
 ```java
 import android.content.Context;


### PR DESCRIPTION
Fix typo on word Recommended

## Summary
Update Docs to fix a typo on Manual Android Setup


Addresses:

- #3790 

## Changelog
Fix typo on Manual Android Setup  documentation.

## Test Plan

Not needed.

