### PR TITLE
reroute pulic download to github releases

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -58,23 +58,11 @@ export default function Index() {
             </FbInternalOnly>
             <OssOnly>
               <div>
-                <p className="landing-btn landing-btn-left landing-btn-label">
+                <a
+                  className="landing-btn primary"
+                  target="_blank"
+                  href="https://github.com/facebook/flipper/releases">
                   Download
-                </p>
-                <a
-                  className="landing-btn landing-btn-middle primary"
-                  href="https://www.facebook.com/fbflipper/public/mac">
-                  Mac
-                </a>
-                <a
-                  className="landing-btn landing-btn-middle primary"
-                  href="https://www.facebook.com/fbflipper/public/other">
-                  Linux
-                </a>
-                <a
-                  className="landing-btn landing-btn-right primary"
-                  href="https://www.facebook.com/fbflipper/public/other">
-                  Windows
                 </a>
                 <a className="landing-btn" href={useBaseUrl('docs/features')}>
                   Learn more
@@ -181,7 +169,7 @@ export default function Index() {
           </a>
           <OssOnly>
             <a
-              href="https://www.facebook.com/fbflipper/public/mac"
+              href="https://github.com/facebook/flipper/releases"
               target="_blank"
               className="landing-btn">
               Download Flipper


### PR DESCRIPTION
## Summary

We have removed a controller to download a flipper build. Let's reroute a download url to github releases instead of having a broken URL

## Changelog

N/A

## Test Plan

hovering over download button now leads to github releases

<img width="632" height="438" alt="Screenshot 2025-09-24 at 19 52 01" src="https://github.com/user-attachments/assets/8f7362cd-3ead-4be4-ad8e-c78efd077e1b" />
