### PR TITLE
[android] Remove deprecated kotlin plugin

### DIFF
--- a/android/plugins/leakcanary2/build.gradle
+++ b/android/plugins/leakcanary2/build.gradle
@@ -7,7 +7,6 @@
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 android {

--- a/android/plugins/retrofit2-protobuf/build.gradle
+++ b/android/plugins/retrofit2-protobuf/build.gradle
@@ -7,7 +7,6 @@
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 android {

--- a/android/tutorial/build.gradle
+++ b/android/tutorial/build.gradle
@@ -7,7 +7,6 @@
 
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 android {


### PR DESCRIPTION
[android] Remove deprecated kotlin plugin

Summary:
See https://goo.gle/kotlin-android-extensions-deprecation.

We don't seem to be making use of the extension.

Test Plan:
```
./gradlew :android:assembleDebug
```

CI

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/flipper/pull/4749).
* #4759
* #4758
* #4757
* #4756
* #4755
* #4754
* #4753
* #4752
* #4751
* #4750
* __->__ #4749