### PR TITLE
Fix issue where headers with the same name aren't all shown

### DIFF
--- a/android/plugins/network/src/main/java/com/facebook/flipper/plugins/network/FlipperOkhttpInterceptor.java
+++ b/android/plugins/network/src/main/java/com/facebook/flipper/plugins/network/FlipperOkhttpInterceptor.java
@@ -176,7 +176,9 @@ public class FlipperOkhttpInterceptor
 
     final Set<String> keys = headers.names();
     for (final String key : keys) {
-      list.add(new NetworkReporter.Header(key, headers.get(key)));
+      for (final String value : headers.values(key)) {
+        list.add(new NetworkReporter.Header(key, value));
+      }
     }
     return list;
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
Right now the network plugin doesn't show multiple headers that share the same name even if they have different values. The main example we ran into with this is multiple `set-cookie` headers. You are allowed to set multiple `set-cookie` headers on a response if the key of the cookie is different for each. See [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie)

> To send multiple cookies, multiple Set-Cookie headers should be sent in the same response.

The key line for the issue is [here](https://github.com/facebook/flipper/blob/main/android/plugins/network/src/main/java/com/facebook/flipper/plugins/network/FlipperOkhttpInterceptor.java#L179)

```java
list.add(new NetworkReporter.Header(key, headers.get(key)));
```

`headers.get(key)` is a call to `okhttp3.Headers` which has the documentation of `Returns the last value corresponding to the specified field, or null.`. 

So for every header with the same `name`, they're all just going to show the value of the last of the same name. 

I updated it to keep each unique name/value pairing separated.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog
Fix duplicate headers with different values getting stripped
<!-- Help reviewers and the release process by writing your own changelog entry. This should just be a brief oneline we can mention in our release notes: https://github.com/facebook/flipper/releases -->

## Test Plan

Printed out the results in the logcat

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI / output of the test runner and how you invoked it. -->

