### PR TITLE
docs: fix broken header in callout block on Getting Started page

### DIFF
--- a/docs/getting-started/index.mdx
+++ b/docs/getting-started/index.mdx
@@ -41,7 +41,7 @@ To work properly with mobile apps, Flipper requires the following:
 
 If you are hacking a JS app, you should be good to go without any extra dependencies installed.
 
-:::information
+:::info Information
 [Experimental] Alternatively, it is possible to run a browser based version of Flipper directly from NPM by using `npx flipper-server`.
 :::
 


### PR DESCRIPTION
## Summary

Changes the callout block header to separate the icon from the header of the callout.

The "information" callout at https://fbflipper.com/docs/getting-started/ displays the info icon and "RMATION".

![image](https://user-images.githubusercontent.com/11802078/187704594-2d9553b1-b754-48b9-b55d-7d64b2fd20ee.png)


## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. This should just be a brief oneline we can mention in our release notes: https://github.com/facebook/flipper/releases -->

Fixed broken header in a callout block in the getting started docs page

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI / output of the test runner and how you invoked it. -->

Build the docs and open `/docs/getting-started/`