### PR TITLE
Pipe through --updater/--no-updater flag for flipper.exe

### DIFF
--- a/desktop/flipper-common/src/settings.tsx
+++ b/desktop/flipper-common/src/settings.tsx
@@ -77,7 +77,7 @@ export type LauncherSettings = {
 };
 
 // Settings that primarily only apply to Electron atm
-// TODO: further separte between flipper-ui config and Electron config
+// TODO: further separate between flipper-ui config and Electron config
 export type ProcessConfig = {
   disabledPlugins: string[];
   lastWindowPosition: {
@@ -90,6 +90,7 @@ export type ProcessConfig = {
   launcherMsg: string | null;
   // Controls whether to delegate to the launcher if present.
   launcherEnabled: boolean;
+  updaterEnabled: boolean;
   // Control whether to suppress "update available" notifications
   suppressPluginUpdateNotifications?: boolean;
 };

--- a/desktop/flipper-server-core/src/utils/__tests__/processConfig.node.tsx
+++ b/desktop/flipper-server-core/src/utils/__tests__/processConfig.node.tsx
@@ -18,6 +18,7 @@ test('config is decoded from env', () => {
       screenCapturePath: '/my/screenshot/path',
       launcherEnabled: false,
       suppressPluginUpdateNotifications: true,
+      updaterEnabled: true,
     }),
   });
 
@@ -28,6 +29,7 @@ test('config is decoded from env', () => {
     screenCapturePath: '/my/screenshot/path',
     launcherEnabled: false,
     suppressPluginUpdateNotifications: true,
+    updaterEnabled: true,
   });
 });
 
@@ -39,5 +41,6 @@ test('config is decoded from env with defaults', () => {
     screenCapturePath: undefined,
     launcherEnabled: true,
     suppressPluginUpdateNotifications: false,
+    updaterEnabled: true,
   });
 });

--- a/desktop/flipper-server-core/src/utils/processConfig.tsx
+++ b/desktop/flipper-server-core/src/utils/processConfig.tsx
@@ -18,7 +18,8 @@ export function loadProcessConfig(env: NodeJS.ProcessEnv): ProcessConfig {
     screenCapturePath: json.screenCapturePath,
     launcherEnabled:
       typeof json.launcherEnabled === 'boolean' ? json.launcherEnabled : true,
-    updaterEnabled: typeof json.updaterEnabled === 'boolean' ? json.updaterEnabled : true,
+    updaterEnabled:
+      typeof json.updaterEnabled === 'boolean' ? json.updaterEnabled : true,
     suppressPluginUpdateNotifications:
       typeof json.suppressPluginUpdateNotifications === 'boolean'
         ? json.suppressPluginUpdateNotifications

--- a/desktop/flipper-server-core/src/utils/processConfig.tsx
+++ b/desktop/flipper-server-core/src/utils/processConfig.tsx
@@ -18,6 +18,7 @@ export function loadProcessConfig(env: NodeJS.ProcessEnv): ProcessConfig {
     screenCapturePath: json.screenCapturePath,
     launcherEnabled:
       typeof json.launcherEnabled === 'boolean' ? json.launcherEnabled : true,
+    updaterEnabled: typeof json.updaterEnabled === 'boolean' ? json.updaterEnabled : true,
     suppressPluginUpdateNotifications:
       typeof json.suppressPluginUpdateNotifications === 'boolean'
         ? json.suppressPluginUpdateNotifications

--- a/desktop/flipper-ui-core/src/chrome/UpdateIndicator.tsx
+++ b/desktop/flipper-ui-core/src/chrome/UpdateIndicator.tsx
@@ -85,6 +85,7 @@ export default function UpdateIndicator() {
       }
     } else if (
       version &&
+      config.updaterEnabled &&
       !config.suppressPluginUpdateNotifications &&
       isProduction()
     ) {

--- a/desktop/flipper-ui-core/src/dispatcher/handleOpenPluginDeeplink.tsx
+++ b/desktop/flipper-ui-core/src/dispatcher/handleOpenPluginDeeplink.tsx
@@ -284,7 +284,7 @@ async function waitForLogin(store: Store) {
 
 async function verifyFlipperIsUpToDate(title: string) {
   const config = getRenderHostInstance().serverConfig.processConfig;
-  if (!isProduction() || isTest() || config.suppressPluginUpdateNotifications) {
+  if (!isProduction() || isTest() || !config.updaterEnabled || config.suppressPluginUpdateNotifications) {
     return;
   }
   const currentVersion = getAppVersion();

--- a/desktop/flipper-ui-core/src/dispatcher/handleOpenPluginDeeplink.tsx
+++ b/desktop/flipper-ui-core/src/dispatcher/handleOpenPluginDeeplink.tsx
@@ -284,7 +284,12 @@ async function waitForLogin(store: Store) {
 
 async function verifyFlipperIsUpToDate(title: string) {
   const config = getRenderHostInstance().serverConfig.processConfig;
-  if (!isProduction() || isTest() || !config.updaterEnabled || config.suppressPluginUpdateNotifications) {
+  if (
+    !isProduction() ||
+    isTest() ||
+    !config.updaterEnabled ||
+    config.suppressPluginUpdateNotifications
+  ) {
     return;
   }
   const currentVersion = getAppVersion();

--- a/desktop/scripts/jest-setup-after.tsx
+++ b/desktop/scripts/jest-setup-after.tsx
@@ -137,6 +137,7 @@ function createStubRenderHost(): RenderHost {
       launcherEnabled: false,
       launcherMsg: null,
       screenCapturePath: `/dev/null`,
+      updaterEnabled: true,
       suppressPluginUpdateNotifications: false,
     },
     settings: {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
In our organization, Flipper is distributed in a version controlled way. As a result, we do not want users to manually update or receive prompts to update when a new version is available. There is already a `--updater` flag in the command line arguments for flipper.exe, but it isn't piped through. This change pipes it through and disables all update related UI when `--no-updater` is passed in.
## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. This should just be a brief oneline we can mention in our release notes: https://github.com/facebook/flipper/releases -->
Support --updater and --no-updater options for flipper.exe

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI / output of the test runner and how you invoked it. -->
Ran `yarn build --win` in flipper/desktop, and launched flipper.exe from flipper/dist/win-unpacked with the `--updater`, `--no-updater` and no flags and ensured the proper behavior was observed (update UI shows by default or when `--updater` is specified, and doesn't show when `--no-updater` is specified).