### PR TITLE
Exclude .circleci folder from docs cleanup

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,4 +25,6 @@ jobs:
           branch: gh-pages
           folder: website/build
           clean: true
+          clean-exclude: |
+            .circleci
           commit-message: "[ci skip] Deploying documentation update"


### PR DESCRIPTION
Without this, our boilplate config gets deleted on every run:

https://github.com/JamesIves/github-pages-deploy-action#additional-build-files-