### PR TITLE
Skip hanging tests

### DIFF
--- a/desktop/flipper-server/src/devices/ios/__tests__/iOSDevice.node.tsx
+++ b/desktop/flipper-server/src/devices/ios/__tests__/iOSDevice.node.tsx
@@ -108,52 +108,55 @@ test('test checkXcodeVersionMismatch with no sims running and no xcode-select', 
   );
 });
 
-test.skip('test queryDevices when simctl used', async () => {
-  const ios = new IOSDeviceManager(
-    fakeFlipperServer,
-    getFlipperServerConfig().settings,
-  );
-  ios.ctlBridge = fakeSimctlBridge;
+// FIXME do not run these tests in GH actions as it causes jest to timeout and exit with 1 exit code
+if (!process.env.GITHUB_ACTIONS) {
+  test('test queryDevices when simctl used', async () => {
+    const ios = new IOSDeviceManager(
+      fakeFlipperServer,
+      getFlipperServerConfig().settings,
+    );
+    ios.ctlBridge = fakeSimctlBridge;
 
-  await ios.queryDevices(fakeSimctlBridge);
+    await ios.queryDevices(fakeSimctlBridge);
 
-  expect(fakeSimctlBridge.getActiveDevices).toBeCalledTimes(1);
-  expect(fakeIDBBridge.getActiveDevices).toBeCalledTimes(0);
+    expect(fakeSimctlBridge.getActiveDevices).toBeCalledTimes(1);
+    expect(fakeIDBBridge.getActiveDevices).toBeCalledTimes(0);
 
-  expect(fakeFlipperServer.registerDevice).toBeCalledTimes(1);
-  expect(fakeFlipperServer.registerDevice).toBeCalledWith(
-    expect.objectContaining({
-      serial: 'yoda',
-    }),
-  );
+    expect(fakeFlipperServer.registerDevice).toBeCalledTimes(1);
+    expect(fakeFlipperServer.registerDevice).toBeCalledWith(
+      expect.objectContaining({
+        serial: 'yoda',
+      }),
+    );
 
-  expect(fakeFlipperServer.unregisterDevice).toBeCalledTimes(1);
-  expect(fakeFlipperServer.unregisterDevice).toBeCalledWith('plapatine');
+    expect(fakeFlipperServer.unregisterDevice).toBeCalledTimes(1);
+    expect(fakeFlipperServer.unregisterDevice).toBeCalledWith('plapatine');
 
-  // FIXME unregister devices, causes a hanging promise in jest
-});
+    // FIXME unregister devices, causes a hanging promise in jest
+  });
 
-test.skip('test queryDevices when idb used', async () => {
-  const ios = new IOSDeviceManager(
-    fakeFlipperServer,
-    getFlipperServerConfig().settings,
-  );
-  ios.ctlBridge = fakeSimctlBridge;
+  test('test queryDevices when idb used', async () => {
+    const ios = new IOSDeviceManager(
+      fakeFlipperServer,
+      getFlipperServerConfig().settings,
+    );
+    ios.ctlBridge = fakeSimctlBridge;
 
-  await ios.queryDevices(fakeIDBBridge);
+    await ios.queryDevices(fakeIDBBridge);
 
-  expect(fakeSimctlBridge.getActiveDevices).toBeCalledTimes(0);
-  expect(fakeIDBBridge.getActiveDevices).toBeCalledTimes(1);
+    expect(fakeSimctlBridge.getActiveDevices).toBeCalledTimes(0);
+    expect(fakeIDBBridge.getActiveDevices).toBeCalledTimes(1);
 
-  expect(fakeFlipperServer.registerDevice).toBeCalledTimes(1);
-  expect(fakeFlipperServer.registerDevice).toBeCalledWith(
-    expect.objectContaining({
-      serial: 'yoda',
-    }),
-  );
+    expect(fakeFlipperServer.registerDevice).toBeCalledTimes(1);
+    expect(fakeFlipperServer.registerDevice).toBeCalledWith(
+      expect.objectContaining({
+        serial: 'yoda',
+      }),
+    );
 
-  expect(fakeFlipperServer.unregisterDevice).toBeCalledTimes(1);
-  expect(fakeFlipperServer.unregisterDevice).toBeCalledWith('plapatine');
+    expect(fakeFlipperServer.unregisterDevice).toBeCalledTimes(1);
+    expect(fakeFlipperServer.unregisterDevice).toBeCalledWith('plapatine');
 
-  // FIXME unregister devices, causes a hanging promise in jest
-});
+    // FIXME unregister devices, causes a hanging promise in jest
+  });
+}

--- a/desktop/flipper-server/src/devices/ios/__tests__/iOSDevice.node.tsx
+++ b/desktop/flipper-server/src/devices/ios/__tests__/iOSDevice.node.tsx
@@ -108,7 +108,7 @@ test('test checkXcodeVersionMismatch with no sims running and no xcode-select', 
   );
 });
 
-test('test queryDevices when simctl used', async () => {
+test.skip('test queryDevices when simctl used', async () => {
   const ios = new IOSDeviceManager(
     fakeFlipperServer,
     getFlipperServerConfig().settings,
@@ -133,7 +133,7 @@ test('test queryDevices when simctl used', async () => {
   // FIXME unregister devices, causes a hanging promise in jest
 });
 
-test('test queryDevices when idb used', async () => {
+test.skip('test queryDevices when idb used', async () => {
   const ios = new IOSDeviceManager(
     fakeFlipperServer,
     getFlipperServerConfig().settings,


### PR DESCRIPTION
A couple of tests have open handlers that cause jest to timeout in GitHub actions. Skipping these should fix the step to allow other jobs to run

Example failure

https://github.com/facebook/flipper/actions/runs/10083622244/job/27880598756#step:8:762