### PR TITLE
Migrate google java format from 1.7 -> 1.19.2

### DIFF
--- a/android/sample/src/main/java/com/facebook/flipper/sample/Database2Helper.java
+++ b/android/sample/src/main/java/com/facebook/flipper/sample/Database2Helper.java
@@ -64,7 +64,10 @@ public class Database2Helper extends SQLiteOpenHelper {
       contentValues.put("column1", "Long text data for testing resizing");
       contentValues.put(
           "column2",
-          "extra extra extra extra extra extra extra extra extra extra extra extra extra extra extra extra extra extra extra extra extra extra extra extra extra extra extra extra extra extra extra extra extra extra extra extra Long text data for testing resizing");
+          "extra extra extra extra extra extra extra extra extra extra extra extra extra extra"
+              + " extra extra extra extra extra extra extra extra extra extra extra extra extra"
+              + " extra extra extra extra extra extra extra extra extra Long text data for testing"
+              + " resizing");
       db.insert("db2_first_table", null, contentValues);
       db.insert("db2_second_table", null, contentValues);
     }

--- a/android/src/main/java/com/facebook/flipper/plugins/crashreporter/CrashReporterPlugin.java
+++ b/android/src/main/java/com/facebook/flipper/plugins/crashreporter/CrashReporterPlugin.java
@@ -31,6 +31,7 @@ public class CrashReporterPlugin implements FlipperPlugin {
 
     return crashreporterPlugin;
   }
+
   /*
    * Activity to be used to display incoming messages
    */
@@ -42,6 +43,7 @@ public class CrashReporterPlugin implements FlipperPlugin {
   public void onConnect(FlipperConnection connection) {
     mConnection = connection;
   }
+
   // This function is called from Litho's error boundary.
   public void sendExceptionMessage(Thread paramThread, Throwable paramThrowable) {
     if (mConnection != null) {

--- a/android/src/main/java/com/facebook/flipper/plugins/inspector/InspectorFlipperPlugin.java
+++ b/android/src/main/java/com/facebook/flipper/plugins/inspector/InspectorFlipperPlugin.java
@@ -75,6 +75,7 @@ public class InspectorFlipperPlugin implements FlipperPlugin {
   public interface ExtensionCommand {
     /** The command to respond to */
     String command();
+
     /** The corresponding FlipperReceiver for the command */
     FlipperReceiver receiver(ObjectTracker tracker, FlipperConnection connection);
   }

--- a/android/src/main/java/com/facebook/flipper/plugins/inspector/NodeDescriptor.java
+++ b/android/src/main/java/com/facebook/flipper/plugins/inspector/NodeDescriptor.java
@@ -118,7 +118,9 @@ public abstract class NodeDescriptor<T> {
     return "";
   }
 
-  /** @return The number of children this node exposes in the inspector. */
+  /**
+   * @return The number of children this node exposes in the inspector.
+   */
   public abstract int getChildCount(T node) throws Exception;
 
   /** Gets child at index for AX tree. Ignores non-view children. */
@@ -126,7 +128,9 @@ public abstract class NodeDescriptor<T> {
     return getChildCount(node);
   }
 
-  /** @return The child at index. */
+  /**
+   * @return The child at index.
+   */
   public abstract Object getChildAt(T node, int index) throws Exception;
 
   /** Gets child at index for AX tree. Ignores non-view children. */

--- a/android/src/main/java/com/facebook/flipper/plugins/inspector/Touch.java
+++ b/android/src/main/java/com/facebook/flipper/plugins/inspector/Touch.java
@@ -25,6 +25,8 @@ public interface Touch {
    */
   void continueWithOffset(int childIndex, int offsetX, int offsetY);
 
-  /** @return Whether or not this Touch is contained within the provided bounds. */
+  /**
+   * @return Whether or not this Touch is contained within the provided bounds.
+   */
   boolean containedIn(int l, int t, int r, int b);
 }

--- a/android/src/test/java/com/facebook/flipper/plugins/databases/DatabasesFlipperPluginTest.java
+++ b/android/src/test/java/com/facebook/flipper/plugins/databases/DatabasesFlipperPluginTest.java
@@ -383,7 +383,8 @@ public class DatabasesFlipperPluginTest {
             new FlipperObject.Builder()
                 .put(
                     "definition",
-                    "CREATE TABLE first_table (_id INTEGER PRIMARY KEY AUTOINCREMENT,column1 TEXT,column2 TEXT)")
+                    "CREATE TABLE first_table (_id INTEGER PRIMARY KEY AUTOINCREMENT,column1"
+                        + " TEXT,column2 TEXT)")
                 .build()));
   }
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/SoLoader/pull/122

This diff migrates google java format form 1.7 to 1.19.2. This update will allow for new language features from java 17 and 21. This diff also formats all necessary files.

 Changelog:
    [Internal][Changed] - Updated format from google-java-format 1.7 -> 1.19.2

Reviewed By: IanChilds

Differential Revision: D52786052


