### PR TITLE
Add react peer-dependency ^18.0.0 for react-native

### DIFF
--- a/react-native/react-native-flipper/package.json
+++ b/react-native/react-native-flipper/package.json
@@ -24,7 +24,7 @@
   "licenseFilename": "LICENSE",
   "readmeFilename": "README.md",
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "react-native": ">0.62.0"
   },
   "devDependencies": {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
With the very established version of React 18.x.x and react-native being dependent on React 18. react-native-flipper should accept react 18 as a peer dependency.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog
Add React ^18.0.0 to react-native as an accepted peer-dependency  
<!-- Help reviewers and the release process by writing your own changelog entry. This should just be a brief oneline we can mention in our release notes: https://github.com/facebook/flipper/releases -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI / output of the test runner and how you invoked it. -->
No tests are required, forced dependency in another project and confirmed it worked with the following dependencies
```
    "react": "18.0.0",
    "react-native": "0.69.1",
    "react-native-flipper": "0.151.0"
```

To the best of my understanding, this should be an unproblematic addition, if I am wrong I am eager to understand.