### PR TITLE
[android] Upgrade Kotlin to 1.8.20

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,6 +10,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlinx-serialization'
 
 android {
+    namespace 'com.facebook.flipper'
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
     ndkVersion rootProject.ndkVersion

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,6 +48,11 @@ android {
         }
     }
 
+    compileOptions {
+        targetCompatibility rootProject.javaTargetVersion
+        sourceCompatibility rootProject.javaTargetVersion
+    }
+
     buildFeatures {
         prefab true
     }

--- a/android/no-op/build.gradle
+++ b/android/no-op/build.gradle
@@ -8,6 +8,7 @@
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'com.facebook.flipper'
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
 
@@ -30,10 +31,3 @@ android {
 }
 
 apply plugin: 'com.vanniktech.maven.publish'
-
-task sourcesJar(type: Jar) {
-    from android.sourceSets.main.java.srcDirs
-    classifier = 'sources'
-}
-
-artifacts.add('archives', sourcesJar)

--- a/android/no-op/src/main/AndroidManifest.xml
+++ b/android/no-op/src/main/AndroidManifest.xml
@@ -6,6 +6,5 @@
   ~ file in the root directory of this source tree.
   -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.facebook.flipper">
+<manifest>
 </manifest>

--- a/android/plugins/leakcanary/build.gradle
+++ b/android/plugins/leakcanary/build.gradle
@@ -8,6 +8,7 @@
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'com.facebook.flipper.plugins.leakcanary'
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
 

--- a/android/plugins/leakcanary/src/main/AndroidManifest.xml
+++ b/android/plugins/leakcanary/src/main/AndroidManifest.xml
@@ -6,6 +6,5 @@
   ~ file in the root directory of this source tree.
   -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.facebook.flipper.plugins.leakcanary">
+<manifest>
 </manifest>

