### PR TITLE
Fix a minor typo inside Android Native documentation

### DIFF
--- a/docs/getting-started/android-native.mdx
+++ b/docs/getting-started/android-native.mdx
@@ -35,7 +35,7 @@ dependencies {
 The `flipper-noop` package provides a limited subset of the APIs provided by the `flipper` package and does not provide any plugin stubs.
 It's recommended that you keep all Flipper instantiation code in a separate build variant to ensure it doesn't accidentally make it into your production builds.
 
-To see how to organise your Flipper initialization into debug and release variants. see thos [sample app](https://github.com/facebook/flipper/tree/main/android/sample/src).
+To see how to organise your Flipper initialization into debug and release variants, check this [sample app](https://github.com/facebook/flipper/tree/main/android/sample/src).
 
 Alternatively, have a look at the third-party [flipper-android-no-op](https://github.com/theGlenn/flipper-android-no-op) repository, which provides empty implementations for several Flipper plugins.
 :::


### PR DESCRIPTION
## Summary

Just fixing a typo

## Changelog

Fix a minor typo inside Android Native documentation

## Test Plan

n/a
