### PR TITLE
Convert the CircleCI workflow to a GitHub Actions workflow

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,0 +1,30 @@
+name: facebook/flipper/build-and-deploy
+on:
+  push:
+    branches:
+    - main
+env:
+  ANDROID_PUBLISH_KEY: ${{ secrets.ANDROID_PUBLISH_KEY }}
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install Dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y sdkmanager
+    - name: Install JDK
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: gradle
+    - name: Install Retry
+      run: scripts/install-retry.sh
+    - name: Build
+      run: |
+        yes | sdkmanager "platforms;android-33" || true
+        /tmp/retry -m 3 ./gradlew :android:assembleRelease --info
+    - name: Deploy Snapshot
+      run: "/tmp/retry -m 3 scripts/publish-android-snapshot.sh"


### PR DESCRIPTION
## Summary

This pull request converts the CircleCI workflows to GitHub actions workflows. [Github Actions Importer](https://github.com/github/gh-actions-importer) was used to convert the workflows initially, then I edited them manually to correct errors in translation.

The `${{ secrets.ANDROID_PUBLISH_KEY }}` key will need to be set for the deployment task to succeed.

## How did you test this change?

I tested these changes in a [forked repo](https://github.com/robandpdx-org/flipper/actions/runs/7935281961).

https://fburl.com/workplace/f6mz6tmw