### PR TITLE
Fix typo in image url in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   Flipper (formerly Sonar) is a platform for debugging mobile apps on iOS and Android and, recently, even JS apps in your browser or in Node.js. Visualize, inspect, and control your apps from a simple desktop interface. Use Flipper as is or extend it using the plugin API.
 </p>
 
-![Flipper](website/static/img/inspector.pngg)
+![Flipper](website/static/img/inspector.png)
 
 ## Table of Contents
 


### PR DESCRIPTION
Introduced in https://github.com/facebook/flipper/commit/40e65901bd6191603248a0ec2b3d31b13ed42e26