### PR TITLE
[android] Upgrade GitHub workflow java version

### DIFF
--- a/.github/workflows/android-sample.yml
+++ b/.github/workflows/android-sample.yml
@@ -11,7 +11,7 @@ jobs:
       - name: set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
       - name: Compute build cache
         run: ./scripts/checksum-android.sh checksum-android.txt
       - uses: actions/cache@v2

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -21,7 +21,7 @@ jobs:
     - name: set up JDK
       uses: actions/setup-java@v1
       with:
-        java-version: 11
+        java-version: 17
     - name: Write GPG Sec Ring
       run: echo '${{ secrets.GPG_KEY_CONTENTS }}' | base64 -d > /tmp/secring.gpg
     - name: Update gradle.properties

--- a/android/plugins/leakcanary2/build.gradle
+++ b/android/plugins/leakcanary2/build.gradle
@@ -7,7 +7,6 @@
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 android {

--- a/android/plugins/retrofit2-protobuf/build.gradle
+++ b/android/plugins/retrofit2-protobuf/build.gradle
@@ -7,7 +7,6 @@
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 android {

--- a/android/tutorial/build.gradle
+++ b/android/tutorial/build.gradle
@@ -7,7 +7,6 @@
 
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 android {

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,7 +27,8 @@ NDK_VERSION=25.1.8937393
 # Gradle internals
 org.gradle.internal.repository.max.retries=10
 org.gradle.internal.repository.initial.backoff=1250
-org.gradle.jvmargs=-Xmx2g -Xms512m -XX:MaxPermSize=1024m -XX:+CMSClassUnloadingEnabled
+# The --add-opens is required for Litho's annotation processor on JDK 17
+org.gradle.jvmargs=-Xmx2g -Xms512m --add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
 systemProp.org.gradle.internal.http.connectionTimeout=120000
 systemProp.org.gradle.internal.http.socketTimeout=120000
 android.useAndroidX=true


### PR DESCRIPTION
[android] Upgrade GitHub workflow java version

Summary:
Version 8 of AGP requires Java 17+. Let's upgrade it here.

There are some flags that are no longer supported, hence the update to gradle.properties.

Test Plan:

- CI

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/flipper/pull/4750).
* #4759
* #4758
* #4757
* #4756
* #4755
* #4754
* #4753
* #4752
* #4751
* __->__ #4750
* #4749