### PR TITLE
feat: Update paste argument schema to support specified programming language

### DIFF
--- a/desktop/flipper-plugin-core/src/plugin/Paste.tsx
+++ b/desktop/flipper-plugin-core/src/plugin/Paste.tsx
@@ -13,6 +13,7 @@ export type CreatePasteArgs = {
   showSuccessNotification?: boolean;
   showErrorNotification?: boolean;
   writeToClipboard?: boolean;
+  language?: string;
 };
 
 export type CreatePasteResult = {


### PR DESCRIPTION
Summary: This diff adds a `language` field into `CreatePasteArgs` type to potentially specify programming language in the paste service

Differential Revision: D45701098

