### PR TITLE
Feature/android datastore viewer

### DIFF
--- a/android/plugins/datastore-viewer/build.gradle
+++ b/android/plugins/datastore-viewer/build.gradle
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+
+android {
+    namespace "com.facebook.flipper.plugins.datastoreviewer"
+    compileSdkVersion rootProject.compileSdkVersion
+    buildToolsVersion rootProject.buildToolsVersion
+
+    defaultConfig {
+        minSdkVersion rootProject.minSdkVersion
+        targetSdkVersion rootProject.targetSdkVersion
+    }
+
+    dependencies {
+        implementation "org.jetbrains.kotlin:kotlin-stdlib:$KOTLIN_VERSION"
+        implementation project(':android')
+        implementation deps.protobuf
+        implementation deps.datastorePreferencesCore
+    }
+}
+
+apply plugin: 'com.vanniktech.maven.publish'

--- a/android/plugins/datastore-viewer/gradle.properties
+++ b/android/plugins/datastore-viewer/gradle.properties
@@ -1,0 +1,11 @@
+#
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the LICENSE
+# file in the root directory of this source tree.
+#
+
+POM_NAME=Flipper Datastore Viewer
+POM_DESCRIPTION=Datastore Viewer plugin for Flipper
+POM_ARTIFACT_ID=flipper-datastore-viewer
+POM_PACKAGING=aar

--- a/android/plugins/datastore-viewer/src/main/java/com/facebook/flipper/plugins/datastoreviewer/DataStoreFlipperPlugin.kt
+++ b/android/plugins/datastore-viewer/src/main/java/com/facebook/flipper/plugins/datastoreviewer/DataStoreFlipperPlugin.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.flipper.plugins.datastoreviewer
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import com.facebook.flipper.core.FlipperConnection
+import com.facebook.flipper.core.FlipperObject
+import com.facebook.flipper.core.FlipperPlugin
+import com.google.protobuf.GeneratedMessageLite
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+
+class DataStoreFlipperPlugin(private val dataStoresMap: Map<String, DataStore<*>>) : FlipperPlugin {
+
+  private var jobs: List<Job>? = null
+
+  override fun getId(): String {
+    return "DataStore"
+  }
+
+  override fun onConnect(connection: FlipperConnection) {
+    registerSetDataStoreReceiver(connection)
+    registerDeleteDataStoreReceiver(connection)
+    collectAllDataStores(connection)
+  }
+
+  override fun onDisconnect() {
+    jobs?.forEach { it.cancel() }
+    jobs = null
+  }
+
+  override fun runInBackground(): Boolean {
+    return false
+  }
+
+  @Suppress("UNCHECKED_CAST", "IMPLICIT_CAST_TO_ANY")
+  private fun registerSetDataStoreReceiver(connection: FlipperConnection) {
+    connection.receive("setDataStoreItem") { params, responder ->
+      val preferencesFileName = params.getString("dataStoreName")
+      val preferenceName = params.getString("preferenceName")
+      runBlocking {
+        (getDataStore(preferencesFileName) as DataStore<Any>).updateData {
+          val value = params.get("preferenceValue")
+          when (it) {
+            is Preferences -> it.setData(preferenceName, value)
+            else -> (it as GeneratedMessageLite<*, *>).setData(preferenceName, value)
+          }
+        }
+      }
+      responder.success()
+    }
+  }
+
+  @Suppress("UNCHECKED_CAST")
+  private fun registerDeleteDataStoreReceiver(connection: FlipperConnection) {
+    connection.receive("deleteDataStoreItem") { params, responder ->
+      val preferencesFileName = params.getString("dataStoreName")
+      val preferenceName = params.getString("preferenceName")
+      runBlocking {
+        (getDataStore(preferencesFileName) as DataStore<Any>).updateData {
+          when (it) {
+            is Preferences -> it.deleteData(preferenceName)
+            else -> throw IllegalArgumentException("type: $it\nDelete ${it.javaClass.simpleName} is not supported!!")
+          }
+        }
+      }
+      responder.success()
+    }
+  }
+
+  private fun collectAllDataStores(connection: FlipperConnection) {
+    jobs = dataStoresMap.map { (key, value) ->
+      CoroutineScope(Dispatchers.IO).launch {
+        value.data.collectLatest {
+          connection.send("dataStoreChange", toFlipperObject(key, value))
+        }
+      }
+    }
+  }
+
+  private fun getDataStore(name: String): DataStore<*> {
+    return dataStoresMap[name]
+      ?: throw IllegalStateException("Unknown datastore $name")
+  }
+
+  private fun toFlipperObject(name: String, dataStore: DataStore<*>): FlipperObject {
+    val dataStoreFlipperObject = when (val data = runBlocking { dataStore.data.first() }) {
+      is Preferences -> data.toFlipperObject()
+      else -> (data as GeneratedMessageLite<*, *>).toFlipperObject()
+    }
+    return FlipperObject.Builder()
+      .put(name, dataStoreFlipperObject)
+      .build()
+  }
+}

