### PR TITLE
Proposal: Allow other runtimes to use the Hermes Debugger plugin for React Native

### DIFF
--- a/desktop/plugins/public/hermesdebuggerrn/index.tsx
+++ b/desktop/plugins/public/hermesdebuggerrn/index.tsx
@@ -96,8 +96,7 @@ export default class extends FlipperDevicePlugin<State, any, any> {
         // We only want to use the Chrome Reload targets.
         const targets = result.filter(
           (target: any) =>
-            target.title ===
-            'React Native Experimental (Improved Chrome Reloads)',
+            target.title.includes('(Improved Chrome Reloads)'),
         );
 
         // Find the currently selected target.


### PR DESCRIPTION
## Motivation

Hi, I'm a member of the [react-native-reanimated](https://github.com/software-mansion/react-native-reanimated) team at Software Mansion, where we develop a module for React Native. Due to the architecture of this module, we need to create our own runtime. It has long been the case that code being executed in our runtime environment, could not have been debugged using most debugging tools. This is due to change soon, as the work done in [this](https://github.com/software-mansion/react-native-reanimated/pull/3526) PR enables full support for debugging using Chrome DevTools, when using Hermes as the runtime.

Unfortunately, this runtime is not visible to the Hermes Debugger plugin as it's name (`Reanimated runtime`) is different from the hard-coded name of React Native's default runtime (`React Native Experimental (Improved Chrome Reloads)`) and therefore cannot be debugged using this method.

## Solutions

1. We (at Software Mansion) could create our own fork of the Hermes Debugger plugin, where we would replace the hard-coded runtime name with the name of our own runtime.

2. The code in the Hermes Debugger plugin could be updated to show all targets, which names include `(Improved Chrome Reloads)`. Then any module, which creates its own runtime, could support Chrome reloads and by indicating that in the name would be shown by the Hermes Debugger plugin.

I believe the second solution to be the preferred one as it enables support for more than just our single use-case, while also adding minimal maintenance work both for Flipper's developers and the community creating modules.

## Other suggestions

If this change was to be implemented, it would be a good idea to have a way to close the debugger and go back to the list of available runtimes (ex. a back button), but I think this is out of the scope of this PR.

## Changes

**_Summary_**: Allow other runtimes to use the Hermes Debugger plugin for React Native

Before:

```ts
const targets = result.filter(
  (target: any) =>
    target.title ===
    'React Native Experimental (Improved Chrome Reloads)',
);
```

After:

```ts
const targets = result.filter(
  (target: any) =>
    target.title.includes('(Improved Chrome Reloads)'),
);
```

## Test Plan

_This change does not require any new testing._