### PR TITLE
fix data inspector white hover background in dark mode

### DIFF
--- a/desktop/flipper-plugin/src/ui/data-inspector/DataInspectorNode.tsx
+++ b/desktop/flipper-plugin/src/ui/data-inspector/DataInspectorNode.tsx
@@ -50,7 +50,7 @@ const BaseContainer = styled.div<{
   paddingLeft: 10,
   userSelect: 'text',
   width: '100%',
-  backgroundColor: props.hovered ? '#f9f9f9' : '',
+  backgroundColor: props.hovered ? theme.selectionBackgroundColor : '',
 }));
 BaseContainer.displayName = 'DataInspector:BaseContainer';
 


### PR DESCRIPTION
## Summary

Fixes the white color background in dark mode for the data-inspector plugin (regarding issue #3805). Now instead of a hardcoded color, the selectionBackgroundColor from theme will be used.

## Changelog

- fix data inspector plugin white hover background color in dark mode

## Test Plan

Previous:
<img width="582" alt="image" src="https://user-images.githubusercontent.com/39571859/182571114-cf0ad6e9-650c-42c2-b91b-df976c09d282.png">

Dark mode:
<img width="582" alt="image" src="https://user-images.githubusercontent.com/39571859/182570580-3961edd4-f9f6-4f65-8008-662ac1a6e36c.png">

Light mode:
<img width="576" alt="image" src="https://user-images.githubusercontent.com/39571859/182570719-64c2296c-1ce2-49c7-8446-ef2db5335128.png">