### PR TITLE
[Actions] `publish-android` - Bump `actions/`- `checkout@v3.5.3`, `setup-java@v3.11.0` & `cache@v3.3.1`

### DIFF
--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -1,5 +1,5 @@
 name: Publish Android
-
+# This action runs on 'git push tag v*' and worflow dispatch as specified below
 on:
   push:
     tags:
@@ -10,17 +10,15 @@ on:
         description: "Tag to upload artifacts to"
         required: false
 
-
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3.5.3
     - name: set up JDK
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3.11.0
       with:
+        distribution: 'temurin'
         java-version: 17
     - name: Write GPG Sec Ring
       run: echo '${{ secrets.GPG_KEY_CONTENTS }}' | base64 -d > /tmp/secring.gpg
@@ -28,7 +26,7 @@ jobs:
       run: echo -e "signing.secretKeyRingFile=/tmp/secring.gpg\nsigning.keyId=${{ secrets.SIGNING_KEY_ID }}\nsigning.password=${{ secrets.SIGNING_PASSWORD }}\nmavenCentralPassword=${{ secrets.SONATYPE_NEXUS_PASSWORD }}\nmavenCentralUsername=${{ secrets.SONATYPE_NEXUS_USERNAME }}\nSONATYPE_HOST=DEFAULT\nRELEASE_SIGNING_ENABLED=true\nSONATYPE_AUTOMATIC_RELEASE=true" >> gradle.properties
     - name: Compute build cache
       run: ./scripts/checksum-android.sh checksum-android.txt
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3.3.1
       with:
         path: |
           ~/.gradle/caches/modules-*


### PR DESCRIPTION
## Summary:

This diff bumps `actions/checkout@v3.5.3`, `actions/setup-java@v3.11.0` & `actions/cache@v3.3.1`

### Ref.:
- `actions/checkout@v3.5.3` changelog: https://github.com/actions/checkout/releases/tag/v3.5.3
- `actions/setup-java@v3.11.0` changelog: https://github.com/actions/setup-java/releases/tag/v3.11.0
- `actions/cache@v3.3.1` changelog: https://github.com/actions/cache/releases/tag/v3.3.1

## Changelog:

[GENERAL] [SECURITY] - [Actions] `publish-android` - Bump `actions/`- `checkout@v3.5.3`, `setup-java@v3.11.0` & `cache@v3.3.1`

## Test Plan

- Workflow should run and work as usual.