### PR TITLE
Fixes RN iOS

### DIFF
--- a/.github/workflows/react-native-example.yml
+++ b/.github/workflows/react-native-example.yml
@@ -38,10 +38,10 @@ jobs:
     - uses: actions/setup-node@v2.1.5
       with:
         node-version: 14.x
-    - name: set up JDK 1.8
+    - name: set up JDK
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
     - name: Compute build cache
       run: ${GITHUB_WORKSPACE}/scripts/checksum-android.sh checksum-android.txt
     - uses: actions/cache@v2

--- a/react-native/ReactNativeFlipperExample/ios/ReactNativeFlipperExample/AppDelegate.m
+++ b/react-native/ReactNativeFlipperExample/ios/ReactNativeFlipperExample/AppDelegate.m
@@ -65,8 +65,7 @@ static void InitializeFlipper(UIApplication* application) {
 - (NSURL*)sourceURLForBridge:(RCTBridge*)bridge {
 #if DEBUG
   return
-      [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index"
-                                                     fallbackResource:nil];
+      [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index"];
 #else
   return [[NSBundle mainBundle] URLForResource:@"main"
                                  withExtension:@"jsbundle"];


### PR DESCRIPTION
Summary:
Update usage of RN `RCTBundleURLProvider` `jsBundleURLForBundleRoot` API.

The previous signature was removed in the current used RN version.

Reference:
https://github.com/facebook/react-native/blob/main/React/Base/RCTBundleURLProvider.h

Differential Revision: D39256797

