### PR TITLE
[gradle] ACTUALLY disable dokka builds

### DIFF
--- a/android/plugins/jetpack-compose/build.gradle
+++ b/android/plugins/jetpack-compose/build.gradle
@@ -31,11 +31,5 @@ android {
     }
 }
 
+
 apply plugin: 'com.vanniktech.maven.publish'
-
-import com.vanniktech.maven.publish.SonatypeHost
-mavenPublishing {
-  // Disable javadoc publishing
-  publishToMavenCentral(SonatypeHost.DEFAULT, false)
-}
-

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,10 @@ subprojects {
     tasks.withType(Javadoc).all {
         enabled = false
     }
+
+    tasks.withType(com.android.build.gradle.tasks.JavaDocGenerationTask).all {
+        enabled = false
+    }
 }
 
 ext {


### PR DESCRIPTION
Summary:

This should hopefully unblock our Android builds for real this time. I didn't realise that the AGP itself seems to ship with a version of Dokka, so just removing the import didn't actually address the problem we were seeing.

Test Plan:

```
./gradlew publishToMavenLocal -PRELEASE_SIGNING_ENABLED=false
```

This now succeeds.