### PR TITLE
fix(build-utils): await stripSourceMapComment

### DIFF
--- a/desktop/scripts/build-utils.tsx
+++ b/desktop/scripts/build-utils.tsx
@@ -123,7 +123,7 @@ async function compile(
     },
   );
   if (!dev) {
-    stripSourceMapComment(out);
+    await stripSourceMapComment(out);
   }
 }
 
@@ -233,7 +233,7 @@ export async function compileMain() {
     });
     console.log('✅  Compiled main bundle.');
     if (!dev) {
-      stripSourceMapComment(out);
+      await stripSourceMapComment(out);
     }
   } catch (err) {
     die(err);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

I've just packaged Flipper for Gentoo Linux and I wanted to use the system electron instead of bundling its own copy into the flipper executable. To do so I use my custom `electron-builder` and `app-builder` versions, which also allows me to support otherwise unsupported architectures like ppc64. That means skipping the downloading/unzipping/bundling steps for electron, which greatly shortens the overall build process.
Being that fast resulted in countless hours of debugging, because the resulting `app.asar` wouldn't work. At some point I noticed that electron-builder cli was working flawlessly while processing the same exact config through the Javascript API resulted in failure, so I started digging into your scripts and I've noticed that you didn't await `stripSourceMapComment` into `desktop/scripts/build-utils.ts`.
In particular the `compile` function was returning before `stripSourceMapComment` had finished doing its stuff, which ended up messing with electron-builder later.
You didn't notice because you download electron, unzip it, etc which takes enough time to let `stripSourceMapComment` finish its stuff before the actual build starts, but since I skip these steps in order to use system electron I've been able to notice it.


## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. This should just be a brief oneline we can mention in our release notes: https://github.com/facebook/flipper/releases -->

I simply await `stripSourceMapComment` promises in `build-utils`.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI / output of the test runner and how you invoked it. -->

`cd desktop && yarn && yarn build` is enough to test this.

## Additional Suggestions

I also suggest to enable the [no-floating-promises](https://typescript-eslint.io/rules/no-floating-promises/) eslint rule in order to ensure similar mistakes won't happen in the future.