### PR TITLE
[gradle] Remove dokka plugin

### DIFF
--- a/android/plugins/jetpack-compose/build.gradle
+++ b/android/plugins/jetpack-compose/build.gradle
@@ -32,3 +32,10 @@ android {
 }
 
 apply plugin: 'com.vanniktech.maven.publish'
+
+import com.vanniktech.maven.publish.SonatypeHost
+mavenPublishing {
+  // Disable javadoc publishing
+  publishToMavenCentral(SonatypeHost.DEFAULT, false)
+}
+

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,6 @@ buildscript {
         classpath 'com.android.tools.build:gradle:8.0.2'
         classpath 'com.vanniktech:gradle-maven-publish-plugin:0.25.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$KOTLIN_VERSION"
-        classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.8.20"
         classpath "org.jetbrains.kotlin:kotlin-serialization:$KOTLIN_VERSION"
     }
 }


### PR DESCRIPTION
[gradle] Remove dokka plugin

Summary:
This is currently breaking our jetpack-compose build and blocks the entire release
as a consequence: https://github.com/facebook/flipper/issues/4970

There are all sorts of workarounds but they require changing the java target
which could have other downstream consequences: https://github.com/Kotlin/dokka/issues/2956

We don't actually rely on these artefacts at all, so it's probably safe to just disable this.

Closes #4970

Test Plan:
./gradlew publishToMavenLocal
