### PR TITLE
Update Podfile setup

### DIFF
--- a/docs/getting-started/react-native-ios.mdx
+++ b/docs/getting-started/react-native-ios.mdx
@@ -27,16 +27,14 @@ require_relative '../node_modules/@react-native-community/cli-platform-ios/nativ
 
 target 'your-app-name' do
   config = use_native_modules!
-  use_react_native!(path: config['reactNativePath'])
-
-  # Enables Flipper.
-  #
-  # Note that if you have use_frameworks! enabled, Flipper will not work and
-  # you should disable these next few lines.
-  use_flipper!({'Flipper' => '0.58.0'}) # should match the version of your Flipper client app
-  post_install do |installer|
-    flipper_post_install(installer)
-  end
+  use_react_native!(
+    :path => config[:reactNativePath],
+    # Enables Flipper.
+    #
+    # Note that if you have use_frameworks! enabled, Flipper will not work and
+    # you should disable these next few lines.
+    :flipper_configuration => FlipperConfiguration.enabled(["Debug"], { 'Flipper' => '0.164.0' }),
+  )
 end
 ```
 


### PR DESCRIPTION
`use_flipper` is deprecated, updated the Podfile setup to match the docs for Automatic setup

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The docs for setting up Podfile are out of date and using a method that is deprecated.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. This should just be a brief oneline we can mention in our release notes: https://github.com/facebook/flipper/releases -->

Update React Native - Manual iOS Setup Documentation

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI / output of the test runner and how you invoked it. -->
n/a
