### PR TITLE
[Breaking] Enforce minimum Node JS to `v18`

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -165,7 +165,7 @@
     "watch": "cross-env TZ=Pacific/Pohnpei node --expose-gc --stack-trace-limit=40 ./node_modules/.bin/jest --watch"
   },
   "engines": {
-    "node": ">=16",
+    "node": ">=18",
     "npm": "use yarn instead",
     "yarn": "^1.16"
   },


### PR DESCRIPTION
## Summary:

Enforce minimum Node JS version to `v18` via `/package.json#engines
`

- Node JS `v16`'s EOL is `2023-09-11`:
https://nodejs.org/en/blog/announcements/nodejs16-eol

- react-native also bumped Node JS to `v18` recently https://github.com/facebook/react-native/pull/37709 (RN `0.73` will probably enforce min Node JS `v18`)

Bumps in CI via:
1. #4898

## Changelog:

[General] [Breaking] - Enforce minimum Node JS `v18`

## Test Plan:

- Should pass tests & builds successfully