### PR TITLE
Add option to allow debugging Android services as well

### DIFF
--- a/android/src/main/java/com/facebook/flipper/android/utils/FlipperUtils.java
+++ b/android/src/main/java/com/facebook/flipper/android/utils/FlipperUtils.java
@@ -16,12 +16,17 @@ public final class FlipperUtils {
 
   private FlipperUtils() {}
 
-  public static boolean shouldEnableFlipper(final Context context) {
+  public static boolean shouldEnableFlipper(
+      final Context context, final boolean allowDebuggingServices) {
     return (BuildConfig.IS_INTERNAL_BUILD || BuildConfig.LOAD_FLIPPER_EXPLICIT)
         && !isEndToEndTest()
-        && isMainProcess(context)
+        && (allowDebuggingServices || isMainProcess(context))
         // Flipper has issue with ASAN build. They cannot be concurrently enabled.
         && !BuildConfig.IS_ASAN_BUILD;
+  }
+
+  public static boolean shouldEnableFlipper(final Context context) {
+    return shouldEnableFlipper(context, false);
   }
 
   private static boolean isEndToEndTest() {


### PR DESCRIPTION
Summary:
In React Native for VR we use `FlipperUtils.shouldEnableFlipper()` to determine whether Flipper should be enabled for the given app build.

The problem is that some of our apps are legitimately running as services (e.g. `com.oculus.explore:explore`), so the check added inside Flipper in D5126205 which only enables Flipper for "main application's process".

This diff adds an ability to relax this requirement (as we do want to do it for the RN VR applications)

Differential Revision: D44511667

