### PR TITLE
Update RN iOS setup to include RN 0.68 new Flipper initialization

### DIFF
--- a/docs/getting-started/react-native-ios.mdx
+++ b/docs/getting-started/react-native-ios.mdx
@@ -105,6 +105,19 @@ The code below enables the following integrations:
 * Shared Preferences
 * Crash Reporter
 
+### React Native 0.68+
+
+If using React Native 0.68 or later, your AppDelegate should include
+
+```objc
+...
+#import <React/RCTAppSetupUtils.h>
+```
+
+RCTAppSetupUtils takes care of initializing Flipper and the integrations mentioned above.
+
+### React Native 0.67
+
 <Tabs defaultValue="ios" values={[{ label: 'iOS', value: 'ios'}, { label: 'Swift', value: 'swift'}]}>
 <TabItem value="ios">
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
When upgrading to RN 0.68, the upgrade helper removes the old Flipper initialization in favor of importing `RCTAppSetupUtils` which abstracts the Flipper initialization. 
To be consistent, we should show in the docs that for 0.68 the preferred way is to import `RCTAppSetupUtils` in the AppDelegate.

## Changelog
- RN iOS setup docs has been updated to include the new way to initialize Flipper on React Native 0.68.

<!-- Help reviewers and the release process by writing your own changelog entry. This should just be a brief oneline we can mention in our release notes: https://github.com/facebook/flipper/releases -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI / output of the test runner and how you invoked it. -->

