### PR TITLE
fix: typo in error log genereate -> generate

### DIFF
--- a/xplat/Flipper/ConnectionContextStore.cpp
+++ b/xplat/Flipper/ConnectionContextStore.cpp
@@ -203,7 +203,7 @@ std::pair<std::string, std::string> ConnectionContextStore::getCertificate() {
           certificate_path.c_str(),
           CERTIFICATE_FILE_NAME,
           CERTIFICATE_PASSWORD)) {
-    log("ERROR: Unable to genereate certificate pkcs#12");
+    log("ERROR: Unable to generate certificate pkcs#12");
     return std::make_pair("", "");
   }
 


### PR DESCRIPTION
## Summary

Noticed this tiny tipo when got the log on my application
