### PR TITLE
[packer] Fix tests

### DIFF
--- a/packer/src/main.rs
+++ b/packer/src/main.rs
@@ -405,7 +405,7 @@ mod test {
     fn test_included_packlist_parses() {
         let res: PackList =
             serde_yaml::from_str(DEFAULT_PACKLIST).expect("Default packlist doesn't deserialize");
-        assert_eq!(res.0.len(), 4);
+        assert_eq!(res.0.len(), 6);
     }
 
     #[test]


### PR DESCRIPTION
[packer] Fix tests

Summary:

Tests broke recently: https://github.com/facebook/flipper/actions/runs/8943237349/job/24567505699

Test Plan:

```
$ cargo test
running 4 tests
Computing manifest      ▕████████████████████▏
test test::test_included_packlist_parses ... ok
test tarsum::test::test_nested_archive_tarsum ... ok
test tarsum::test::test_differently_ordered_archives ... ok
Computing manifest      ▕████████████████████▏
test test::test_manifest ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
```
