### PR TITLE
Fix snapshot build on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 jobs:
   snapshot:
     environment:
-      _JAVA_OPTIONS: "-Xmx1500m -XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -XX:ParallelGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2"
+      # _JAVA_OPTIONS: "-Xmx1500m -XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -XX:ParallelGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2"
       TERM: 'dumb'
     executor:
       name: android/android-machine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,11 @@
 version: 2.1
+orbs:
+  android: circleci/android@2.1.2
 executors:
   default-executor:
-    docker:
-      - image: circleci/android:api-30-ndk
-    resource_class: large
+    name: android/android-machine
+    tag: 2021.10.1
+    resource-class: large
 
     environment:
       _JAVA_OPTIONS: "-Xmx1500m -XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -XX:ParallelGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2"
@@ -18,16 +20,21 @@ jobs:
           name: install retry
           command: scripts/install-retry.sh
       - run:
-          name: build and deploy
+          name: build
           command: |
-            yes | sdkmanager "platforms;android-27" || true
-            /tmp/retry -m 3 ./gradlew :android:assembleRelease
+            yes | sdkmanager "platforms;android-30" || true
+            /tmp/retry -m 3 ./gradlew :android:assembleRelease --info
+      - run:
+          name: deploy snapshot
+          command: |
             /tmp/retry -m 3 scripts/publish-android-snapshot.sh
+      - android/save-gradle-cache:
+          cache-prefix: v1a
 workflows:
   version: 2
   build-and-deploy:
     jobs:
-      - snapshot:
-          filters:
-            branches:
-              only: main
+      - snapshot
+#           filters:
+#             branches:
+#               only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,6 @@ orbs:
 jobs:
   snapshot:
     environment:
-      # _JAVA_OPTIONS: "-Xmx1500m -XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -XX:ParallelGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2"
       TERM: 'dumb'
     executor:
       name: android/android-machine
@@ -32,7 +31,7 @@ workflows:
   version: 2
   build-and-deploy:
     jobs:
-      - snapshot
-#           filters:
-#             branches:
-#               only: main
+      - snapshot:
+          filters:
+            branches:
+              only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,19 +1,15 @@
 version: 2.1
 orbs:
   android: circleci/android@2.1.2
-executors:
-  default-executor:
-    name: android/android-machine
-    tag: 2021.10.1
-    resource-class: large
-
+jobs:
+  snapshot:
     environment:
       _JAVA_OPTIONS: "-Xmx1500m -XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -XX:ParallelGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2"
       TERM: 'dumb'
-
-jobs:
-  snapshot:
-    executor: default-executor
+    executor:
+      name: android/android-machine
+      tag: 2021.10.1
+      resource-class: large
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,8 @@ jobs:
       resource-class: large
     steps:
       - checkout
+      - android/restore-gradle-cache:
+          cache-prefix: v1a
       - run:
           name: install retry
           command: scripts/install-retry.sh


### PR DESCRIPTION
It somehow broke with 16983deaaf3ab3ea7584e1b80f5c458204964deb and failed with a fairly unspecific error message: https://app.circleci.com/pipelines/github/facebook/flipper/11548/workflows/5f114b29-edd8-4a12-97c0-97e2b6e2aef3/jobs/6136

This fixes it and also upgrades the build to make use of the new "orb" system Circle CI provides.