### PR TITLE
[Actions] `release` - Switch to `softprops/action-gh-release@v0.1.15`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,12 +31,12 @@ jobs:
           version_assertion_command: 'grep -q "\"version\": \"$version\"" desktop/package.json'
       - name: Create release
         if: ${{ steps.tag-version-commit.outputs.tag != '' }}
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v0.1.15
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ steps.tag-version-commit.outputs.tag }}
-          release_name: ${{ steps.tag-version-commit.outputs.tag }}
+          name: ${{ steps.tag-version-commit.outputs.tag }}
           body: |
             See https://github.com/facebook/flipper/blob/main/desktop/static/CHANGELOG.md
             for full notes.


### PR DESCRIPTION
## Summary:

This diff switches to `softprops/action-gh-release@v0.1.15` for creating a release since `actions/create-release` is *archived* and is **NOT maintained**.

### Ref.:
- `actions/create-release` archived and not maintained notice: https://github.com/actions/create-release
- `softprops/action-gh-release@v0.1.15` changelog: https://github.com/softprops/action-gh-release/releases/tag/v0.1.15

## Changelog:

[GENERAL] [SECURITY] - [Actions] `release` - Switch to `softprops/action-gh-release@v0.1.15` to create a release

## Test Plan

- Workflow should run and work as usual.