### PR TITLE
Removes duplicated section in getting started documentation

### DIFF
--- a/docs/getting-started/react-native.mdx
+++ b/docs/getting-started/react-native.mdx
@@ -39,12 +39,6 @@ iOS:
 
 1. Call `use_flipper` with a specific version in `ios/Podfile`, for example: `use_flipper!({ 'Flipper' => '0.153.0' })`.
 2. Run `pod install --repo-update` in the `ios` directory.
-* Android
-    1. Bump the `FLIPPER_VERSION` variable in `android/gradle.properties`, for example: `FLIPPER_VERSION=0.153.0`.
-    2. Run `./gradlew clean` in the `android` directory.
-* iOS
-    1. Call `use_flipper` with a specific version in `ios/Podfile`, for example: `use_flipper!({ 'Flipper' => '0.153.0' })`.
-    2. Run `pod install --repo-update` in the `ios` directory.
 
 ## Manual Setup
 


### PR DESCRIPTION
## Summary

When reading the getting started documentation, i realized that the instructions were duplicated. I removed one of the sections.

## Changelog

Removed duplicate section in react-native getting started docs.

## Test Plan

n/a