### PR TITLE
Update docs to use latest Flipper SDK

### DIFF
--- a/docs/getting-started/react-native.mdx
+++ b/docs/getting-started/react-native.mdx
@@ -37,6 +37,11 @@ Android:
 
 iOS:
 
+react-native version => 0.69.0
+1. Call `FlipperConfiguration.enabled` with a specific version in `ios/Podfile`, for example: `:flipper_configuration => FlipperConfiguration.enabled(["Debug"], { 'Flipper' => '0.157.0' }),`.
+2. Run `pod install --repo-update` in the `ios` directory.
+
+react-native version < 0.69.0
 1. Call `use_flipper` with a specific version in `ios/Podfile`, for example: `use_flipper!({ 'Flipper' => '0.157.0' })`.
 2. Run `pod install --repo-update` in the `ios` directory.
 


### PR DESCRIPTION
Since react-native 0.69 the use_flipper method has been refactored to a different way to enable flipper within a react-native project.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
After upgrading to react-native 0.69.0 my Flipper SDK version downgraded to version 0.125.0. I had to find a new way to be able to pass the version as parameter so i can use the latest flipper SDK. As i could not find any documentation about this, I read the source code and had to figure it out myself. Hope to save some time for some people in the future.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. This should just be a brief oneline we can mention in our release notes: https://github.com/facebook/flipper/releases -->
Updated docs to use latest Flipper SDK

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI / output of the test runner and how you invoked it. -->
No tests as it is a documentation change.

