### PR TITLE
Network plugin - Support formatting network request

### DIFF
--- a/android/plugins/network/src/main/java/com/facebook/flipper/plugins/network/NetworkRequestFormatter.java
+++ b/android/plugins/network/src/main/java/com/facebook/flipper/plugins/network/NetworkRequestFormatter.java
@@ -1,0 +1,11 @@
+package com.facebook.flipper.plugins.network;
+
+public interface NetworkRequestFormatter {
+    interface OnCompletionListener {
+        void onCompletion(String json);
+    }
+
+    boolean shouldFormat(NetworkReporter.RequestInfo request);
+
+    void format(NetworkReporter.RequestInfo request, OnCompletionListener onCompletionListener);
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

The network plugin allows for formatting network responses, making it possible to convert protobuf messages into a human-readable format. However, there is currently no method to format network request bodies. This PR introduces a NetworkRequestFormatter to address this issue.

## Changelog

Network plugin: Support formatting request body

## Test Plan

Here we intercepted the network call and modified the request and response bodies

<img width="1280" alt="Screenshot 2024-07-11 at 23 13 58" src="https://github.com/user-attachments/assets/5bd20884-0ffc-48cf-867e-c74c4b6735df">


