### PR TITLE
Only link react-native-flipper for Debug configuration

### DIFF
--- a/react-native/react-native-flipper/react-native.config.js
+++ b/react-native/react-native-flipper/react-native.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  dependency: {
+    platforms: {
+      ios: {
+        configurations: ['Debug'],
+      },
+    },
+  },
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Use cocoapods `configurations` option to only link react-native-flipper in debug build, this is the same default as what react-native does for the flipper pod.

This fixes issues where react-native-flipper is still included in release build, but not flipper which causes a linking error.

If someone decides to still include flipper in release builds they can override this configuration in their app `react-native.config.js` with something like:

```js
module.exports = {
  dependencies: {
    'react-native-flipper': {
      ios: {
        configurations: ['Debug', 'Release'],
      },
    },
  },
};
```

## Changelog

Only link react-native-flipper for Debug configuration

## Test Plan

Tested by making this change locally in an app and building for both release and debug configurations.

