### PR TITLE
update documentation for using react-native-flipper > 0.182.0

### DIFF
--- a/docs/getting-started/react-native.mdx
+++ b/docs/getting-started/react-native.mdx
@@ -37,6 +37,10 @@ Android:
 1. Bump the `FLIPPER_VERSION` variable in `android/gradle.properties`, for example: `FLIPPER_VERSION=0.190.0`.
 2. Run `./gradlew clean` in the `android` directory.
 
+For react-native-flipper > 0.182.0 also modify the `app/build.gradle` file to lock the fresco version to 0.182.0
+`debugImplementation("com.facebook.flipper:flipper-fresco-plugin:0.182.0")`
+
+
 iOS:
 
 react-native version => 0.69.0


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
The current documentation is missing a vital step to using flipper greater than 0.182.0.  This small change should save a lot of time for folks looking to upgrade.
Since fresco is longer packaged with flipper the guidance to upgrade along with the react-native default code for the build.gradle file needs to be updated

## Changelog

update documentation for using react-native-flipper > 0.182.0

## Test Plan

follow current documentation to upgrade with a fresh react-native, note the build failure.
Apply the change outlined in the proposed docs and enjoy the happy.

