### PR TITLE
feat(network-plugin): add support for optional "gql operation name" in data table

### DIFF
--- a/desktop/plugins/public/network/index.tsx
+++ b/desktop/plugins/public/network/index.tsx
@@ -55,6 +55,7 @@ import {
   formatDuration,
   requestsToText,
   decodeBody,
+  formatOperationName,
 } from './utils';
 import RequestDetails from './RequestDetails';
 import {assembleChunksIfResponseIsComplete} from './chunks';
@@ -660,6 +661,13 @@ const baseColumns: DataTableColumn<Request>[] = [
     title: 'Response Time',
     width: 120,
     visible: false,
+  },
+  {
+    key: 'requestData',
+    title: 'GraphQL operation name',
+    width: 120,
+    visible: false,
+    formatters: formatOperationName,
   },
   {
     key: 'domain',

--- a/desktop/plugins/public/network/utils.tsx
+++ b/desktop/plugins/public/network/utils.tsx
@@ -264,6 +264,15 @@ export function formatStatus(status: number | undefined) {
   return status ? '' + status : '';
 }
 
+export function formatOperationName(requestData: string): string {
+  try {
+    const parsedData = JSON.parse(requestData);
+    return parsedData?.operationName;
+  } catch (_err) {
+    return '';
+  }
+}
+
 export function requestsToText(requests: Request[]): string {
   const request = requests[0];
   if (!request || !request.url) {


### PR DESCRIPTION

## Summary
Using this network tab explorer at a company that works in graphql is very difficult because everything comes from the same HTTP route. I've added support for an optional (not visible by default) "GraphQL operation name" field for people who want to use that.

## Changelog
Adds a new optional column in the desktop network plugin called "GraphQL operation name" which will display the operation name if its available.

## Test Plan
I didn't see much in the way of component testing for this behaviour. Looking for some guidance here. I'm happy to add some if we think that makes sense



https://user-images.githubusercontent.com/17029928/227016610-b6da1ff3-4a7e-45c6-88da-ceaa6fad53ad.mp4



