### PR TITLE
[ci] Update set-output syntax

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -20,7 +20,8 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(yarn cache dir)"
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+      shell: bash
     - uses: actions/cache@v2
       id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
       with:


### PR DESCRIPTION
Summary:

This will otherwise break soon.

Closes https://github.com/facebook/flipper/pull/5430.

Redone using the instructions from here: https://github.com/actions/cache/blob/main/examples.md#node---yarn

Test Plan:
Green CI