### PR TITLE
Fix: WS should not reconnect on 1001

### DIFF
--- a/js/js-flipper/src/client.ts
+++ b/js/js-flipper/src/client.ts
@@ -237,7 +237,7 @@ export class FlipperClient {
     };
     this.ws.onclose = ({code}) => {
       // Some WS implementations do not properly set `wasClean`
-      if (code !== WSCloseCode.NormalClosure) {
+      if (![WSCloseCode.NormalClosure, WSCloseCode.GoingAway].includes(code)) {
         this.reconnect();
       }
     };


### PR DESCRIPTION
Due to bug in ReactNative `WebSocket` implementation, the `ws.close(1000)` method will not carry the provided `onclose` event number. It would close connection with `1001` instead.

Technically, the `1001` also seems as normal status code to close WS connection, so likely we don't wanna use reconnect anyway.

This only impacts older RN versions (iOS), as it was later fixed: https://github.com/facebook/react-native/pull/24950/files

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. This should just be a brief oneline we can mention in our release notes: https://github.com/facebook/flipper/releases -->
- Do not reconnect when WS close code is `1001` - GoingAway

## Test Plan

Run `flipperClient.stop()`, then the connection should not be reconnected (only reproducible on RN env.)

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI / output of the test runner and how you invoked it. -->

