### PR TITLE
[js] Disable another flaky test

### DIFF
--- a/desktop/flipper-ui/src/__tests__/PluginContainer.node.tsx
+++ b/desktop/flipper-ui/src/__tests__/PluginContainer.node.tsx
@@ -124,7 +124,8 @@ test.skip('Plugin container can render plugin and receive updates', async () => 
   expect((await renderer.findByTestId('counter')).textContent).toBe('2');
 });
 
-test('Number of times console errors/warning during plugin render', async () => {
+// TODO(T119353406): Disabled due to flakiness.
+test.skip('Number of times console errors/warning during plugin render', async () => {
   await renderMockFlipperWithPlugin(TestPlugin);
 
   expect(errorSpy.mock.calls).toEqual([


### PR DESCRIPTION

Test Plan:
```
$ yarn test
Test Suites: 2 skipped, 98 passed, 98 of 100 total
Tests:       19 skipped, 545 passed, 564 total
Snapshots:   190 passed, 190 total
Time:        44.194 s, estimated 169 s
Ran all test suites.
✨  Done in 49.96s.
```
