### PR TITLE
[Actions] `publish-pods` - Bump `actions/checkout@v3.5.3` & `peter-evans/create-pull-request@v5.0.2`

### DIFF
--- a/.github/workflows/publish-pods.yml
+++ b/.github/workflows/publish-pods.yml
@@ -1,4 +1,5 @@
 name: Publish Pods
+# This action runs on 'git push tag v*'
 on:
   push:
     tags:
@@ -9,7 +10,7 @@ jobs:
   publish_flipper_pod:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.5.3
 
       - name: Install Dependences
         run: pod repo update
@@ -29,7 +30,7 @@ jobs:
     needs: publish_flipper_pod
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.5.3
 
       - name: Install Dependences
         run: pod repo update
@@ -49,7 +50,7 @@ jobs:
     needs: publish_flipperkit_pod
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.5.3
 
       - name: Update Flipper's Podspec
         run: ./scripts/update-pod-versions.sh ./ ./Flipper.podspec
@@ -123,7 +124,7 @@ jobs:
           git branch
 
       - name: Create PR to Update Podfile.lock
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v5.0.2
         with:
           title: "Automated: Update Podfile.lock"
           body: |


### PR DESCRIPTION
## Summary:

This diff bumps `actions/checkout@v3.5.3` & `peter-evans/create-pull-request@v5.0.2`

### Ref.:
- `actions/checkout@v3.5.3` changelog: https://github.com/actions/checkout/releases/tag/v3.5.3
- `peter-evans/create-pull-request@v5.0.2` changelog: https://github.com/peter-evans/create-pull-request/releases/tag/v5.0.2

## Changelog:

[GENERAL] [SECURITY] - [Actions] `publish-pods` - Bump `actions/checkout@v3.5.3` & `peter-evans/create-pull-request@v5.0.2`

## Test Plan

- Workflow should run and work as usual.