--- a/android/plugins/datastore-viewer/src/main/java/com/facebook/flipper/plugins/datastoreviewer/PreferencesUtils.kt
+++ b/android/plugins/datastore-viewer/src/main/java/com/facebook/flipper/plugins/datastoreviewer/PreferencesUtils.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.flipper.plugins.datastoreviewer
+
+import androidx.datastore.preferences.core.Preferences
+import com.facebook.flipper.core.FlipperObject
+
+@Suppress("UNCHECKED_CAST")
+internal fun Preferences.setData(name: String, value: Any): Preferences {
+  return toMutablePreferences().apply {
+    val (originalKey, originalValue) = asMap().entries.first { it.key.name == name }
+    if (originalValue is Set<*>) {
+      throw IllegalArgumentException("key: $name value: ${originalValue}\nType ${originalValue.javaClass.simpleName} is not supported!!")
+    }
+    set(originalKey as Preferences.Key<Any>, value)
+  }
+}
+
+internal fun Preferences.deleteData(name: String): Preferences {
+  return toMutablePreferences().apply {
+    val originalEntry = asMap().entries.firstOrNull { it.key.name == name }
+      ?: throw IllegalArgumentException("key: $name\nvalue is null!!")
+    remove(originalEntry.key)
+  }
+}
+
+internal fun Preferences.toFlipperObject(): FlipperObject {
+  return FlipperObject.Builder().apply {
+    asMap().forEach { (key, value) ->
+      put(key.name, value)
+    }
+  }.build()
+}

--- a/android/plugins/datastore-viewer/src/main/java/com/facebook/flipper/plugins/datastoreviewer/ProtoUtils.kt
+++ b/android/plugins/datastore-viewer/src/main/java/com/facebook/flipper/plugins/datastoreviewer/ProtoUtils.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.flipper.plugins.datastoreviewer
+
+import com.facebook.flipper.core.FlipperObject
+import com.google.protobuf.GeneratedMessageLite
+import java.lang.reflect.Modifier
+
+internal fun GeneratedMessageLite<*, *>.setData(
+  name: String,
+  value: Any,
+): GeneratedMessageLite<*, *> {
+  return toBuilder().apply {
+    val instance = javaClass.superclass.getDeclaredField("instance")
+      .apply { isAccessible = true }
+      .get(this)
+    val field = instance.javaClass.getDeclaredField(name)
+      .apply { isAccessible = true }
+
+    runCatching {
+      field.set(instance, value)
+    }.onFailure {
+      val newValue = when (val originalValue = field.get(instance)) {
+        is Float -> (value as Double).toFloat()
+        else -> {
+          throw IllegalArgumentException("key: $name originalValue: $originalValue newValue: ${value}\nTypeCast ${value.javaClass.simpleName} to ${originalValue.javaClass.simpleName} is not supported!!")
+        }
+      }
+      field.set(instance, newValue)
+    }
+  }.build()
+}
+
+internal fun GeneratedMessageLite<*, *>.toFlipperObject(): FlipperObject {
+  return FlipperObject.Builder().apply {
+    this@toFlipperObject.javaClass.declaredFields
+      .filterNot { Modifier.isStatic(it.modifiers) }
+      .forEach {
+        it.isAccessible = true
+        put(it.name, it.get(this@toFlipperObject))
+      }
+  }.build()
+}

--- a/android/sample/AndroidManifest.xml
+++ b/android/sample/AndroidManifest.xml
@@ -93,6 +93,8 @@
         android:exported="true"/>
     <activity android:name="com.facebook.flipper.connectivitytest.ConnectionTestActivity"
         android:exported="true"/>
+    <activity android:name="com.facebook.flipper.sample.datastore.DataStoreTestActivity"
+        android:exported="true"/>
   </application>
 
 </manifest>

--- a/android/sample/build.gradle
+++ b/android/sample/build.gradle
@@ -6,6 +6,8 @@
  */
 
 apply plugin: 'com.android.application'
