### PR TITLE
Upgrade dispatch-workflow action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,23 +242,20 @@ jobs:
     steps:
     - name: Publish Workflow Dispatch
       if: ${{ needs.release.outputs.tag != '' }}
-      uses: benc-uk/workflow-dispatch@v1.1
+      uses: benc-uk/workflow-dispatch@v1.2.2
       with:
         workflow: Publish Pods
-        token: ${{ secrets.PERSONAL_TOKEN }}
         ref: ${{ needs.release.outputs.tag }}
     - name: Publish NPM
       if: ${{ needs.release.outputs.tag != '' }}
-      uses: benc-uk/workflow-dispatch@v1.1
+      uses: benc-uk/workflow-dispatch@v1.2.2
       with:
         workflow: Publish NPM
-        token: ${{ secrets.PERSONAL_TOKEN }}
         ref: ${{ needs.release.outputs.tag }}
     - name: Publish Android
       if: ${{ needs.release.outputs.tag != '' }}
-      uses: benc-uk/workflow-dispatch@v1.1
+      uses: benc-uk/workflow-dispatch@v1.2.2
       with:
         workflow: Publish Android
-        token: ${{ secrets.PERSONAL_TOKEN }}
         ref: ${{ needs.release.outputs.tag }}
         inputs: '{"tag": "${{ needs.release.outputs.tag }}"}'


### PR DESCRIPTION
Summary:
It's currently failing and a few according to [the docs](https://github.com/benc-uk/workflow-dispatch) the token we supply shouldn't be necessary.

Test Plan:
Sadly only one way:

testinprod
