### PR TITLE
[Actions] `nodejs-pkg` - Bump `actions/setup-node@v3.6.0` & `actions/checkout@v3.5.3`

### DIFF
--- a/.github/workflows/nodejs-pkg.yml
+++ b/.github/workflows/nodejs-pkg.yml
@@ -1,18 +1,15 @@
 name: PKG Node CI
-
+# This actions runs on 'git push' and PRs
 on: [push, pull_request]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     env:
       pkg-directory: ./desktop/pkg
-
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
+    - uses: actions/checkout@v3.5.3
+    - uses: actions/setup-node@v3.6.0
       with:
         node-version: '18.x'
     - name: install


### PR DESCRIPTION
## Summary:

This diff bumps `actions/setup-node@v3.6.0` & `actions/checkout@v3.5.3`

### Ref.:
- `actions/checkout@v3.5.3` changelog: https://github.com/actions/checkout/releases/tag/v3.5.3
- `actions/setup-node@v3.6.0` changelog: https://github.com/actions/setup-node/releases/tag/v3.6.0

## Changelog:

[GENERAL] [SECURITY] - [Actions] `nodejs-pkg` - Bump `actions/setup-node@v3.6.0` & `actions/checkout@v3.5.3`

## Test Plan

- Workflow should run and work as usual.