### PR TITLE
Fix: [Android] Flipper Leakcanary plugin's OnHeapAnalyzedListener has been deprecated

### DIFF
--- a/android/plugins/leakcanary2/src/main/java/com/facebook/flipper/plugins/leakcanary2/FlipperLeakEventListener.kt
+++ b/android/plugins/leakcanary2/src/main/java/com/facebook/flipper/plugins/leakcanary2/FlipperLeakEventListener.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.flipper.plugins.leakcanary2
+
+import com.facebook.flipper.android.AndroidFlipperClient
+import leakcanary.EventListener
+import shark.HeapAnalysis
+import shark.HeapAnalysisSuccess
+
+class FlipperLeakEventListener : EventListener {
+    private val leaks: MutableList<Leak> = mutableListOf()
+
+    override fun onEvent(event: EventListener.Event) {
+        if (event is EventListener.Event.HeapAnalysisDone.HeapAnalysisSucceeded) {
+            val heapAnalysis = event.heapAnalysis
+            leaks.addAll(heapAnalysis.toLeakList())
+
+            AndroidFlipperClient.getInstanceIfInitialized()?.let { client ->
+                (client.getPlugin(LeakCanary2FlipperPlugin.ID) as? LeakCanary2FlipperPlugin)?.reportLeaks(
+                    leaks)
+            }
+        }
+    }
+
+    private fun HeapAnalysis.toLeakList(): List<Leak> {
+        return if (this is HeapAnalysisSuccess) {
+            allLeaks
+                .mapNotNull {
+                    if (it.leakTraces.isNotEmpty()) {
+                        it.leakTraces[0].toLeak(it.shortDescription)
+                    } else {
+                        null
+                    }
+                }
+                .toList()
+        } else {
+            emptyList()
+        }
+    }
+}

--- a/android/plugins/leakcanary2/src/main/java/com/facebook/flipper/plugins/leakcanary2/FlipperLeakListener.kt
+++ b/android/plugins/leakcanary2/src/main/java/com/facebook/flipper/plugins/leakcanary2/FlipperLeakListener.kt
@@ -13,6 +13,7 @@ import leakcanary.OnHeapAnalyzedListener
 import shark.HeapAnalysis
 import shark.HeapAnalysisSuccess
 
+@Deprecated("Use FlipperLeakEventListener add to LeakCanary.config.eventListeners instead")
 class FlipperLeakListener : OnHeapAnalyzedListener {
   private val leaks: MutableList<Leak> = mutableListOf()
 

--- a/desktop/plugins/public/leak_canary/docs/setup.mdx
+++ b/desktop/plugins/public/leak_canary/docs/setup.mdx
@@ -16,7 +16,7 @@ dependencies {
 2. Update your the `onCreate` method in you `Application` to add the LeakCanary2 plugin to Flipper and the Flipper listener to LeakCanary:
 
 ```kt
-import com.facebook.flipper.plugins.leakcanary2.FlipperLeakListener
+import com.facebook.flipper.plugins.leakcanary2.FlipperLeakEventListener
 import com.facebook.flipper.plugins.leakcanary2.LeakCanary2FlipperPlugin
 
 ...
@@ -27,9 +27,9 @@ import com.facebook.flipper.plugins.leakcanary2.LeakCanary2FlipperPlugin
     /*
     set the flipper listener in leak canary config
     */
-    LeakCanary.config = LeakCanary.config.copy(
-        onHeapAnalyzedListener = FlipperLeakListener()
-    )
+    LeakCanary.config = LeakCanary.config.run {
+        copy(eventListeners = eventListeners + FlipperLeakEventListener)
+    }
 
     SoLoader.init(this, false)
 


### PR DESCRIPTION
Flipper Leakcanary plugin's OnHeapAnalyzedListener has been deprecated.

## Summary

Flipper Leakcanary plugin's OnHeapAnalyzedListener has been deprecated change to EventListener implement.

## Changelog

1. add FlipperLeakEventListener.kt to implement EventListener.
2. update doc

## Test Plan

Setup the  Leakcanary plugin use FlipperLeakEventListener, test if it works.
