### PR TITLE
fix(react-native): Ensure Java17 is used on android builds

### DIFF
--- a/react-native/react-native-flipper/android/build.gradle
+++ b/react-native/react-native-flipper/android/build.gradle
@@ -47,6 +47,12 @@ def safeExtGet(prop, fallback) {
 
 apply plugin: 'com.android.library'
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', DEFAULT_COMPILE_SDK_VERSION)
     buildToolsVersion safeExtGet('buildToolsVersion', DEFAULT_BUILD_TOOLS_VERSION)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

React Native's Android build works perfectly fine on **Java 21**, except when the `react-native-flipper` dependency is added. When this happens, the build fails with the error below, which I believe is related to [this bug](https://issuetracker.google.com/issues/294137077) in android-gradle-plugin (apparently fixed in v8.2.1):

```console
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':react-native-flipper:compileDebugJavaWithJavac'.
> Could not resolve all files for configuration ':react-native-flipper:androidJdkImage'.
   > Failed to transform core-for-system-modules.jar to match attributes {artifactType=_internal_android_jdk_image, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}.
      > Execution failed for JdkImageTransform: C:\DevTools\AndroidSDK\platforms\android-34\core-for-system-modules.jar.
         > Error while executing process C:\Program Files\Java\jdk-21\bin\jlink.exe with arguments {--module-path C:\Users\josel\.gradle\caches\transforms-4\4c11f83178b8b05ef6bb8aa8733cb824-2b06f07d-2086-4edc-82ec-39eda73a7cd3\transformed\output\temp\jmod --add-modules java.base --output C:\Users\josel\.gradle\caches\transforms-4\4c11f83178b8b05ef6bb8aa8733cb824-2b06f07d-2086-4edc-82ec-39eda73a7cd3\transformed\output\jdkImage --disable-plugin system-modules}
```

This PR ensures that **Java 17** is always used on the Android build of `react-native-flipper` by using [Gradle's Java Toolchain](https://docs.gradle.org/current/userguide/toolchains.html). This allows developers using **Java 21** to build with Flipper. Even though it solves the problem, it'd be more beneficial to provide full support of **Java 21** since it was released ~6 months ago, and it will be the LTS for the next year and a half. I'm not sure what needs to be done to provide that support, but I'll be happy to help if possible 🙂 

## Changelog

Ensures Java 17 is always used on the Android build of `react-native-flipper`, allowing developers to use more recent Java version on their React Native environments.

## Test Plan

Unfortunately, the `ReactNativeFlipperExample` app cannot be used to test this change because it needs to be heavily updated first. But it's possible to test the change with a new React Native app:

1. Create a new React Native app (at least at v0.73.6)
2. Ensure you are using Java 21 on your environment
3. Update the Gradle Wrapper to make it Java 21 compatible:
    - `cd android/`
    - `gradle wrapper --distribution-type BIN --gradle-version 8.6`
4. Add `react-native-flipper` dependency and configure Flipper for Android
5. Attempt to build the React Native app: `yarn android`
6. You'll see the error mentioned before
7. Apply the PR changes
8. Build the React Native app again
9. The build should succeed on Java 21

