### PR TITLE
docs: Remove repeated instructions

### DIFF
--- a/docs/getting-started/react-native.mdx
+++ b/docs/getting-started/react-native.mdx
@@ -39,12 +39,6 @@ iOS:
 
 1. Call `use_flipper` with a specific version in `ios/Podfile`, for example: `use_flipper!({ 'Flipper' => '0.149.0' })`.
 2. Run `pod install --repo-update` in the `ios` directory.
-* Android
-    1. Bump the `FLIPPER_VERSION` variable in `android/gradle.properties`, for example: `FLIPPER_VERSION=0.149.0`.
-    2. Run `./gradlew clean` in the `android` directory.
-* iOS
-    1. Call `use_flipper` with a specific version in `ios/Podfile`, for example: `use_flipper!({ 'Flipper' => '0.149.0' })`.
-    2. Run `pod install --repo-update` in the `ios` directory.
 
 ## Manual Setup
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This fixes a small issue in the docs, where the iOS and Android React Native Flipper SDK version instructions are repeated.

## Changelog

Remove repeated SDK version instructions in the docs.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI / output of the test runner and how you invoked it. -->

