### PR TITLE
[Actions] `iOS-dependent-pod-lint` - Bump `actions/checkout@v3.5.3`

### DIFF
--- a/.github/workflows/iOS-dependent-pod-lint.yml
+++ b/.github/workflows/iOS-dependent-pod-lint.yml
@@ -1,4 +1,5 @@
 name: Validate Dependent Podspecs
+# This action runs on push and PRs to below specified paths
 on:
   push:
     paths:
@@ -14,7 +15,7 @@ jobs:
       run:
         working-directory: iOS/Podspecs
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.5.3
       - name: Install Dependences
         run: pod repo update
       - name: Lint Folly
@@ -26,7 +27,7 @@ jobs:
       run:
         working-directory: iOS/Podspecs
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.5.3
       - name: Install Dependences
         run: pod repo update
       - name: Lint Peertalk


### PR DESCRIPTION
## Summary:

This diff bumps `actions/checkout@v3.5.3`

### Ref.:
- `actions/checkout@v3.5.3` changelog: https://github.com/actions/checkout/releases/tag/v3.5.3

## Changelog:

[GENERAL] [SECURITY] - [Actions] `iOS-dependent-pod-lint` - Bump `actions/checkout@v3.5.3`

## Test Plan

- Workflow should run and work as usual.