### PR TITLE
[flipper] Don't break the build if the reactdevtools patching fails

### DIFF
--- a/desktop/plugins/public/reactdevtools/package.json
+++ b/desktop/plugins/public/reactdevtools/package.json
@@ -39,6 +39,6 @@
     "flipper-plugin": "*"
   },
   "scripts": {
-    "postinstall": "ts-node scripts/remove-sourcemap-reference.tsx"
+    "postinstall": "ts-node scripts/remove-sourcemap-reference.tsx || true"
   }
 }


### PR DESCRIPTION
[flipper] Don't break the build if the reactdevtools patching fails

Summary:
There seems to be a bug in yarn workspaces on Windows:

```
Error: Cannot find module 'D:\\a\\flipper\\flipper\\desktop\\plugins\\public\\node_modules\\node_modules\\ts-node\\dist\\bin.js
```


Test Plan:
Let's see if CI will be happy again.

Reviewers:

Subscribers:

Tasks:

Tags:
