### PR TITLE
Update Java version in Github workflow

### DIFF
--- a/.github/workflows/react-native-example.yml
+++ b/.github/workflows/react-native-example.yml
@@ -38,10 +38,10 @@ jobs:
     - uses: actions/setup-node@v2.1.5
       with:
         node-version: 14.x
-    - name: set up JDK 1.8
+    - name: set up JDK
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
     - name: Compute build cache
       run: ${GITHUB_WORKSPACE}/scripts/checksum-android.sh checksum-android.txt
     - uses: actions/cache@v2


### PR DESCRIPTION
Summary:
Update to use Java 11 instead of 1.8.

Aim is to bring parity with the other existing workflows but more importantly fix the build as is broken at the moment.

Differential Revision: D39254936

