### PR TITLE
Fix searching for FlipperClient.h headers in productions builds if PRODUCTION=1 passed

### DIFF
--- a/react-native/react-native-flipper/react-native-flipper.podspec
+++ b/react-native/react-native-flipper/react-native-flipper.podspec
@@ -25,6 +25,10 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,swift}"
   s.pod_target_xcconfig = { "HEADER_SEARCH_PATHS" => "\"${PODS_ROOT}/Headers/Public/FlipperKit\"" }
   s.requires_arc = true
-  s.compiler_flags = compiler_flags
+  if ENV['PRODUCTION'] == '1'
+    Pod::UI.puts "#{s.name}: Found PRODUCTION=1, #{s.name} will be disabled for production builds"
+  else
+    s.compiler_flags = compiler_flags
+  end
   s.dependency "React-Core"
 end


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
In newer builds of react-native if you passed parameters PRODUCTION=1, flipper pods won't get installed
you can see that in their codebase here [react_native_pods.rb](https://github.com/facebook/react-native/blob/6a43fafd78d581f63c664b9af6d10828ac7f77fa/scripts/react_native_pods.rb#L140)

so when building ios `react-native-flipper` set `compiler_flags = '-DFB_SONARKIT_ENABLED=1'` in the podspec file
which initializeFlipper and lead to the following error: 
`node_modules/react-native-flipper/ios/FlipperReactNativeJavaScriptPluginManager.h:12:9: 'FlipperKit/FlipperClient.h' file not found` 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog
use same condition as react-native to wrap `s.compiler_flags = compiler_flags`
and conditionally pass `compiler_flags = '-DFB_SONARKIT_ENABLED=1'` to compiler_flags to avoid build problems 

<!-- Help reviewers and the release process by writing your own changelog entry. This should just be a brief oneline we can mention in our release notes: https://github.com/facebook/flipper/releases -->

## Test Plan
To reproduce
- create new react-native app
- install react-native-flipper `yarn add react-native-flipper`
- run `env PRODUCTION=1  npx pod-install `
- run `yarn ios`

Before patch:
```sh
node_modules/react-native-flipper/ios/FlipperReactNativeJavaScriptPluginManager.h:12:9: 'FlipperKit/FlipperClient.h' file not found
```


After patch:
```sh
▸ Build Succeeded
success Successfully built the app
```

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI / output of the test runner and how you invoked it. -->