### PR TITLE
Back out "Upgrade gradle and maven-publish plugin"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,8 +11,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
-        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.22.0'
+        classpath 'com.android.tools.build:gradle:7.0.4'
+        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.20.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$KOTLIN_VERSION"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.7.10"
         classpath "org.jetbrains.kotlin:kotlin-serialization:$KOTLIN_VERSION"


### PR DESCRIPTION
Summary:
Revert: D39730258 (https://github.com/facebook/flipper/commit/b43d8f5c80babfd2015325b59a0fc475c3674c50)

It is causing some issues with producing the necessary libraries for all supported abis (libevent-core.so)

Differential Revision: D39846721

