### PR TITLE
[Actions] `publish-npm` - Bump `actions/`- `setup-node@v3.6.0` & `checkout@v3.5.3`

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,4 +1,5 @@
 name: Publish NPM
+# This action runs on 'git push tag v*'
 on:
   push:
     tags:
@@ -13,8 +14,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3.5.3
+      - uses: actions/setup-node@v3.6.0
         with:
           node-version: '18.x'
       - name: Install


### PR DESCRIPTION
## Summary:

This diff bumps `actions/setup-node@v3.6.0` & `actions/checkout@v3.5.3`

### Ref.:
- `actions/checkout@v3.5.3` changelog: https://github.com/actions/checkout/releases/tag/v3.5.3
- `actions/setup-node@v3.6.0` changelog: https://github.com/actions/setup-node/releases/tag/v3.6.0

## Changelog:

[GENERAL] [SECURITY] - [Actions] `publish-npm` - Bump `actions/`- `setup-node@v3.6.0` & `checkout@v3.5.3`

## Test Plan

- Workflow should run and work as usual.