### PR TITLE
feat: add React 18 as peerDependency

### DIFF
--- a/react-native/react-native-flipper/package.json
+++ b/react-native/react-native-flipper/package.json
@@ -24,7 +24,7 @@
   "licenseFilename": "LICENSE",
   "readmeFilename": "README.md",
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "react-native": ">0.62.0"
   },
   "devDependencies": {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
React Native 0.69 already depends on React 18 so it complains when using latest version of react-native-flipper.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog
Added React 18 as peer dependency for react-native-flipper
<!-- Help reviewers and the release process by writing your own changelog entry. This should just be a brief oneline we can mention in our release notes: https://github.com/facebook/flipper/releases -->

