### PR TITLE
Refactor: Use React & ReactDOM `18.x` features and methods in `flipper-ui-core`

### DIFF
--- a/desktop/flipper-ui-core/src/chrome/ChangelogSheet.tsx
+++ b/desktop/flipper-ui-core/src/chrome/ChangelogSheet.tsx
@@ -7,8 +7,8 @@
  * @format
  */
 
-import {Markdown} from '../ui';
 import React, {Component} from 'react';
+import {Markdown} from '../ui';
 import {reportUsage} from 'flipper-common';
 import {Modal} from 'antd';
 import {Dialog, theme} from 'flipper-plugin';

--- a/desktop/flipper-ui-core/src/chrome/ConsoleLogs.tsx
+++ b/desktop/flipper-ui-core/src/chrome/ConsoleLogs.tsx
@@ -7,8 +7,7 @@
  * @format
  */
 
-import {useMemo} from 'react';
-import React from 'react';
+import React, {useMemo} from 'react';
 import {Console} from 'console-feed';
 import type {Methods} from 'console-feed/lib/definitions/Methods';
 import type {Styles} from 'console-feed/lib/definitions/Styles';

--- a/desktop/flipper-ui-core/src/chrome/DoctorSheet.tsx
+++ b/desktop/flipper-ui-core/src/chrome/DoctorSheet.tsx
@@ -7,6 +7,7 @@
  * @format
  */
 