--- a/android/plugins/leakcanary2/build.gradle
+++ b/android/plugins/leakcanary2/build.gradle
@@ -10,6 +10,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
 android {
+    namespace 'com.facebook.flipper.plugins.leakcanary2'
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
 

--- a/android/plugins/leakcanary2/build.gradle
+++ b/android/plugins/leakcanary2/build.gradle
@@ -19,6 +19,11 @@ android {
         targetSdkVersion rootProject.targetSdkVersion
     }
 
+    compileOptions {
+        targetCompatibility rootProject.javaTargetVersion
+        sourceCompatibility rootProject.javaTargetVersion
+    }
+
     dependencies {
         compileOnly "org.jetbrains.kotlin:kotlin-stdlib:$KOTLIN_VERSION"
         implementation project(':android')

--- a/android/plugins/leakcanary2/src/main/AndroidManifest.xml
+++ b/android/plugins/leakcanary2/src/main/AndroidManifest.xml
@@ -6,6 +6,5 @@
   ~ file in the root directory of this source tree.
   -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.facebook.flipper.plugins.leakcanary2">
+<manifest>
 </manifest>

--- a/android/plugins/litho/build.gradle
+++ b/android/plugins/litho/build.gradle
@@ -9,6 +9,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace 'com.facebook.flipper.plugins.litho'
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
 

--- a/android/plugins/litho/build.gradle
+++ b/android/plugins/litho/build.gradle
@@ -18,6 +18,11 @@ android {
         targetSdkVersion rootProject.targetSdkVersion
     }
 
+    compileOptions {
+        targetCompatibility rootProject.javaTargetVersion
+        sourceCompatibility rootProject.javaTargetVersion
+    }
+
     dependencies {
         compileOnly deps.lithoAnnotations
         implementation project(':android')

--- a/android/plugins/litho/src/main/AndroidManifest.xml
+++ b/android/plugins/litho/src/main/AndroidManifest.xml
@@ -6,6 +6,5 @@
   ~ file in the root directory of this source tree.
   -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.facebook.flipper.plugins.litho">
+<manifest>
 </manifest>

--- a/android/plugins/network/build.gradle
+++ b/android/plugins/network/build.gradle
@@ -8,6 +8,7 @@
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'com.facebook.flipper.plugins.network'
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
 

--- a/android/plugins/network/src/main/AndroidManifest.xml
+++ b/android/plugins/network/src/main/AndroidManifest.xml
@@ -6,6 +6,5 @@
   ~ file in the root directory of this source tree.
   -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.facebook.flipper.plugins.network">
+<manifest>
 </manifest>

--- a/android/plugins/retrofit2-protobuf/build.gradle
+++ b/android/plugins/retrofit2-protobuf/build.gradle
@@ -19,6 +19,11 @@ android {
         targetSdkVersion rootProject.targetSdkVersion
     }
 
+    compileOptions {
+        targetCompatibility rootProject.javaTargetVersion
+        sourceCompatibility rootProject.javaTargetVersion
+    }
+
     dependencies {
         implementation "org.jetbrains.kotlin:kotlin-stdlib:$KOTLIN_VERSION"
         implementation project(':android')

--- a/android/plugins/retrofit2-protobuf/build.gradle
+++ b/android/plugins/retrofit2-protobuf/build.gradle
@@ -10,6 +10,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
 android {
+    namespace 'com.facebook.flipper.plugins.retrofit2protobuf'
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
 

--- a/android/plugins/retrofit2-protobuf/src/main/AndroidManifest.xml
+++ b/android/plugins/retrofit2-protobuf/src/main/AndroidManifest.xml
@@ -6,6 +6,5 @@
   ~ file in the root directory of this source tree.
   -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.facebook.flipper.plugins.retrofit2protobuf">
+<manifest>
 </manifest>

--- a/android/sample/AndroidManifest.xml
+++ b/android/sample/AndroidManifest.xml
@@ -8,11 +8,8 @@
   -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.facebook.flipper.sample">
+    xmlns:tools="http://schemas.android.com/tools">
   <uses-permission android:name="android.permission.INTERNET" />
-  <uses-sdk android:minSdkVersion="15"
-            android:targetSdkVersion="31"/>
 
   <application
       android:name=".FlipperSampleApplication"

--- a/android/sample/build.gradle
+++ b/android/sample/build.gradle
@@ -13,7 +13,7 @@ android {
     buildToolsVersion rootProject.buildToolsVersion
     ndkVersion rootProject.ndkVersion
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 23
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         applicationId 'com.facebook.flipper.sample'
         targetSdkVersion rootProject.targetSdkVersion

--- a/android/sample/build.gradle
+++ b/android/sample/build.gradle
@@ -12,6 +12,7 @@ android {
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
     ndkVersion rootProject.ndkVersion
+
     defaultConfig {
         minSdkVersion 23
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
@@ -36,8 +37,8 @@ android {
     }
 
     compileOptions {
-        targetCompatibility JavaVersion.VERSION_1_8
-        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility rootProject.javaTargetVersion
+        sourceCompatibility rootProject.javaTargetVersion
     }
 
     packagingOptions {

--- a/android/sample/build.gradle
+++ b/android/sample/build.gradle
@@ -8,6 +8,7 @@
 apply plugin: 'com.android.application'
 
 android {
+    namespace 'com.facebook.flipper.sample'
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
     ndkVersion rootProject.ndkVersion

--- a/android/third-party/AndroidManifest.xml
+++ b/android/third-party/AndroidManifest.xml
@@ -6,5 +6,5 @@
   ~ file in the root directory of this source tree.
   -->
 
-<manifest package="com.facebook.flipper.thirdparty">
+<manifest>
 </manifest>

--- a/android/third-party/build.gradle
+++ b/android/third-party/build.gradle
@@ -9,6 +9,7 @@ apply plugin: 'com.android.library'
 apply from: 'native.gradle'
 
 android {
+    namespace 'com.facebook.flipper.thirdparty'
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
 

--- a/android/third-party/overrides/DoubleConversion/build.gradle
+++ b/android/third-party/overrides/DoubleConversion/build.gradle
@@ -8,6 +8,7 @@
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'com.doubleconversion'
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
     ndkVersion rootProject.ndkVersion

--- a/android/third-party/overrides/Folly/build.gradle
+++ b/android/third-party/overrides/Folly/build.gradle
@@ -8,6 +8,7 @@
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'com.folly'
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
     ndkVersion rootProject.ndkVersion

--- a/android/third-party/overrides/LibEvent/build.gradle
+++ b/android/third-party/overrides/LibEvent/build.gradle
@@ -8,6 +8,7 @@
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'com.libevent'
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
     ndkVersion rootProject.ndkVersion

--- a/android/third-party/overrides/glog/build.gradle
+++ b/android/third-party/overrides/glog/build.gradle
@@ -8,6 +8,7 @@
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'com.glog'
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
     ndkVersion rootProject.ndkVersion

--- a/android/tutorial/build.gradle
+++ b/android/tutorial/build.gradle
@@ -10,6 +10,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
 android {
+    namespace 'com.facebook.flipper.sample.tutorial'
 
     defaultConfig {
         applicationId "com.facebook.flipper.sample.tutorial"

--- a/android/tutorial/build.gradle
+++ b/android/tutorial/build.gradle
@@ -22,8 +22,8 @@ android {
     }
 
     compileOptions {
-        targetCompatibility JavaVersion.VERSION_1_8
-        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility rootProject.javaTargetVersion
+        sourceCompatibility rootProject.javaTargetVersion
     }
 
     buildTypes {
@@ -31,10 +31,6 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
-    }
-
-    kotlinOptions {
-        jvmTarget = "1.8"
     }
 
     packagingOptions {

--- a/android/tutorial/src/main/AndroidManifest.xml
+++ b/android/tutorial/src/main/AndroidManifest.xml
@@ -5,8 +5,7 @@
   ~ file in the root directory of this source tree.
   -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.facebook.flipper.sample.tutorial">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />

--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,7 @@ ext {
     compileSdkVersion = 31
     buildToolsVersion = "30.0.3"
     ndkVersion = "$NDK_VERSION"
+    javaTargetVersion = JavaVersion.VERSION_17
 }
 
 ext.deps = [

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.0'
+        classpath 'com.android.tools.build:gradle:8.0.1'
         classpath 'com.vanniktech:gradle-maven-publish-plugin:0.25.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$KOTLIN_VERSION"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.8.10"

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,3 +33,6 @@ systemProp.org.gradle.internal.http.connectionTimeout=120000
 systemProp.org.gradle.internal.http.socketTimeout=120000
 android.useAndroidX=true
 android.enableJetifier=true
+android.defaults.buildfeatures.buildconfig=true
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ POM_ISSUES_URL=https://github.com/facebook/flipper/issues/
 # Shared version numbers
 LITHO_VERSION=0.44.0
 ANDROIDX_VERSION=1.3.0
-KOTLIN_VERSION=1.6.20
+KOTLIN_VERSION=1.8.20
 FBJNI_VERSION=0.3.0
 SOLOADER_VERSION=0.10.4
 # NDK

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -5,7 +5,6 @@
 
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
-distributionSha256Sum=cb87f222c5585bd46838ad4db78463a5c5f3d336e5e2b98dc7c0c586527351c2
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/xplat/AndroidManifest.xml
+++ b/xplat/AndroidManifest.xml
@@ -6,6 +6,5 @@
   ~ file in the root directory of this source tree.
   -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.facebook.xplat.sonar">
+<manifest>
 </manifest>

--- a/xplat/build.gradle
+++ b/xplat/build.gradle
@@ -8,6 +8,7 @@
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'com.facebook.xplat.sonar'
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
     ndkVersion rootProject.ndkVersion


### PR DESCRIPTION
[android] Upgrade Kotlin to 1.8.20

Summary:
The additional source/target settings should hopefully no longer be necessary with
AGP 8.1:

https://kotlinlang.org/docs/gradle-configure-project.html#gradle-java-toolchains-support

Test Plan:
- CI
- Build sample app
- AS sync

Tasks: T153533673

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/flipper/pull/4753).
* #4759
* #4758
* #4757
* #4756
* #4755
* #4754
* __->__ #4753
* #4752
* #4751