### PR TITLE
Fix electron error during build for desktop plugins

### DIFF
--- a/desktop/pkg-lib/src/runBuild.tsx
+++ b/desktop/pkg-lib/src/runBuild.tsx
@@ -65,9 +65,8 @@ async function runBuild({
       '@ant-design/icons',
       // It is an optional dependency for rollup that we use in react-devtools
       'fsevents',
-      // Allow desktop plugins to build
-      'fs',
-      'path',
+      // Allow desktop plugins that require electron to build (deprecated)
+      'electron',
     ],
     sourcemap: dev ? 'inline' : 'external',
     minify: !dev,

--- a/desktop/pkg-lib/src/runBuild.tsx
+++ b/desktop/pkg-lib/src/runBuild.tsx
@@ -65,6 +65,9 @@ async function runBuild({
       '@ant-design/icons',
       // It is an optional dependency for rollup that we use in react-devtools
       'fsevents',
+      // Allow desktop plugins to build
+      'fs',
+      'path',
     ],
     sourcemap: dev ? 'inline' : 'external',
     minify: !dev,


### PR DESCRIPTION
## Summary

Allow desktop plugin to build

Relevant ticket: https://github.com/facebook/flipper/issues/4139

