### PR TITLE
Forward declare the DatabaseDriver protocol

### DIFF
--- a/iOS/Plugins/FlipperKitDatabasesPlugin/FlipperKitDatabasesPlugin/FlipperKitDatabasesPlugin.h
+++ b/iOS/Plugins/FlipperKitDatabasesPlugin/FlipperKitDatabasesPlugin/FlipperKitDatabasesPlugin.h
@@ -9,8 +9,8 @@
 
 #import <FlipperKit/FlipperPlugin.h>
 #import <Foundation/Foundation.h>
-#import "DatabaseDriver.h"
 
+@protocol DatabaseDriver;
 @class DatabasesManager;
 
 @interface FlipperKitDatabasesPlugin : NSObject<FlipperPlugin>


### PR DESCRIPTION
## Summary

This allows us to remove the `DatabaseDriver.h` header import, and `DatabaseDriver.h` no longer needs to be a public header.

## Changelog

`FlipperKitDatabasesPlugin/DatabaseDriver.h` is no longer a public header.

## Test Plan

Successfully built the FlipperKitDatabasesPlugin plugin code