### PR TITLE
[Actions] `react-native-example` - Bump multiple actions

### DIFF
--- a/.github/workflows/react-native-example.yml
+++ b/.github/workflows/react-native-example.yml
@@ -1,5 +1,7 @@
 name: Build React Native example
+# This action runs on 'git push' and PRs
 on: [push, pull_request]
+
 jobs:
   build-react-native-example-ios:
     runs-on: macos-latest
@@ -7,11 +9,11 @@ jobs:
       run:
         working-directory: react-native/ReactNativeFlipperExample
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2.1.5
+    - uses: actions/checkout@v3.5.3
+    - uses: actions/setup-node@v3.6.0
       with:
         node-version: '18.x'
-    - uses: maxim-lobanov/setup-cocoapods@v1
+    - uses: maxim-lobanov/setup-cocoapods@v1.3.0
       with:
         # Path to Podfile.lock file to determine Cocoapods version
         # n.b. doesn't seem to respect cwd:
@@ -34,17 +36,18 @@ jobs:
       run:
         working-directory: react-native/ReactNativeFlipperExample
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2.1.5
+    - uses: actions/checkout@v3.5.3
+    - uses: actions/setup-node@v3.6.0
       with:
         node-version: '18.x'
     - name: set up JDK
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3.11.0
       with:
-        java-version: 11
+        distribution: 'temurin'
+        java-version: '11'
     - name: Compute build cache
       run: ${GITHUB_WORKSPACE}/scripts/checksum-android.sh checksum-android.txt
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3.3.1
       with:
         path: |
           ~/.gradle/caches/modules-*
@@ -67,14 +70,16 @@ jobs:
       run:
         working-directory: react-native/ReactNativeFlipperExample
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2.1.5
+      - uses: actions/checkout@v3.5.3
+      - uses: actions/setup-node@v3.6.0
         with:
           node-version: '18.x'
-      - uses: nuget/setup-nuget@v1
+      - name: Set up NuGet.exe
+      - uses: NuGet/setup-nuget@v1.2.0
         with:
           nuget-version: '5.x'
-      - uses: microsoft/setup-msbuild@v1.1
+      - name: Add msbuild to PATH
+      - uses: microsoft/setup-msbuild@v1.3.1
       - name: Gather environment info
         run: npx envinfo
       - name: Install vcpkg packages


### PR DESCRIPTION
## Summary:

This diff bumps `actions/checkout@v3.5.3`, `actions/setup-node@v3.6.0`, `actions/setup-java@v3.11.0`, `actions/cache@v3.3.1`, `maxim-lobanov/setup-cocoapods@v1.3.0`, `NuGet/setup-nuget@v1.2.0` and `microsoft/setup-msbuild@v1.3.1`

### Ref.:
- `actions/checkout@v3.5.3` changelog: https://github.com/actions/checkout/releases/tag/v3.5.3
- `actions/setup-node@v3.6.0` changelog: https://github.com/actions/setup-node/releases/tag/v3.6.0
- `actions/setup-java@v3.11.0` changelog: https://github.com/actions/setup-java/releases/tag/v3.11.0
- `actions/cache@v3.3.1` changelog: https://github.com/actions/cache/releases/tag/v3.3.1
- `NuGet/setup-nuget@v1.2.0` changelog: https://github.com/NuGet/setup-nuget/releases/tag/v1.2.0
- `microsoft/setup-msbuild@v1.3.1` changelog: https://github.com/microsoft/setup-msbuild/releases/tag/v1.3.1

## Changelog:

[GENERAL] [SECURITY] - [Actions] `react-native-example` - Bump `actions/`- `checkout@v3.5.3`, `setup-node@3.6.0`, `setup-java@v3.11.0`, `cache@v3.3.1`, `maxim-lobanov/setup-cocoapods@v1.3.0`, `NuGet/setup-nuget@v1.2.0` and `microsoft/setup-msbuild@v1.3.1`

## Test Plan

- Workflow should run and work as usual.