### PR TITLE
Fixed plugin installation table columns width

### DIFF
--- a/desktop/flipper-ui/src/chrome/plugin-manager/PluginInstaller.tsx
+++ b/desktop/flipper-ui/src/chrome/plugin-manager/PluginInstaller.tsx
@@ -32,6 +32,28 @@ const {Text, Link} = Typography;
 
 const TAG = 'PluginInstaller';
 
+const columnSizes = {
+  name: '25%',
+  version: '10%',
+  description: 'flex',
+  install: '15%',
+};
+
+const columns = {
+  name: {
+    value: 'Name',
+  },
+  version: {
+    value: 'Version',
+  },
+  description: {
+    value: 'Description',
+  },
+  install: {
+    value: 'Action',
+  },
+};
+
 type PropsFromState = {
   installedPlugins: Map<string, InstalledPluginDetails>;
 };
@@ -57,28 +79,6 @@ const PluginInstaller = function ({
 }: Props) {
   const [restartRequired, setRestartRequired] = useState(false);
   const [query, setQuery] = useState('');
-
-  const columnSizes = {
-    name: '25%',
-    version: '10%',
-    description: 'flex',
-    install: '15%',
-  };
-  
-  const columns = {
-    name: {
-      value: 'Name',
-    },
-    version: {
-      value: 'Version',
-    },
-    description: {
-      value: 'Description',
-    },
-    install: {
-      value: 'Action',
-    },
-  };
 
   const onInstall = useCallback(async () => {
     refreshInstalledPlugins();

--- a/desktop/flipper-ui/src/chrome/plugin-manager/PluginInstaller.tsx
+++ b/desktop/flipper-ui/src/chrome/plugin-manager/PluginInstaller.tsx
@@ -32,28 +32,6 @@ const {Text, Link} = Typography;
 
 const TAG = 'PluginInstaller';
 
-const columnSizes = {
-  name: '25%',
-  version: '10%',
-  description: 'flex',
-  install: '15%',
-};
-
-const columns = {
-  name: {
-    value: 'Name',
-  },
-  version: {
-    value: 'Version',
-  },
-  description: {
-    value: 'Description',
-  },
-  install: {
-    value: 'Action',
-  },
-};
-
 type PropsFromState = {
   installedPlugins: Map<string, InstalledPluginDetails>;
 };
@@ -79,6 +57,28 @@ const PluginInstaller = function ({
 }: Props) {
   const [restartRequired, setRestartRequired] = useState(false);
   const [query, setQuery] = useState('');
+
+  const columnSizes = {
+    name: '25%',
+    version: '10%',
+    description: 'flex',
+    install: '15%',
+  };
+  
+  const columns = {
+    name: {
+      value: 'Name',
+    },
+    version: {
+      value: 'Version',
+    },
+    description: {
+      value: 'Description',
+    },
+    install: {
+      value: 'Action',
+    },
+  };
 
   const onInstall = useCallback(async () => {
     refreshInstalledPlugins();

--- a/desktop/flipper-ui/src/ui/components/table/TableHead.tsx
+++ b/desktop/flipper-ui/src/ui/components/table/TableHead.tsx
@@ -109,7 +109,7 @@ class TableHeadColumn extends PureComponent<{
   ref: HTMLElement | undefined | null;
 
   componentDidMount() {
-    if (this.props.horizontallyScrollable && this.ref) {
+    if (this.props.horizontallyScrollable && this.ref && !this.props.isResizable) {
       // measure initial width
       this.onResize(this.ref.getBoundingClientRect().width);
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

the issue was that in the plugin installation popup table, the columns had a width of 0, making it impossible to see any data and the install/uninstall button.

This PR addresses the issue #5124 

<img width="1379" alt="Screenshot 2023-09-21 alle 16 46 19" src="https://github.com/facebook/flipper/assets/29179493/cf14a3b2-7385-4677-ade8-9e23108ca9ec">

After the fix

<img width="1379" alt="image" src="https://github.com/facebook/flipper/assets/29179493/08caacf4-8326-429e-bd9c-a50feb55cea6">

I resolved the issue by moving the constants declaring the column widths inside the component, which previously caused the columns to have a width of 0 in the plugin installation popup table.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. This should just be a brief oneline we can mention in our release notes: https://github.com/facebook/flipper/releases -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI / output of the test runner and how you invoked it. -->

