### PR TITLE
fix: prefixed plugin package name

### DIFF
--- a/desktop/flipper-server-core/src/plugins/PluginManager.tsx
+++ b/desktop/flipper-server-core/src/plugins/PluginManager.tsx
@@ -27,6 +27,7 @@ import {
   getInstalledPluginDetails,
   getInstalledPlugins,
   getPluginVersionInstallationDir,
+  getPluginDirNameFromPackageName,
   installPluginFromFile,
   removePlugins,
   getUpdatablePlugins,
@@ -129,7 +130,10 @@ export class PluginManager {
       `Downloading plugin "${title}" v${version} from "${downloadUrl}" to "${installationDir}".`,
     );
     const tmpDir = await getTempDirName();
-    const tmpFile = path.join(tmpDir, `${name}-${version}.tgz`);
+    const tmpFile = path.join(
+      tmpDir,
+      `${getPluginDirNameFromPackageName(name)}-${version}.tgz`,
+    );
     try {
       const cancelationSource = axios.CancelToken.source();
       if (await fs.pathExists(installationDir)) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

When distributing plugin over Marketplace. Currently there is an issue with downloading a plugin to `tmp` folder if the plugin `packageName` starts with `@company-prefix/flipper-plugin-name`. It would throw `ENONET` error while trying to stream the response data into `tmp` folder.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. This should just be a brief oneline we can mention in our release notes: https://github.com/facebook/flipper/releases -->
- add support for prefixed plugin package names (`@shopify/flipper-plugin-name`,...)

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI / output of the test runner and how you invoked it. -->
- Try install a plugin from Marketplace which has `/` in the plugin `package.json` `name`.

