### PR TITLE
fix: 404 docs links in app inspect

### DIFF
--- a/desktop/flipper-ui-core/src/sandy-chrome/appinspect/AppInspect.tsx
+++ b/desktop/flipper-ui-core/src/sandy-chrome/appinspect/AppInspect.tsx
@@ -36,7 +36,7 @@ const appTooltip = (
     Inspect apps by selecting connected devices and emulators. Navigate and
     bookmark frequent destinations in the app. Refresh, screenshot and
     screenrecord is also available.{' '}
-    <Link href="https://fbflipper.com/docs/getting-started/index">
+    <Link href="https://fbflipper.com/docs/getting-started/">
       Learn More
     </Link>
   </>

--- a/desktop/flipper-ui-core/src/sandy-chrome/appinspect/NoDevices.tsx
+++ b/desktop/flipper-ui-core/src/sandy-chrome/appinspect/NoDevices.tsx
@@ -36,7 +36,7 @@ export function NoDevices() {
           <Text>
             Start a fresh emulator <RocketOutlined onClick={onLaunchEmulator} />{' '}
             or check the{' '}
-            <Link href="https://fbflipper.com/docs/getting-started/troubleshooting/troubleshooting">
+            <Link href="https://fbflipper.com/docs/getting-started/troubleshooting/">
               troubleshooting guide
             </Link>
             .


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Currently, the `app inspect` tooltip at the left rail has a link to the getting started page that doesn't exist.
New path is `/docs/getting-started/`.

Also fix troubleshooting guide and no devices are found to `/docs/getting-started/troubleshooting/`
