### PR TITLE
Pass DatabaseDescriptor to -executeSQL

### DIFF
--- a/iOS/Plugins/FlipperKitDatabasesPlugin/FlipperKitDatabasesPlugin/DatabaseDriver.h
+++ b/iOS/Plugins/FlipperKitDatabasesPlugin/FlipperKitDatabasesPlugin/DatabaseDriver.h
@@ -33,5 +33,8 @@
                                reverse:(BOOL)reverse
                                  start:(NSInteger)start
                                  count:(NSInteger)count;
-- (DatabaseExecuteSqlResponse*)executeSQL:(NSString*)sql;
+- (DatabaseExecuteSqlResponse*)
+    executeSQLWithDatabaseDescriptor:
+        (id<DatabaseDescriptor>)databaseDescriptor
+                                 sql:(NSString*)sql;
 @end

--- a/iOS/Plugins/FlipperKitDatabasesPlugin/FlipperKitDatabasesPlugin/DatabasesManager.m
+++ b/iOS/Plugins/FlipperKitDatabasesPlugin/FlipperKitDatabasesPlugin/DatabasesManager.m
@@ -213,7 +213,10 @@
         }
         @try {
           DatabaseExecuteSqlResponse* sqlResponse =
-              [descriptorHolder.databaseDriver executeSQL:request.value];
+              [descriptorHolder.databaseDriver
+                    executeSQLWithDatabaseDescriptor:descriptorHolder
+                                                         .databaseDescriptor
+                                                 sql:request.value];
           NSDictionary* response =
               [ObjectMapper databaseExecuteSqlResponseToDictionary:sqlResponse];
           [responder success:response];

--- a/iOS/Plugins/FlipperKitDatabasesPlugin/FlipperKitDatabasesPlugin/Mock/MockDatabaseDriver.m
+++ b/iOS/Plugins/FlipperKitDatabasesPlugin/FlipperKitDatabasesPlugin/Mock/MockDatabaseDriver.m
@@ -91,7 +91,10 @@
                                                          total:numRows];
 }
 
-- (DatabaseExecuteSqlResponse*)executeSQL:(NSString*)sql {
+- (DatabaseExecuteSqlResponse*)
+    executeSQLWithDatabaseDescriptor:
+        (id<DatabaseDescriptor>)databaseDescriptor
+                                 sql:(NSString*)sql {
   // Generate a mock response with a random type
   NSString* type;
   NSArray* columns = @[ @"id", @"name", @"age" ];


### PR DESCRIPTION
## Summary

Unlike the other `DatabaseDriver` protocol methods, `-executeSQL:` wasn't passing the `DatabaseDescriptor` object. The database driver implementation needs that context in order to know which database connection to use.

This matches the Android DatabaseDriver interface:

https://github.com/facebook/flipper/blob/9053a6c2ef61f7033ef3c006b2c4c6edab7dc41d/android/src/main/java/com/facebook/flipper/plugins/databases/DatabaseDriver.java#L52-L53

I renamed this method to `-executeSQLWithDatabaseDescriptor:sql:` to match the convention used by the other methods.

## Changelog

In DatabaseDriver, rename -executeSQL: to executeSQLWithDatabaseDescriptor:sql: and pass the DatabaseDescriptor object.

## Test Plan

Verified the `MockDatabaseDriver` implementation continues to work as before, and verified that the `execute` command now receives the DatabaseDescriptor (in a local project).