+apply plugin: 'kotlin-android'
+apply plugin: 'com.google.protobuf'
 
 android {
     compileSdkVersion rootProject.compileSdkVersion
@@ -42,6 +44,9 @@ android {
 
 
 dependencies {
+    // Kotlin
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$KOTLIN_VERSION"
+
     // Android Support Library
     implementation deps.supportAppCompat
 
@@ -57,6 +62,8 @@ dependencies {
     implementation deps.soloader
     implementation deps.okhttp3
     implementation deps.fresco
+    implementation deps.protobuf
+    implementation deps.datastorePreferences
 
     // Integration test
     androidTestImplementation deps.testCore
@@ -72,5 +79,21 @@ dependencies {
     debugImplementation project(':fresco-plugin')
     debugImplementation project(':network-plugin')
     debugImplementation project(':litho-plugin')
+    debugImplementation project(':datastore-viewer')
     releaseImplementation project(':noop')
+}
+
+protobuf {
+    protoc {
+        artifact = "com.google.protobuf:protoc:3.18.0"
+    }
+    generateProtoTasks {
+        all().each { task ->
+            task.builtins {
+                java {
+                    option 'lite'
+                }
+            }
+        }
+    }
 }

--- a/android/sample/build.gradle
+++ b/android/sample/build.gradle
@@ -49,6 +49,7 @@ dependencies {
 
     // Android Support Library
     implementation deps.supportAppCompat
+    implementation deps.supportRecyclerView
 
     // Litho
     implementation deps.lithoCore

--- a/android/sample/src/debug/java/com/facebook/flipper/sample/FlipperInitializer.java
+++ b/android/sample/src/debug/java/com/facebook/flipper/sample/FlipperInitializer.java
@@ -27,6 +27,7 @@ import com.facebook.flipper.plugins.uidebugger.UIDebuggerFlipperPlugin;
 import com.facebook.flipper.plugins.uidebugger.descriptors.DescriptorRegister;
 import com.facebook.flipper.plugins.uidebugger.litho.UIDebuggerLithoSupport;
 import com.facebook.flipper.plugins.uidebugger.observers.TreeObserverFactory;
+import com.facebook.flipper.sample.datastore.DataStoreHelperKt;
 import com.facebook.litho.config.ComponentsConfiguration;
 import com.facebook.litho.editor.flipper.LithoFlipperDescriptors;
 

--- a/android/sample/src/debug/java/com/facebook/flipper/sample/FlipperInitializer.java
+++ b/android/sample/src/debug/java/com/facebook/flipper/sample/FlipperInitializer.java
@@ -9,9 +9,11 @@ package com.facebook.flipper.sample;
 
 import android.app.Application;
 import android.content.Context;
+
 import com.facebook.flipper.core.FlipperClient;
 import com.facebook.flipper.plugins.crashreporter.CrashReporterPlugin;
 import com.facebook.flipper.plugins.databases.DatabasesFlipperPlugin;
+import com.facebook.flipper.plugins.datastoreviewer.DataStoreFlipperPlugin;
 import com.facebook.flipper.plugins.example.ExampleFlipperPlugin;
 import com.facebook.flipper.plugins.fresco.FrescoFlipperPlugin;
 import com.facebook.flipper.plugins.inspector.DescriptorMapping;
@@ -27,8 +29,11 @@ import com.facebook.flipper.plugins.uidebugger.litho.UIDebuggerLithoSupport;
 import com.facebook.flipper.plugins.uidebugger.observers.TreeObserverFactory;
 import com.facebook.litho.config.ComponentsConfiguration;
 import com.facebook.litho.editor.flipper.LithoFlipperDescriptors;
+
 import java.util.Arrays;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
+
 import okhttp3.OkHttpClient;
 
 public final class FlipperInitializer {
@@ -68,6 +73,12 @@ public final class FlipperInitializer {
     client.addPlugin(
         new UIDebuggerFlipperPlugin(
             (Application) context, descriptorRegister, treeObserverFactory));
+    client.addPlugin(new DataStoreFlipperPlugin(
+        Map.of(
+            DataStoreHelperKt.KEY_DATASTORE_1, DataStoreHelperKt.getDatastore1(context),
+            DataStoreHelperKt.KEY_DATASTORE_2, DataStoreHelperKt.getDatastore2(context)
+        )
+    ));
     client.start();
 
     final OkHttpClient okHttpClient =

--- a/android/sample/src/main/java/com/facebook/flipper/sample/DataStoreHelper.kt
+++ b/android/sample/src/main/java/com/facebook/flipper/sample/DataStoreHelper.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.flipper.sample
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.dataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.doublePreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.floatPreferencesKey
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.core.stringSetPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import com.google.protobuf.ByteString
+import kotlinx.coroutines.runBlocking
+
+const val KEY_DATASTORE_1 = "DATASTORE_1"
+const val KEY_DATASTORE_2 = "DATASTORE_2"
+
+val Context.datastore1 by preferencesDataStore(KEY_DATASTORE_1)
+val Context.datastore2 by dataStore(KEY_DATASTORE_2, ProtoSerializer)
+
+fun Context.initDataStore() {
+  datastore1.initPreferencesDataStore()
+  datastore2.initSampleProtoDataStore()
+}
+
+private val SAMPLE_BOOLEAN = booleanPreferencesKey("SAMPLE_BOOLEAN")
+private val SAMPLE_INTEGER = intPreferencesKey("SAMPLE_INTEGER")
+private val SAMPLE_LONG = longPreferencesKey("SAMPLE_LONG")
+private val SAMPLE_FLOAT = floatPreferencesKey("SAMPLE_FLOAT")
+private val SAMPLE_DOUBLE = doublePreferencesKey("SAMPLE_DOUBLE")
+private val SAMPLE_STRING = stringPreferencesKey("SAMPLE_STRING")
+private val SAMPLE_STRING_SET = stringSetPreferencesKey("SAMPLE_STRING_SET")
+
+fun DataStore<Preferences>.initPreferencesDataStore() {
+  runBlocking {
+    edit {
+      it.clear()
+      it[SAMPLE_BOOLEAN] = false
+      it[SAMPLE_INTEGER] = 123
+      it[SAMPLE_LONG] = 456L
+      it[SAMPLE_FLOAT] = 7.8f
+      it[SAMPLE_DOUBLE] = 9.0
+      it[SAMPLE_STRING] = "SAMPLE_STRING"
+      it[SAMPLE_STRING_SET] = setOf("STRING:1", "STRING:2")
+    }
+  }
+}
+
+fun DataStore<SampleProto>.initSampleProtoDataStore() {
+  runBlocking {
+    updateData {
+      SampleProto.newBuilder().apply {
+        sampleBoolean = false
+        sampleInteger = 123
+        sampleLong = 456L
+        sampleFloat = 7.8f
+        sampleDouble = 9.0
+        sampleString = "SAMPLE_STRING"
+        sampleBytes = ByteString.copyFrom("SAMPLE_BYTES".encodeToByteArray())
+        sampleEnum = SampleProto.SampleEnum.NORTH
+      }.build()
+    }
+  }
+}

--- a/android/sample/src/main/java/com/facebook/flipper/sample/FlipperSampleApplication.java
+++ b/android/sample/src/main/java/com/facebook/flipper/sample/FlipperSampleApplication.java
@@ -7,6 +7,8 @@
 
 package com.facebook.flipper.sample;
 
+import static com.facebook.flipper.sample.DataStoreHelperKt.initDataStore;
+
 import android.app.Application;
 import android.content.Context;
 import android.database.DatabaseUtils;
@@ -42,5 +44,7 @@ public class FlipperSampleApplication extends Application {
 
     DatabaseUtils.queryNumEntries(db1Helper.getReadableDatabase(), "db1_first_table", null, null);
     DatabaseUtils.queryNumEntries(db2Helper.getReadableDatabase(), "db2_first_table", null, null);
+
+    initDataStore(this);
   }
 }

--- a/android/sample/src/main/java/com/facebook/flipper/sample/FlipperSampleApplication.java
+++ b/android/sample/src/main/java/com/facebook/flipper/sample/FlipperSampleApplication.java
@@ -7,7 +7,7 @@
 
 package com.facebook.flipper.sample;
 
-import static com.facebook.flipper.sample.DataStoreHelperKt.initDataStore;
+import static com.facebook.flipper.sample.datastore.DataStoreHelperKt.initDataStore;
 
 import android.app.Application;
 import android.content.Context;

--- a/android/sample/src/main/java/com/facebook/flipper/sample/ProtoSerializer.kt
+++ b/android/sample/src/main/java/com/facebook/flipper/sample/ProtoSerializer.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.flipper.sample
+
+import androidx.datastore.core.CorruptionException
+import androidx.datastore.core.Serializer
+import androidx.datastore.preferences.protobuf.InvalidProtocolBufferException
+import java.io.InputStream
+import java.io.OutputStream
+
+object ProtoSerializer : Serializer<SampleProto> {
+
+  override val defaultValue: SampleProto = SampleProto.getDefaultInstance()
+
+  override suspend fun readFrom(input: InputStream): SampleProto {
+    try {
+      return SampleProto.parseFrom(input)
+    } catch (exception: InvalidProtocolBufferException) {
+      throw CorruptionException("Cannot read proto.", exception)
+    }
+  }
+
+  override suspend fun writeTo(t: SampleProto, output: OutputStream) = t.writeTo(output)
+}

--- a/android/sample/src/main/java/com/facebook/flipper/sample/RootComponentSpec.java
+++ b/android/sample/src/main/java/com/facebook/flipper/sample/RootComponentSpec.java
@@ -11,6 +11,7 @@ import android.content.Intent;
 import com.facebook.drawee.backends.pipeline.Fresco;
 import com.facebook.drawee.interfaces.DraweeController;
 import com.facebook.flipper.android.diagnostics.FlipperDiagnosticActivity;
+import com.facebook.flipper.sample.datastore.DataStoreTestActivity;
 import com.facebook.flipper.sample.network.NetworkClient;
 import com.facebook.litho.ClickEvent;
 import com.facebook.litho.Column;
@@ -116,8 +117,15 @@ public class RootComponentSpec {
                     .clickHandler(RootComponent.openIncrementActivity(c)))
             .child(
                 Text.create(c)
-                    .text("Crash this app")
+                    .text("Navigate to datastore test page")
                     .key("12")
+                    .marginDip(YogaEdge.ALL, 10)
+                    .textSizeSp(20)
+                    .clickHandler(RootComponent.openDataStoreTestActivity(c)))
+            .child(
+                Text.create(c)
+                    .text("Crash this app")
+                    .key("13")
                     .marginDip(YogaEdge.ALL, 10)
                     .textSizeSp(20)
                     .clickHandler(RootComponent.triggerCrash(c)))
@@ -201,6 +209,12 @@ public class RootComponentSpec {
   @OnEvent(ClickEvent.class)
   static void openIncrementActivity(final ComponentContext c) {
     final Intent intent = new Intent(c.getAndroidContext(), ButtonsActivity.class);
+    c.getAndroidContext().startActivity(intent);
+  }
+
+  @OnEvent(ClickEvent.class)
+  static void openDataStoreTestActivity(final ComponentContext c) {
+    final Intent intent = new Intent(c.getAndroidContext(), DataStoreTestActivity.class);
     c.getAndroidContext().startActivity(intent);
   }
 }

--- a/android/sample/src/main/java/com/facebook/flipper/sample/datastore/DataStoreAdapter.kt
+++ b/android/sample/src/main/java/com/facebook/flipper/sample/datastore/DataStoreAdapter.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.flipper.sample.datastore
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.facebook.flipper.sample.R
+
+data class DataStorePair(val key: String, val value: Any)
+
+class DataStoreAdapter : ListAdapter<DataStorePair, DataStoreAdapter.ViewHolder>(DiffCallback()) {
+
+  override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+    return LayoutInflater.from(parent.context)
+      .inflate(R.layout.item_datastore, parent, false)
+      .let { ViewHolder(it) }
+  }
+
+  override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+    val item = getItem(position)
+    holder.bind(item)
+  }
+
+  class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+    fun bind(item: DataStorePair) {
+      itemView.findViewById<TextView>(R.id.key_text_view).text = item.key
+      itemView.findViewById<TextView>(R.id.type_text_view).text =
+        item.value.javaClass.simpleName
+      itemView.findViewById<TextView>(R.id.value_text_view).text = item.value.toString()
+    }
+  }
+
+  private class DiffCallback : DiffUtil.ItemCallback<DataStorePair>() {
+    override fun areItemsTheSame(oldItem: DataStorePair, newItem: DataStorePair): Boolean {
+      return oldItem.key == newItem.key
+    }
+
+    override fun areContentsTheSame(oldItem: DataStorePair, newItem: DataStorePair): Boolean {
+      return oldItem == newItem
+    }
+  }
+}

--- a/android/sample/src/main/java/com/facebook/flipper/sample/datastore/DataStoreHelper.kt
+++ b/android/sample/src/main/java/com/facebook/flipper/sample/datastore/DataStoreHelper.kt
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package com.facebook.flipper.sample
+package com.facebook.flipper.sample.datastore
 
 import android.content.Context
 import androidx.datastore.core.DataStore
@@ -20,6 +20,7 @@ import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import com.facebook.flipper.sample.SampleProto
 import com.google.protobuf.ByteString
 import kotlinx.coroutines.runBlocking
 

--- a/android/sample/src/main/java/com/facebook/flipper/sample/datastore/DataStoreTestActivity.kt
+++ b/android/sample/src/main/java/com/facebook/flipper/sample/datastore/DataStoreTestActivity.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.flipper.sample.datastore
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.recyclerview.widget.RecyclerView
+import com.facebook.flipper.sample.NavigationFacade
+import com.facebook.flipper.sample.R
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+
+class DataStoreTestActivity : AppCompatActivity() {
+
+  private val preferenceAdapter = DataStoreAdapter()
+  private val protoAdapter = DataStoreAdapter()
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    NavigationFacade.sendNavigationEvent("flipper://datastore_test_activity/")
+    setContentView(R.layout.activity_datastore)
+
+    findViewById<RecyclerView>(R.id.preference_datastore_recycler_view).adapter = preferenceAdapter
+    CoroutineScope(Dispatchers.IO).launch {
+      datastore1.data.collectLatest {
+        val dataStorePairList = it.asMap().map { (key, value) -> DataStorePair(key.name, value) }
+        preferenceAdapter.submitList(dataStorePairList)
+      }
+    }
+
+    findViewById<RecyclerView>(R.id.proto_datastore_recycler_view).adapter = protoAdapter
+    CoroutineScope(Dispatchers.IO).launch {
+      datastore2.data.collectLatest { proto ->
+        val dataStorePairList = listOf(
+          DataStorePair("sample_boolean", proto.sampleBoolean),
+          DataStorePair("sample_integer", proto.sampleInteger),
+          DataStorePair("sample_long", proto.sampleLong),
+          DataStorePair("sample_float", proto.sampleFloat),
+          DataStorePair("sample_double", proto.sampleDouble),
+          DataStorePair("sample_string", proto.sampleString),
+          DataStorePair("sample_bytes", proto.sampleBytes),
+          DataStorePair("sample_enum", proto.sampleEnum),
+        )
+        protoAdapter.submitList(dataStorePairList)
+      }
+    }
+  }
+}

--- a/android/sample/src/main/java/com/facebook/flipper/sample/datastore/ProtoSerializer.kt
+++ b/android/sample/src/main/java/com/facebook/flipper/sample/datastore/ProtoSerializer.kt
@@ -5,11 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package com.facebook.flipper.sample
+package com.facebook.flipper.sample.datastore
 
 import androidx.datastore.core.CorruptionException
 import androidx.datastore.core.Serializer
 import androidx.datastore.preferences.protobuf.InvalidProtocolBufferException
+import com.facebook.flipper.sample.SampleProto
 import java.io.InputStream
 import java.io.OutputStream
 

--- a/android/sample/src/main/proto/SampleProto.proto
+++ b/android/sample/src/main/proto/SampleProto.proto
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+syntax = "proto3";
+
+option java_package = "com.facebook.flipper.sample";
+option java_multiple_files = true;
+
+message SampleProto {
+  bool sample_boolean = 1;
+  int32 sample_integer = 2;
+  int64 sample_long = 3;
+  float sample_float = 4;
+  double sample_double = 5;
+  string sample_string = 6;
+  bytes sample_bytes = 7;
+  enum SampleEnum {
+    EAST = 0;
+    WEST = 1;
+    SOUTH = 2;
+    NORTH = 3;
+  }
+  SampleEnum sample_enum = 8;
+}

--- a/android/sample/src/main/res/layout/activity_datastore.xml
+++ b/android/sample/src/main/res/layout/activity_datastore.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<HorizontalScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:clipToPadding="false"
+    android:padding="16dp">
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Preference DataStore"
+            android:textSize="16sp" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/preference_datastore_recycler_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:clipToPadding="false"
+            android:paddingTop="8dp"
+            android:paddingBottom="8dp"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            tools:itemCount="5"
+            tools:listitem="@layout/item_datastore" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="Proto DataStore"
+            android:textSize="16sp" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/proto_datastore_recycler_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:clipToPadding="false"
+            android:paddingTop="8dp"
+            android:paddingBottom="8dp"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            tools:itemCount="5"
+            tools:listitem="@layout/item_datastore" />
+    </LinearLayout>
+</HorizontalScrollView>

--- a/android/sample/src/main/res/layout/item_datastore.xml
+++ b/android/sample/src/main/res/layout/item_datastore.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TableRow xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:paddingTop="4dp"
+    android:paddingBottom="4dp">
+
+    <TextView
+        android:id="@+id/key_text_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="40dp"
+        android:layout_marginRight="40dp"
+        tools:text="long_long_long_key" />
+
+    <TextView
+        android:id="@+id/type_text_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="40dp"
+        android:layout_marginRight="40dp"
+        tools:text="type" />
+
+    <TextView
+        android:id="@+id/value_text_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        tools:text="very very very long long long very very very long long long very very very long long long value" />
+</TableRow>

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ ext.deps = [
         supportAnnotations : "androidx.annotation:annotation:$ANDROIDX_VERSION",
         supportAppCompat   : "androidx.appcompat:appcompat:$ANDROIDX_VERSION",
         supportCoreUi      : "androidx.legacy:legacy-support-core-ui:$ANDROIDX_VERSION",
-        supportRecyclerView: "androidx.recyclerview:recyclerview:$ANDROIDX_VERSION",
+        supportRecyclerView: "androidx.recyclerview:recyclerview:1.2.1",
         supportConstraintLayout: "androidx.constraintlayout:constraintlayout:2.1.4",
         supportSqlite      : "androidx.sqlite:sqlite-framework:2.2.0",
         supportEspresso    : 'androidx.test.espresso:espresso-core:3.4.0',

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$KOTLIN_VERSION"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.7.10"
         classpath "org.jetbrains.kotlin:kotlin-serialization:$KOTLIN_VERSION"
+        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.19"
     }
 }
 
@@ -110,5 +111,8 @@ ext.deps = [
         // Plugin dependencies
         frescoFlipper      : 'com.facebook.fresco:flipper:2.6.0',
         frescoStetho       : 'com.facebook.fresco:stetho:2.6.0',
-        fresco             : 'com.facebook.fresco:fresco:2.6.0'
+        fresco             : 'com.facebook.fresco:fresco:2.6.0',
+        // Datastore Viewer
+        datastorePreferences: "androidx.datastore:datastore-preferences:1.0.0",
+        datastorePreferencesCore: "androidx.datastore:datastore-preferences-core:1.0.0",
 ]

--- a/desktop/plugins/public/datastore-viewer/docs/overview.mdx
+++ b/desktop/plugins/public/datastore-viewer/docs/overview.mdx
@@ -1,0 +1,7 @@
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
+The DataStore Viewer plugin enables you to easily inspect and modify the data contained within your android app's DataStore.
+
+Current value of the given datastore automatically appear in Flipper.
+
+You may also edit the values in Flipper. This can be done by clicking on the value of the specific key you wish to edit, editing the value and then pressing enter.

--- a/desktop/plugins/public/datastore-viewer/docs/setup.mdx
+++ b/desktop/plugins/public/datastore-viewer/docs/setup.mdx
@@ -1,0 +1,31 @@
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
+The plugin is for Android only.
+
+## Android
+
+```java
+import com.facebook.flipper.plugins.datastoreviewer.DataStoreFlipperPlugin;
+
+client.addPlugin(
+    new DataStoreFlipperPlugin(
+        Map.of(
+            "name1", getDatastore1(context),
+            "name2", getDatastore2(context)
+        )
+    )
+);
+```
+
+```kotlin
+import com.facebook.flipper.plugins.datastoreviewer.DataStoreFlipperPlugin
+
+client.addPlugin(
+    DataStoreFlipperPlugin(
+        mapOf(
+            "name1" to getDatastore1(context),
+            "name2" to getDatastore2(context)
+        )
+    )
+);
+```

--- a/desktop/plugins/public/datastore-viewer/index.tsx
+++ b/desktop/plugins/public/datastore-viewer/index.tsx
@@ -1,0 +1,138 @@
+import { Heading, FlexColumn, FlexRow, ManagedDataInspector, styled, Select } from 'flipper';
+import { PluginClient, createState, usePlugin, useValue } from 'flipper-plugin';
+import { clone } from 'lodash';
+
+import React from 'react';
+
+type DataStore = Record<string, any>;
+
+type DataStoreChangeEvent = Record<string, DataStore>;
+
+type SetDataStoreParams = {
+    dataStoreName: string;
+    preferenceName: string;
+    preferenceValue: any;
+};
+type DeleteDataStoreParams = {
+    dataStoreName: string;
+    preferenceName: string;
+};
+
+type Events = { dataStoreChange: DataStoreChangeEvent };
+type Methods = {
+    setDataStoreItem: (params: SetDataStoreParams) => Promise<DataStore>;
+    deleteDataStoreItem: (params: DeleteDataStoreParams) => Promise<DataStore>;
+};
+
+export function plugin(client: PluginClient<Events, Methods>) {
+    const selectedDataStoreName = createState<string | null>(
+        null,
+        { persist: 'selectedDataStoreName' },
+    );
+
+    const allDataStores = createState<Record<string, DataStore>>(
+        {},
+        { persist: 'allDataStores' },
+    );
+
+    function setSelectedDataStore(value: string) {
+        selectedDataStoreName.set(value);
+    }
+
+    async function setDataStoreItem(params: SetDataStoreParams) {
+        await client.send('setDataStoreItem', params);
+    }
+
+    async function deleteDataStoreItem(params: DeleteDataStoreParams) {
+        await client.send('deleteDataStoreItem', params);
+    }
+
+    function _updateDataStore(update: { name: string; dataStore: DataStore }) {
+        if (selectedDataStoreName.get() == null) {
+            selectedDataStoreName.set(update.name);
+        }
+        allDataStores.update((draft) => {
+            draft[update.name] = update.dataStore;
+        });
+    }
+
+    client.onMessage('dataStoreChange', (change) => {
+        Object.entries(change)
+            .forEach(([name, dataStore]) => _updateDataStore({ name, dataStore }));
+    });
+
+    return {
+        selectedDataStoreName,
+        allDataStores,
+        setSelectedDataStore,
+        setDataStoreItem,
+        deleteDataStoreItem,
+    };
+}
+
+const InspectorColumn = styled(FlexColumn)({ flexGrow: 0.2 });
+const RootColumn = styled(FlexColumn)({
+    paddingLeft: '16px',
+    paddingRight: '16px',
+    paddingTop: '16px',
+});
+
+export function Component() {
+    const pluginInstance = usePlugin(plugin);
+    const selectedDataStoreName = useValue(pluginInstance.selectedDataStoreName);
+    const allDataStores = useValue(pluginInstance.allDataStores);
+
+    if (selectedDataStoreName == null) {
+        return null;
+    }
+    const dataStore = allDataStores[selectedDataStoreName];
+    if (dataStore == null) {
+        return null;
+    }
+
+    return (
+        <RootColumn grow>
+            <Heading>
+                <span style={{ marginRight: '12px' }}>DataStore File</span>
+                <Select
+                    options={Object.keys(allDataStores)
+                        .reduce((obj, item) => {
+                            obj[item] = item;
+                            return obj;
+                        }, {} as Record<string, string>)}
+                    selected={selectedDataStoreName}
+                    onChange={pluginInstance.setSelectedDataStore}
+                />
+            </Heading>
+            <FlexRow grow scrollable>
+                <InspectorColumn>
+                    <Heading>Inspector</Heading>
+                    <ManagedDataInspector
+                        data={dataStore}
+                        setValue={async (path: Array<string>, value: any) => {
+                            if (dataStore == null) {
+                                return;
+                            }
+                            let newValue = value;
+                            if (path.length === 2 && dataStore) {
+                                newValue = clone(dataStore[path[0]]);
+                                newValue[path[1]] = value;
+                            }
+                            await pluginInstance.setDataStoreItem({
+                                dataStoreName: selectedDataStoreName,
+                                preferenceName: path[0],
+                                preferenceValue: newValue,
+                            });
+                        }}
+                        onDelete={async (path: Array<string>) =>
+                            await pluginInstance.deleteDataStoreItem({
+                                dataStoreName: selectedDataStoreName,
+                                preferenceName: path[0],
+                            })
+                        }
+                    />
+                </InspectorColumn>
+            </FlexRow>
+        </RootColumn>
+    );
+}

--- a/desktop/plugins/public/datastore-viewer/package.json
+++ b/desktop/plugins/public/datastore-viewer/package.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://fbflipper.com/schemas/plugin-package/v2.json",
+  "name": "flipper-plugin-datastore",
+  "id": "DataStore",
+  "version": "0.0.0",
+  "title": "DataStore Viewer",
+  "icon": "apps",
+  "main": "dist/bundle.js",
+  "flipperBundlerEntry": "index.tsx",
+  "license": "MIT",
+  "keywords": [
+    "flipper-plugin"
+  ],
+  "peerDependencies": {
+    "flipper-plugin": "*"
+  },
+  "bugs": {
+    "url": "https://github.com/facebook/flipper/issues"
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -45,3 +45,6 @@ project(':leakcanary2-plugin').projectDir = file('android/plugins/leakcanary2')
 
 include ':retrofit2-protobuf'
 project(':retrofit2-protobuf').projectDir = file('android/plugins/retrofit2-protobuf')
+
+include ':datastore-viewer'
+project(':datastore-viewer').projectDir = file('android/plugins/datastore-viewer')


### PR DESCRIPTION
## Summary
- Add support for DataStore (shared preferences replacement)
  - https://github.com/facebook/flipper/issues/2407

## Changelog
- Create Flipper plug-in that inspects, edits, and deletes androidx.dataStore
  - works with both Preferences and Proto DataStore.

## Test Plan
### Sample App
- build, install & start android sample app
- navigate to datastore test page

### Flipper Desktop App
- start flipper desktop app
- enable `DataStore Viewer` plug-in once
- inspect, edit value by double-click, and delete data by right-click