### PR TITLE
[circleci] Bump Android resources

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,13 @@
 version: 2.1
 orbs:
-  android: circleci/android@2.1.2
+  android: circleci/android@2.3.0
 jobs:
   snapshot:
     environment:
       TERM: 'dumb'
     executor:
       name: android/android-machine
-      tag: 2021.10.1
+      tag: 2023.04.1
       resource-class: large
     steps:
       - checkout
@@ -19,7 +19,7 @@ jobs:
       - run:
           name: build
           command: |
-            yes | sdkmanager "platforms;android-30" || true
+            yes | sdkmanager "platforms;android-33" || true
             /tmp/retry -m 3 ./gradlew :android:assembleRelease --info
       - run:
           name: deploy snapshot


### PR DESCRIPTION
Summary:

Fix the current test failures due to the new JDK requirements.

Test Plan:

Hard to dry-run. Best I can offer is the check here using the CircleCI UI:

![Screenshot 2023-05-24 at 11 45 19](https://github.com/facebook/flipper/assets/9906/2197d2cf-b6af-4463-8389-636029e983da)
