### PR TITLE
[Actions] CI - Bump Node JS to `v18` in CI Pipeline

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v3.5.3
     - uses: actions/setup-node@v3.6.0
       with:
-        node-version: '16.x'
+        node-version: '18.x'
     - name: yarn install (with retry)
       uses: nick-fields/retry@v2.8.3
       with:
@@ -33,7 +33,7 @@ jobs:
     - uses: actions/checkout@v3.5.3
     - uses: actions/setup-node@v3.6.0
       with:
-        node-version: '16.x'
+        node-version: '18.x'
     - name: js-flipper - yarn install (with retry)
       uses: nick-fields/retry@v2.8.3
       with:

--- a/.github/workflows/nodejs-doctor.yml
+++ b/.github/workflows/nodejs-doctor.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
       with:
-        node-version: '16.x'
+        node-version: '18.x'
     - name: install
       working-directory: ${{env.doctor-directory}}
       run: yarn

--- a/.github/workflows/nodejs-pkg.yml
+++ b/.github/workflows/nodejs-pkg.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
       with:
-        node-version: '16.x'
+        node-version: '18.x'
     - name: install
       working-directory: ${{env.pkg-directory}}
       run: yarn

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x]
+        node-version: [18.x]
         os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
 
     steps:

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: '16.x'
+          node-version: '18.x'
       - name: Install
         run: yarn
       - name: Set versions

--- a/.github/workflows/react-native-example.yml
+++ b/.github/workflows/react-native-example.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2.1.5
       with:
-        node-version: 16.x
+        node-version: '18.x'
     - uses: maxim-lobanov/setup-cocoapods@v1
       with:
         # Path to Podfile.lock file to determine Cocoapods version
@@ -37,7 +37,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2.1.5
       with:
-        node-version: 16.x
+        node-version: '18.x'
     - name: set up JDK
       uses: actions/setup-java@v1
       with:
@@ -70,7 +70,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2.1.5
         with:
-          node-version: 16.x
+          node-version: '18.x'
       - uses: nuget/setup-nuget@v1
         with:
           nuget-version: '5.x'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
         ref: ${{ needs.release.outputs.tag }}
     - uses: actions/setup-node@v1
       with:
-        node-version: '16.x'
+        node-version: '18.x'
     - name: Install
       uses: nick-invision/retry@v2.6.0
       with:
@@ -88,7 +88,7 @@ jobs:
         ref: ${{ needs.release.outputs.tag }}
     - uses: actions/setup-node@v1
       with:
-        node-version: '16.x'
+        node-version: '18.x'
     - name: Install
       uses: nick-invision/retry@v2.6.0
       with:
@@ -120,7 +120,7 @@ jobs:
         ref: ${{ needs.release.outputs.tag }}
     - uses: actions/setup-node@v1
       with:
-        node-version: '16.x'
+        node-version: '18.x'
     - name: Install
       uses: nick-invision/retry@v2.6.0
       with:
@@ -154,7 +154,7 @@ jobs:
         ref: ${{ needs.release.outputs.tag }}
     - uses: actions/setup-node@v1
       with:
-        node-version: '16.x'
+        node-version: '18.x'
     - name: Install
       uses: nick-invision/retry@v2.0.0
       with:


### PR DESCRIPTION
## Summary

This diff bumps Node JS to `v18` in CI Pipeline.
Related PR:
1. #4897

## Changelog

[General] [Changed] - Bump Node JS to `v18` in CI Pipeline

## Test Plan

- Should pass tests & builds successfully