### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,22 +70,22 @@ jobs:
       - name: List dist artifacts
         run: ls -l dist/
       - name: Upload Mac x86-64
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v4
         with:
           name: "Flipper-server-mac-x64.dmg"
           path: "dist/Flipper-server-mac-x64.dmg"
       - name: Upload Mac aarch64
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v4
         with:
           name: "Flipper-server-mac-aarch64.dmg"
           path: "dist/Flipper-server-mac-aarch64.dmg"
       - name: Upload Linux x64
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v4
         with:
           name: "flipper-server-linux.tar.gz"
           path: "dist/flipper-server-linux.tar.gz"
       - name: Upload Windows x64
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v4
         with:
           name: "flipper-server-windows.tar.gz"
           path: "dist/flipper-server-windows.tar.gz"
@@ -115,7 +115,7 @@ jobs:
       - name: List dist artifacts
         run: ls -l dist/
       - name: Upload flipper-server
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v4
         with:
           name: "flipper-server.tgz"
           path: "dist/flipper-server.tgz"
@@ -133,19 +133,19 @@ jobs:
           ref: ${{ needs.release.outputs.tag }}
       - name: Download Flipper Server x86-64
         if: ${{ needs.release.outputs.tag != '' }}
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: "Flipper-server-mac-x64.dmg"
           path: "Flipper-server-mac-x64.dmg"
       - name: Download Flipper Server aarch64
         if: ${{ needs.release.outputs.tag != '' }}
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: "Flipper-server-mac-aarch64.dmg"
           path: "Flipper-server-mac-aarch64.dmg"
       - name: Download Flipper Server
         if: ${{ needs.release.outputs.tag != '' }}
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: "flipper-server.tgz"
           path: "flipper-server.tgz"


### PR DESCRIPTION
v1 has reached EOL: https://github.com/facebook/flipper/actions/runs/10920033765/job/30309276425

According to the docs, our basic use is still supported and not affected by breaking changes: https://github.com/actions/upload-artifact
