### PR TITLE
[android][sample] Disable Fresco integration for now

### DIFF
--- a/android/sample/src/main/java/com/facebook/flipper/sample/RootComponentSpec.java
+++ b/android/sample/src/main/java/com/facebook/flipper/sample/RootComponentSpec.java
@@ -124,12 +124,13 @@ public class RootComponentSpec {
                     .marginDip(YogaEdge.ALL, 10)
                     .textSizeSp(20)
                     .clickHandler(RootComponent.triggerCrash(c)))
-            .child(
+            // TODO: Re-enable once we have a new Litho v0.48.0-compatible version of Fresco.
+            /*.child(
                 FrescoVitoImage2.create(c)
                     .uri(Uri.parse("https://fbflipper.com/img/icon.png"))
                     .marginDip(YogaEdge.ALL, 10)
                     .widthDip(150)
-                    .heightDip(150))
+                    .heightDip(150))*/
             .build();
 
     return VerticalScroll.create(c).childComponent(col).build();

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ POM_DEVELOPER_ID=facebook
 POM_DEVELOPER_NAME=facebook
 POM_ISSUES_URL=https://github.com/facebook/flipper/issues/
 # Shared version numbers
-LITHO_VERSION=0.44.0
+LITHO_VERSION=0.48.0
 ANDROIDX_VERSION=1.3.0
 KOTLIN_VERSION=1.8.20
 FBJNI_VERSION=0.3.0


### PR DESCRIPTION
[android][sample] Disable Fresco integration for now

Summary:
There's currently a startup crash

https://gist.github.com/passy/3f6b5935d8f9171ea0d3d915857b9786

We'll need to wait for a new Fresco release. In the meantime, let's comment this out so we can still use the rest of the app.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/flipper/pull/5101).
* __->__ #5101
* #5100