+import React, {Component} from 'react';
 import {
   FlexColumn,
   styled,
@@ -20,7 +21,6 @@ import {
   FlexBox,
   Checkbox,
 } from '../ui';
-import React, {Component} from 'react';
 import {connect} from 'react-redux';
 import {State as Store} from '../reducers';
 import {

--- a/desktop/flipper-ui-core/src/chrome/ExportDataPluginSheet.tsx
+++ b/desktop/flipper-ui-core/src/chrome/ExportDataPluginSheet.tsx
@@ -7,8 +7,8 @@
  * @format
  */
 
-import {connect} from 'react-redux';
 import React, {Component} from 'react';
+import {connect} from 'react-redux';
 import {State as Store} from '../reducers';
 import ListView from './ListView';
 import {FlexColumn, styled} from '../ui';

--- a/desktop/flipper-ui-core/src/chrome/FlipperDevTools.tsx
+++ b/desktop/flipper-ui-core/src/chrome/FlipperDevTools.tsx
@@ -7,8 +7,8 @@
  * @format
  */
 
-import {Layout} from '../ui';
 import React from 'react';
+import {Layout} from '../ui';
 import {Tab, Tabs} from 'flipper-plugin';
 import {ConsoleLogs} from './ConsoleLogs';
 import {FlipperMessages} from './FlipperMessages';

--- a/desktop/flipper-ui-core/src/chrome/FlipperMessages.tsx
+++ b/desktop/flipper-ui-core/src/chrome/FlipperMessages.tsx
@@ -7,6 +7,7 @@
  * @format
  */
 
+import React, {useCallback, useState} from 'react';
 import {
   DataInspector,
   DataTable,
@@ -24,7 +25,6 @@ import {
   PauseCircleOutlined,
   PlayCircleOutlined,
 } from '@ant-design/icons';
-import React, {useCallback, useState} from 'react';
 
 export type MessageInfo = {
   time?: Date;

--- a/desktop/flipper-ui-core/src/chrome/ListView.tsx
+++ b/desktop/flipper-ui-core/src/chrome/ListView.tsx
@@ -7,6 +7,7 @@
  * @format
  */
 
+import React, {Component} from 'react';
 import {
   Text,
   FlexColumn,
@@ -20,7 +21,6 @@ import {
   Tooltip,
   Glyph,
 } from '../ui';
-import React, {Component} from 'react';
 import {theme} from 'flipper-plugin';
 
 export type SelectionType = 'multiple' | 'single';

--- a/desktop/flipper-ui-core/src/chrome/PluginActions.tsx
+++ b/desktop/flipper-ui-core/src/chrome/PluginActions.tsx
@@ -7,6 +7,7 @@
  * @format
  */
 
+import React, {useMemo, useCallback} from 'react';
 import {
   DownloadOutlined,
   LoadingOutlined,
@@ -14,8 +15,6 @@ import {
 } from '@ant-design/icons';
 import {Alert, Button} from 'antd';
 import {DownloadablePluginDetails} from 'flipper-common';
-import React, {useMemo} from 'react';
-import {useCallback} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import {PluginDefinition} from '../plugin';
 import {startPluginDownload} from '../reducers/pluginDownloads';

--- a/desktop/flipper-ui-core/src/chrome/PluginActionsMenu.tsx
+++ b/desktop/flipper-ui-core/src/chrome/PluginActionsMenu.tsx
@@ -7,6 +7,7 @@
  * @format
  */
 
+import React, {useEffect} from 'react';
 import Icon, {MacCommandOutlined} from '@ant-design/icons';
 import {css} from '@emotion/css';
 import {Button, Menu, MenuItemProps, Row, Tooltip} from 'antd';
@@ -16,7 +17,6 @@ import {
   TrackingScope,
   useTrackedCallback,
 } from 'flipper-plugin';
-import React, {useEffect} from 'react';
 import {getActivePlugin} from '../selectors/connections';
 import {registerShortcut} from '../utils/registerShortcut';
 import {useStore} from '../utils/useStore';

--- a/desktop/flipper-ui-core/src/chrome/ScreenCaptureButtons.tsx
+++ b/desktop/flipper-ui-core/src/chrome/ScreenCaptureButtons.tsx
@@ -7,8 +7,8 @@
  * @format
  */
 
-import {Button as AntButton, message} from 'antd';
 import React, {useState, useCallback} from 'react';
+import {Button as AntButton, message} from 'antd';
 import {capture, getCaptureLocation, getFileName} from '../utils/screenshot';
 import {CameraOutlined, VideoCameraOutlined} from '@ant-design/icons';
 import {useStore} from '../utils/useStore';

--- a/desktop/flipper-ui-core/src/chrome/ShareSheetExportFile.tsx
+++ b/desktop/flipper-ui-core/src/chrome/ShareSheetExportFile.tsx
@@ -7,8 +7,8 @@
  * @format
  */
 
-import {FlexColumn, Button, styled, Text, FlexRow, Spacer} from '../ui';
 import React, {Component} from 'react';
+import {FlexColumn, Button, styled, Text, FlexRow, Spacer} from '../ui';
 import {reportPlatformFailures} from 'flipper-common';
 import {Logger} from 'flipper-common';
 import {IdlerImpl} from '../utils/Idler';

--- a/desktop/flipper-ui-core/src/chrome/ShareSheetExportUrl.tsx
+++ b/desktop/flipper-ui-core/src/chrome/ShareSheetExportUrl.tsx
@@ -7,8 +7,8 @@
  * @format
  */
 
-import {FlexColumn, styled, Text, FlexRow, Spacer, Input} from '../ui';
 import React, {Component} from 'react';
+import {FlexColumn, styled, Text, FlexRow, Spacer, Input} from '../ui';
 import {ReactReduxContext, ReactReduxContextValue} from 'react-redux';
 import {Logger} from 'flipper-common';
 import {IdlerImpl} from '../utils/Idler';

--- a/desktop/flipper-ui-core/src/chrome/ShareSheetPendingDialog.tsx
+++ b/desktop/flipper-ui-core/src/chrome/ShareSheetPendingDialog.tsx
@@ -7,9 +7,9 @@
  * @format
  */
 
+import React from 'react';
 import {Button, Typography} from 'antd';
 import {Layout, Spinner} from 'flipper-plugin';
-import React from 'react';
 
 const {Text} = Typography;
 

--- a/desktop/flipper-ui-core/src/chrome/UpdateIndicator.tsx
+++ b/desktop/flipper-ui-core/src/chrome/UpdateIndicator.tsx
@@ -7,10 +7,10 @@
  * @format
  */
 
+import React, {useEffect, useState} from 'react';
 import {notification, Typography} from 'antd';
 import isProduction from '../utils/isProduction';
 import {reportPlatformFailures, ReleaseChannel} from 'flipper-common';
-import React, {useEffect, useState} from 'react';
 import fbConfig from '../fb-stubs/config';
 import {useStore} from '../utils/useStore';
 import {getAppVersion} from '../utils/info';

--- a/desktop/flipper-ui-core/src/chrome/plugin-manager/PluginDebugger.tsx
+++ b/desktop/flipper-ui-core/src/chrome/plugin-manager/PluginDebugger.tsx
@@ -7,11 +7,11 @@
  * @format
  */
 
+import React, {Component} from 'react';
 import {PluginDetails} from 'flipper-common';
 import {Layout} from 'flipper-plugin';
 import Client from '../../Client';
 import {TableBodyRow} from '../../ui/components/table/types';
-import React, {Component} from 'react';
 import {connect} from 'react-redux';
 import {Text, ManagedTable, styled, colors} from '../../ui';
 import StatusIndicator from '../../ui/components/StatusIndicator';

--- a/desktop/flipper-ui-core/src/chrome/plugin-manager/PluginInstaller.tsx
+++ b/desktop/flipper-ui-core/src/chrome/plugin-manager/PluginInstaller.tsx
@@ -7,9 +7,9 @@
  * @format
  */
 
+import React, {useCallback, useState, useEffect} from 'react';
 import {Layout, theme} from 'flipper-plugin';
 import {LoadingIndicator, TableRows, ManagedTable, Glyph} from '../../ui';
-import React, {useCallback, useState, useEffect} from 'react';
 import {
   reportPlatformFailures,
   reportUsage,

--- a/desktop/flipper-ui-core/src/chrome/plugin-manager/PluginPackageInstaller.tsx
+++ b/desktop/flipper-ui-core/src/chrome/plugin-manager/PluginPackageInstaller.tsx
@@ -7,6 +7,7 @@
  * @format
  */
 
+import React, {useState} from 'react';
 import {
   Button,
   FlexRow,
@@ -16,7 +17,6 @@ import {
   LoadingIndicator,
 } from '../../ui';
 import styled from '@emotion/styled';
-import React, {useState} from 'react';
 import {Toolbar, FileSelector} from 'flipper-plugin';
 import {getRenderHostInstance} from 'flipper-frontend-core';
 

--- a/desktop/flipper-ui-core/src/chrome/settings/KeyboardShortcutInput.tsx
+++ b/desktop/flipper-ui-core/src/chrome/settings/KeyboardShortcutInput.tsx
@@ -7,8 +7,8 @@
  * @format
  */
 
-import {FlexColumn, styled, FlexRow, Text, Glyph} from '../../ui';
 import React, {useRef, useState, useEffect} from 'react';
+import {FlexColumn, styled, FlexRow, Text, Glyph} from '../../ui';
 import {theme} from 'flipper-plugin';
 
 type PressedKeys = {

--- a/desktop/flipper-ui-core/src/chrome/settings/ToggledSection.tsx
+++ b/desktop/flipper-ui-core/src/chrome/settings/ToggledSection.tsx
@@ -7,8 +7,8 @@
  * @format
  */
 
-import {FlexColumn, styled, FlexRow, ToggleButton} from '../../ui';
 import React from 'react';
+import {FlexColumn, styled, FlexRow, ToggleButton} from '../../ui';
 import {theme} from 'flipper-plugin';
 
 const IndentedSection = styled(FlexColumn)({

--- a/desktop/flipper-ui-core/src/chrome/settings/configFields.tsx
+++ b/desktop/flipper-ui-core/src/chrome/settings/configFields.tsx
@@ -7,6 +7,7 @@
  * @format
  */
 
+import React, {useState, useEffect} from 'react';
 import {
   FlexColumn,
   styled,
@@ -16,7 +17,6 @@ import {
   colors,
   Glyph,
 } from '../../ui';
-import React, {useState, useEffect} from 'react';
 import {getFlipperLib, theme} from 'flipper-plugin';
 import {getRenderHostInstance} from 'flipper-frontend-core';
 

--- a/desktop/flipper-ui-core/src/dispatcher/plugins.tsx
+++ b/desktop/flipper-ui-core/src/dispatcher/plugins.tsx
@@ -8,17 +8,17 @@
  */
 
 import type {Store} from '../reducers/index';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import ReactDOMClient from 'react-dom/client';
+import ReactIs from 'react-is';
 import {
   InstalledPluginDetails,
   Logger,
   MarketplacePluginDetails,
 } from 'flipper-common';
 import {PluginDefinition} from '../plugin';
-import React from 'react';
 import * as ReactJsxRuntime from 'react/jsx-runtime';
-import ReactDOM from 'react-dom';
-import ReactDOMClient from 'react-dom/client';
-import ReactIs from 'react-is';
 import {
   registerPlugins,
   addGatekeepedPlugins,

--- a/desktop/flipper-ui-core/src/reducers/notifications.tsx
+++ b/desktop/flipper-ui-core/src/reducers/notifications.tsx
@@ -7,9 +7,9 @@
  * @format
  */
 
+import React from 'react';
 import {Notification} from 'flipper-plugin';
 import {Actions} from './';
-import React from 'react';
 import {getStringFromErrorLike} from 'flipper-common';
 
 export const GLOBAL_NOTIFICATION_PLUGIN_ID = 'Flipper';

--- a/desktop/flipper-ui-core/src/sandy-chrome/DetailSidebarImpl.tsx
+++ b/desktop/flipper-ui-core/src/sandy-chrome/DetailSidebarImpl.tsx
@@ -8,7 +8,7 @@
  */
 
 import React, {useEffect, useState} from 'react';
-import ReactDOM from 'react-dom';
+import {createPortal} from 'react-dom';
 import {toggleRightSidebarAvailable} from '../reducers/application';
 import {useDispatch, useStore} from '../utils/useStore';
 import {ContentContainer} from '../sandy-chrome/ContentContainer';
@@ -68,7 +68,7 @@ export function DetailSidebarImpl({
     (children &&
       rightSidebarVisible &&
       domNode &&
-      ReactDOM.createPortal(
+      createPortal(
         <_Sidebar
           minWidth={minWidth}
           width={width || 300}

--- a/desktop/flipper-ui-core/src/sandy-chrome/LeftRail.tsx
+++ b/desktop/flipper-ui-core/src/sandy-chrome/LeftRail.tsx
@@ -7,7 +7,14 @@
  * @format
  */
 
-import React, {cloneElement, useState, useCallback, useMemo} from 'react';
+import React, {
+  cloneElement,
+  useState,
+  useEffect,
+  useCallback,
+  useMemo,
+} from 'react';
+
 import {
   Button,
   Divider,
@@ -77,7 +84,6 @@ import {openDeeplinkDialog} from '../deeplink';
 import {css} from '@emotion/css';
 import {getRenderHostInstance} from 'flipper-frontend-core';
 import {StyleGuide} from './StyleGuide';
-import {useEffect} from 'react';
 import {isConnected, currentUser, logoutUser} from '../fb-stubs/user';
 
 const LeftRailButtonElem = styled(Button)<{kind?: 'small'}>(({kind}) => ({

--- a/desktop/flipper-ui-core/src/startFlipperDesktop.tsx
+++ b/desktop/flipper-ui-core/src/startFlipperDesktop.tsx
@@ -167,14 +167,8 @@ function init(flipperServer: FlipperServer) {
 
   connectFlipperServerToStore(flipperServer, store, logger);
 
-  // TODO T116224873: Return the following code back instead of ReactDOM.react when the following issue is fixed: https://github.com/react-component/trigger/issues/288
-  // const root = createRoot(document.getElementById('root')!);
-  // root.render(<AppFrame logger={logger} persistor={persistor} />);
-
-  ReactDOM.render(
-    <AppFrame logger={logger} persistor={persistor} />,
-    document.getElementById('root')!,
-  );
+  const root = createRoot(document.getElementById('root') as HTMLElement);
+  root.render(<AppFrame logger={logger} persistor={persistor} />);
 
   enableConsoleHook();
 

--- a/desktop/flipper-ui-core/src/ui/components/ErrorBoundary.tsx
+++ b/desktop/flipper-ui-core/src/ui/components/ErrorBoundary.tsx
@@ -8,12 +8,11 @@
  */
 
 import {CodeBlock} from 'flipper-plugin';
-import {Component, ErrorInfo} from 'react';
+import React, {Component, ErrorInfo} from 'react';
 import Heading from './Heading';
 import Button from './Button';
 import View from './View';
 import styled from '@emotion/styled';
-import React from 'react';
 
 const ErrorBoundaryContainer = styled(View)({
   overflow: 'auto',

--- a/desktop/flipper-ui-core/src/ui/components/ModalOverlay.tsx
+++ b/desktop/flipper-ui-core/src/ui/components/ModalOverlay.tsx
@@ -8,8 +8,7 @@
  */
 
 import styled from '@emotion/styled';
-import {Component} from 'react';
-import React from 'react';
+import React, {Component} from 'react';
 
 const Overlay = styled.div({
   alignItems: 'center',

--- a/desktop/flipper-ui-core/src/ui/components/Orderable.tsx
+++ b/desktop/flipper-ui-core/src/ui/components/Orderable.tsx
@@ -9,8 +9,7 @@
 
 import {Rect} from '../../utils/geometry';
 import styled from '@emotion/styled';
-import {Component} from 'react';
-import React from 'react';
+import React, {Component} from 'react';
 
 export type OrderableOrder = Array<string>;
 

--- a/desktop/flipper-ui-core/src/ui/components/Radio.tsx
+++ b/desktop/flipper-ui-core/src/ui/components/Radio.tsx
@@ -7,9 +7,8 @@
  * @format
  */
 
-import {PureComponent} from 'react';
+import React, {PureComponent} from 'react';
 import styled from '@emotion/styled';
-import React from 'react';
 
 type RadioProps = {
   /** Whether the radio button is checked. */

--- a/desktop/flipper-ui-core/src/ui/components/Select.tsx
+++ b/desktop/flipper-ui-core/src/ui/components/Select.tsx
@@ -7,10 +7,9 @@
  * @format
  */
 
-import {Component, CSSProperties} from 'react';
+import React, {Component, CSSProperties} from 'react';
 import Text from './Text';
 import styled from '@emotion/styled';
-import React from 'react';
 import {theme} from 'flipper-plugin';
 
 const Label = styled.label({

--- a/desktop/flipper-ui-core/src/ui/components/Sidebar.tsx
+++ b/desktop/flipper-ui-core/src/ui/components/Sidebar.tsx
@@ -7,12 +7,11 @@
  * @format
  */
 
+import React, {Component} from 'react';
 import {theme, _Interactive, _InteractiveProps} from 'flipper-plugin';
 import FlexColumn from './FlexColumn';
-import {Component} from 'react';
 import styled from '@emotion/styled';
 import {Property} from 'csstype';
-import React from 'react';
 
 const SidebarInteractiveContainer = styled(_Interactive)<_InteractiveProps>({
   flex: 'none',

--- a/desktop/flipper-ui-core/src/ui/components/Tabs.tsx
+++ b/desktop/flipper-ui-core/src/ui/components/Tabs.tsx
@@ -7,6 +7,7 @@
  * @format
  */
 
+import React, {useContext} from 'react';
 import FlexColumn from './FlexColumn';
 import styled from '@emotion/styled';
 import Orderable from './Orderable';
@@ -14,7 +15,6 @@ import FlexRow from './FlexRow';
 import {colors} from './colors';
 import Tab, {Props as TabProps} from './Tab';
 import {Property} from 'csstype';
-import React, {useContext} from 'react';
 import {TabsContext} from './TabsContainer';
 import {theme, _wrapInteractionHandler} from 'flipper-plugin';
 

--- a/desktop/flipper-ui-core/src/ui/components/Tooltip.tsx
+++ b/desktop/flipper-ui-core/src/ui/components/Tooltip.tsx
@@ -7,9 +7,9 @@
  * @format
  */
 
+import React, {useContext, useCallback, useRef, useEffect} from 'react';
 import {TooltipOptions, TooltipContext} from './TooltipProvider';
 import styled from '@emotion/styled';
-import React, {useContext, useCallback, useRef, useEffect} from 'react';
 
 const TooltipContainer = styled.div({
   display: 'contents',

--- a/desktop/flipper-ui-core/src/ui/components/TooltipProvider.tsx
+++ b/desktop/flipper-ui-core/src/ui/components/TooltipProvider.tsx
@@ -7,11 +7,10 @@
  * @format
  */
 
+import React, {memo, createContext, useMemo, useState, useRef} from 'react';
 import styled from '@emotion/styled';
 import {colors} from './colors';
-import {memo, createContext, useMemo, useState, useRef} from 'react';
 import {Property} from 'csstype';
-import React from 'react';
 
 const defaultOptions = {
   backgroundColor: colors.blueGray,

--- a/desktop/flipper-ui-core/src/ui/components/elements-inspector/Visualizer.tsx
+++ b/desktop/flipper-ui-core/src/ui/components/elements-inspector/Visualizer.tsx
@@ -8,7 +8,7 @@
  */
 
 import React from 'react';
-import ReactDOM from 'react-dom';
+import {createPortal} from 'react-dom';
 import {ElementsInspectorElement} from 'flipper-plugin';
 import styled from '@emotion/styled';
 
@@ -39,7 +39,7 @@ export function VisualizerPortal(props: {
         }
       : null;
 
-  return ReactDOM.createPortal(
+  return createPortal(
     <Visualizer
       screenDimensions={props.screenDimensions}
       element={position}

--- a/desktop/flipper-ui-core/src/ui/components/elements-inspector/sidebar.tsx
+++ b/desktop/flipper-ui-core/src/ui/components/elements-inspector/sidebar.tsx
@@ -7,14 +7,13 @@
  * @format
  */
 
+import React, {Component} from 'react';
 import {ElementsInspectorElement} from 'flipper-plugin';
 import {PluginClient} from '../../../plugin';
 import Client from '../../../Client';
 import {Logger} from 'flipper-common';
 import Panel from '../Panel';
 import {DataInspector} from 'flipper-plugin';
-import {Component} from 'react';
-import React from 'react';
 
 import deepEqual from 'deep-equal';
 

--- a/desktop/flipper-ui-core/src/ui/components/searchable/FilterToken.tsx
+++ b/desktop/flipper-ui-core/src/ui/components/searchable/FilterToken.tsx
@@ -8,10 +8,9 @@
  */
 
 import {Filter} from '../filter/types';
-import {PureComponent} from 'react';
+import React, {PureComponent} from 'react';
 import Text from '../Text';
 import styled from '@emotion/styled';
-import React from 'react';
 import {Property} from 'csstype';
 import {theme} from 'flipper-plugin';
 import {ContextMenuItem, createContextMenu} from '../ContextMenu';

--- a/desktop/flipper-ui-core/src/ui/components/searchable/Searchable.tsx
+++ b/desktop/flipper-ui-core/src/ui/components/searchable/Searchable.tsx
@@ -9,7 +9,7 @@
 
 import {Filter} from '../filter/types';
 import {TableColumns} from '../table/types';
-import {PureComponent} from 'react';
+import React, {PureComponent} from 'react';
 import Input from '../Input';
 import Text from '../Text';
 import FlexBox from '../FlexBox';
@@ -18,7 +18,6 @@ import FilterToken from './FilterToken';
 import styled from '@emotion/styled';
 import {debounce} from 'lodash';
 import ToggleButton from '../ToggleSwitch';
-import React from 'react';
 import {Layout, theme, Toolbar} from 'flipper-plugin';
 import {getRenderHostInstance} from 'flipper-frontend-core';
 

--- a/desktop/flipper-ui-core/src/ui/components/searchable/SearchableTable.tsx
+++ b/desktop/flipper-ui-core/src/ui/components/searchable/SearchableTable.tsx
@@ -8,10 +8,10 @@
  */
 
 import {Filter} from '../filter/types';
+import React, {PureComponent} from 'react';
 import ManagedTable, {ManagedTableProps} from '../table/ManagedTable';
 import {TableBodyRow} from '../table/types';
 import Searchable, {SearchableProps} from './Searchable';
-import React, {PureComponent} from 'react';
 import {textContent} from 'flipper-plugin';
 import deepEqual from 'deep-equal';
 

--- a/desktop/flipper-ui-core/src/ui/components/table/TableHead.tsx
+++ b/desktop/flipper-ui-core/src/ui/components/table/TableHead.tsx
@@ -15,14 +15,13 @@ import {
   TableOnSort,
   TableRowSortOrder,
 } from './types';
+import React, {PureComponent} from 'react';
 import {normalizeColumnWidth, isPercentage} from './utils';
-import {PureComponent} from 'react';
 import ContextMenu, {ContextMenuItem} from '../ContextMenu';
 import {theme, _Interactive, _InteractiveProps} from 'flipper-plugin';
 import styled from '@emotion/styled';
 import {colors} from '../colors';
 import FlexRow from '../FlexRow';
-import React from 'react';
 
 const TableHeaderArrow = styled.span({
   float: 'right',


### PR DESCRIPTION
## Summary

This diff refactors `flipper-ui-core` to use React and ReactDOM `18` features and methods.
It's already using React & ReactDOM `18.x` *experimental* version.

Such as using,
- `root.render(...)` instead of `ReactDOM.render(...)`
- named import for `createPortal`

Also, formats most of the files to keep "import react" statements at the top.

## Changelog

[Internal] [Changed] - Refactor: Use React & ReactDOM `18.x` features and methods in `flipper-ui-core`

## Test Plan

- Tests and builds should pass.