### PR TITLE
Updated Flipper react native android version to 0.250.0

### DIFF
--- a/docs/getting-started/react-native-android.mdx
+++ b/docs/getting-started/react-native-android.mdx
@@ -23,11 +23,11 @@ repositories {
 }
 
 dependencies {
-  debugImplementation('com.facebook.flipper:flipper:0.35.0') {
+  debugImplementation('com.facebook.flipper:flipper:0.250.0') {
     exclude group:'com.facebook.fbjni'
   }
 
-  debugImplementation('com.facebook.flipper:flipper-network-plugin:0.35.0') {
+  debugImplementation('com.facebook.flipper:flipper-network-plugin:0.250.0') {
     exclude group:'com.facebook.flipper'
   }
 }


### PR DESCRIPTION
This commit updates the Flipper documentation to reflect the usage of version 0.250.0. The changes include updating dependencies in the build.gradle file to use the latest version from Maven Central. Old version is not working latest react native 0.74.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. This should just be a brief oneline we can mention in our release notes: https://github.com/facebook/flipper/releases -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI / output of the test runner and how you invoked it. -->

